### PR TITLE
Re-add documentation on the color preference type

### DIFF
--- a/docs/framework.md
+++ b/docs/framework.md
@@ -102,7 +102,7 @@ For `"select"`-type preferences, an object of value/label entries. Unused for ot
 Default value of the preference to display to the user. This does not automatically set the default value of the preference in storage; scripts should ensure to use the same defaults as they display.
 
 If the preference `type` is `"checkbox"`, this value should be a boolean.  
-If the preference `type` is `"text"`, this value should be a string.
+If the preference `type` is `"text"`, this value should be a string.  
 If the preference `type` is `"color"`, this value should either be a string representing a hexadecimal colour code (`#1a2b3c`) or an empty string.
 If the preference `type` is `"select"`, this value should be a string that matches one of the keys in `options`.
 

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -81,7 +81,7 @@ Object with 1 or more custom keys; each key is used internally as a preference's
 - Type: String
 - Required: Yes
 
-Type of preference. Supported values: `"checkbox"`, `"text"`, `"select"`
+Type of preference. Supported values: `"checkbox"`, `"text"`, `"color"`, `"select"`
 
 #### `"preferences"`: \<preference name\>: `"label"`
 - Type: String
@@ -102,7 +102,8 @@ For `"select"`-type preferences, an object of value/label entries. Unused for ot
 Default value of the preference to display to the user. This does not automatically set the default value of the preference in storage; scripts should ensure to use the same defaults as they display.
 
 If the preference `type` is `"checkbox"`, this value should be a boolean.  
-If the preference `type` is `"text"`, this value should be a string.  
+If the preference `type` is `"text"`, this value should be a string.
+If the preference `type` is `"color"`, this value should either be a string representing a hexadecimal colour code (`#1a2b3c`) or an empty string.
 If the preference `type` is `"select"`, this value should be a string that matches one of the keys in `options`.
 
 # Scripts index

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -103,7 +103,7 @@ Default value of the preference to display to the user. This does not automatica
 
 If the preference `type` is `"checkbox"`, this value should be a boolean.  
 If the preference `type` is `"text"`, this value should be a string.  
-If the preference `type` is `"color"`, this value should either be a string representing a hexadecimal colour code (`#1a2b3c`) or an empty string.
+If the preference `type` is `"color"`, this value should either be a string representing a hexadecimal colour code (`#1a2b3c`) or an empty string.  
 If the preference `type` is `"select"`, this value should be a string that matches one of the keys in `options`.
 
 # Scripts index

--- a/docs/framework.md
+++ b/docs/framework.md
@@ -103,7 +103,7 @@ Default value of the preference to display to the user. This does not automatica
 
 If the preference `type` is `"checkbox"`, this value should be a boolean.  
 If the preference `type` is `"text"`, this value should be a string.  
-If the preference `type` is `"color"`, this value should either be a string representing a hexadecimal colour code (`#1a2b3c`) or an empty string.  
+If the preference `type` is `"color"`, this value should either be a string representing a hexadecimal colour code (i.e. `"#1a2b3c"`) or an empty string.  
 If the preference `type` is `"select"`, this value should be a string that matches one of the keys in `options`.
 
 # Scripts index


### PR DESCRIPTION
I *think* this is all it needs in terms of documentation, but then again I implemented the thing, so it may not be as obvious to outsiders.