### PR TITLE
new script: Search My Stuff

### DIFF
--- a/src/scripts/_index.json
+++ b/src/scripts/_index.json
@@ -8,6 +8,7 @@
   "one_click_postage",
   "open_in_tabs",
   "painter",
+  "search_boxes",
   "timestamps",
   "tweaks"
 ]

--- a/src/scripts/search_boxes.css
+++ b/src/scripts/search_boxes.css
@@ -1,8 +1,8 @@
-#search-likes-box {
+#xkit-search-box {
 	padding: 10px 10px 28px 10px;
 }
 
-#search-likes-input {
+#xkit-search-input {
 	width: 100%;
 	border-radius: 3px;
 	border: 0px;
@@ -13,9 +13,9 @@
 	background: var(--white) 10px 50% no-repeat url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAYAAABy6+R8AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QjMxRTZFMEZBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QjMxRTZFMTBBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpCMzFFNkUwREE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpCMzFFNkUwRUE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pnjwe50AAADhSURBVHjalJExEoIwEEVDvAAdpUeQhhk7OQKeAO2k4wh6AztK4w04AvYUUNp5BDwB/sz8MGsGh/HP/MmyyctulmAcR2VVVdUOSwnHcAg38LUoiofyFFgIQI7YqHkZgEeZWEVRZCvU8ACfcGCfJMmlbVtbKYO3iDvkng7SbMmqBHB3G2wr4+dZVtJ8g5KAB3bujIRC9ac0p+Sm9yXkNqzy8iE3tVqCiNdiz8yN/Ib4wFzHVb7DTjbFG/sJ4s25+LmKLRnmQglO0C/xXY0AY700KbaUErDVh8VK3mAGXPL+CDAAWp9eZGKACQQAAAAASUVORK5CYII=') !important;
 }
 
-#search-likes-input::placeholder { color: var(--gray-40); }
+#xkit-search-input::placeholder { color: var(--gray-40); }
 
-.search-likes-status-bar {
+.xkit-search-status-bar {
 	font-size: 1rem;
 	background: rgba(0,0,0,0.12);
 	border: 1px solid rgba(0,0,0,0.22);
@@ -26,20 +26,20 @@
 	text-align: center;
 }
 
-.search-likes-status-bar a {
+.xkit-search-status-bar a {
 	cursor: pointer;
     color: var(--transparent-white-65);
 }
 
-#search-likes-status-bar-bottom {
+#xkit-search-status-bar-bottom {
 	margin-top: -20px;
 }
 
-#search-likes-status-bar-top {
+#xkit-search-status-bar-top {
 	margin-bottom: 20px;
 }
 
-.xkit--react #search-likes-status-bar-bottom ~ div {
+.xkit--react #xkit-search-status-bar-bottom ~ div {
 	display: none;
 }
 

--- a/src/scripts/search_boxes.css
+++ b/src/scripts/search_boxes.css
@@ -1,0 +1,49 @@
+#search-likes-box {
+	padding: 10px 10px 28px 10px;
+}
+
+#search-likes-input {
+	width: 100%;
+	border-radius: 3px;
+	border: 0px;
+	padding: 10px 10px 10px 30px;
+	font-size: 1rem;
+	box-sizing: border-box;
+	color: var(--black);
+	background: var(--white) 10px 50% no-repeat url('data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA0AAAANCAYAAABy6+R8AAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6QjMxRTZFMEZBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6QjMxRTZFMTBBODY4MTFFMkFDMDJFMzk3N0RDMDc2NDQiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDpCMzFFNkUwREE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDpCMzFFNkUwRUE4NjgxMUUyQUMwMkUzOTc3REMwNzY0NCIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/Pnjwe50AAADhSURBVHjalJExEoIwEEVDvAAdpUeQhhk7OQKeAO2k4wh6AztK4w04AvYUUNp5BDwB/sz8MGsGh/HP/MmyyctulmAcR2VVVdUOSwnHcAg38LUoiofyFFgIQI7YqHkZgEeZWEVRZCvU8ACfcGCfJMmlbVtbKYO3iDvkng7SbMmqBHB3G2wr4+dZVtJ8g5KAB3bujIRC9ac0p+Sm9yXkNqzy8iE3tVqCiNdiz8yN/Ib4wFzHVb7DTjbFG/sJ4s25+LmKLRnmQglO0C/xXY0AY700KbaUErDVh8VK3mAGXPL+CDAAWp9eZGKACQQAAAAASUVORK5CYII=') !important;
+}
+
+#search-likes-input::placeholder { color: var(--gray-40); }
+
+.search-likes-status-bar {
+	font-size: 1rem;
+	background: rgba(0,0,0,0.12);
+	border: 1px solid rgba(0,0,0,0.22);
+    color: var(--transparent-white-65);
+	padding: 10px 14px;
+	border-radius: 6px;
+	line-height: 1.3;
+	text-align: center;
+}
+
+.search-likes-status-bar a {
+	cursor: pointer;
+    color: var(--transparent-white-65);
+}
+
+#search-likes-status-bar-bottom {
+	margin-top: -20px;
+}
+
+#search-likes-status-bar-top {
+	margin-bottom: 20px;
+}
+
+.xkit--react #search-likes-status-bar-bottom ~ div {
+	display: none;
+}
+
+#prevent-load {
+	height: 1600px;
+	border-top: 2px solid var(--transparent-white-13);
+}

--- a/src/scripts/search_boxes.js
+++ b/src/scripts/search_boxes.js
@@ -9,11 +9,17 @@
   let endlessScrollingDisabled;
   let searchingCss;
 
-  const onStorageChanged = function (changes, areaName) {
-    if (areaName !== 'local') {
-    return;
+  const onStorageChanged = async function (changes, areaName) {
+    if (areaName !== 'local') { return; }
+
+    const {
+      'search_boxes.preferences.maxResults': maxResultsChanges,
+    } = changes;
+
+    if (maxResultsChanges) {
+      maxResults = parseInt(maxResultsChanges.newValue);
+      maxResults = !isNaN(maxResults) && maxResults > 0 ? maxResults : 200;
     }
-    // I have absolutely no idea, to be 100% honest with you
   };
 
   const main = async function () {
@@ -359,7 +365,6 @@
   // TODO:
   // don't run literally everywhere lmao
   // handle soft refresh/navigation
-  // handle preference change
   // handle clean
   // mark.js
   // use mark.js instead of actually searching manually

--- a/src/scripts/search_boxes.js
+++ b/src/scripts/search_boxes.js
@@ -56,7 +56,7 @@
     $('#xkit-search-input').click(newSearchTerm);
 
     const newSearchDebounced = debounce(newSearchTerm, 500);
-		$('#xkit-search-input').keyup(newSearchDebounced);
+    $('#xkit-search-input').keyup(newSearchDebounced);
   };
 
   // Stolen from mutations.js
@@ -69,27 +69,27 @@
   // };
 
   // Stolen from xkit 7
-  const debounce = function(func, wait) {
-    var timeout_id;
-    return function() {
-      var last_context = this;
-      var last_args = arguments;
+  const debounce = function (func, wait) {
+    var timeoutID;
+    return function () {
+      var lastContext = this;
+      var lastArgs = arguments;
 
-      var exec = function() {
-        timeout_id = null;
-        func.apply(last_context, last_args);
+      var exec = function () {
+        timeoutID = null;
+        func.apply(lastContext, lastArgs);
       };
-      clearTimeout(timeout_id);
-      timeout_id = setTimeout(exec, wait);
+      clearTimeout(timeoutID);
+      timeoutID = setTimeout(exec, wait);
     };
   };
 
-  const newSearchTerm = async function() {
+  const newSearchTerm = async function () {
     var newTerm = $(this).val().toLowerCase().trim();
     if (newTerm.length < 2) {
       newTerm = '';
     }
-    if (term != newTerm) {
+    if (term !== newTerm) {
       if (!searching) {
         await searchStart();
       }
@@ -100,7 +100,7 @@
       updateStatusBar(`Searching for <b>"${term}"</b>, please wait...`);
 
       waitForRender().then(() => {
-        //add: unmark
+        // add: unmark
         $allPosts
           .removeClass('xkit-search-done')
           .removeClass('xkit-search-shown');
@@ -109,7 +109,7 @@
     }
   };
 
-  const searchStart = async function() {
+  const searchStart = async function () {
     searching = true;
     const { onNewPosts } = await fakeImport('/src/util/mutations.js');
     const { keyToCss, descendantSelector } = await fakeImport('/src/util/css_map.js');
@@ -117,7 +117,7 @@
     onNewPosts.addListener(processNewPosts);
     $(await keyToCss('timeline')).attr('id', 'xkit-search-timeline');
     $(await descendantSelector('timeline', 'loader')).attr('id', 'xkit-search-loader');
-    $('#xkit-search-timeline').after(`<div id='prevent-load'></div>`);
+    $('#xkit-search-timeline').after('<div id=\'prevent-load\'></div>');
 
     updateStatusBar(`Searching for <b>"${term}"</b>`);
     waitForRender().then(() => {
@@ -131,11 +131,11 @@
         #xkit-search-timeline .xkit-search-shown article {
           display: block;
         }`;
-        addStyle(searchingCss);
+      addStyle(searchingCss);
     });
   };
 
-  const searchEnd = async function() {
+  const searchEnd = async function () {
     searching = false;
     const { onNewPosts } = await fakeImport('/src/util/mutations.js');
     onNewPosts.removeListener(processNewPosts);
@@ -153,7 +153,7 @@
     removeStyle(searchingCss);
   };
 
-  const processNewPosts = async function() {
+  const processNewPosts = async function () {
     if (!searching) { return; }
     // add: don't run on the dashboard
     const $allPosts = $('#xkit-search-timeline [data-id]');
@@ -168,9 +168,9 @@
     });
   };
 
-  const filterPosts = async function(term) {
+  const filterPosts = async function (newTerm) {
     var postsToShow = [];
-    if (!term) {
+    if (!newTerm) {
       updateStatusBar('...');
       return;
     }
@@ -178,36 +178,36 @@
     const $posts = $('#xkit-search-timeline [data-id]:not(.xkit-search-done)')
       .addClass('xkit-search-done');
 
-    updateStatusBar(`Searching for <b>"${term}"</b>, please wait...`);
+    updateStatusBar(`Searching for <b>"${newTerm}"</b>, please wait...`);
 
     let renderChunkSize = 3;
-    const render = function() {
+    const render = function () {
       for (const postToShow of postsToShow) {
         postToShow.classList.add('xkit-search-shown');
-        //add: mark
+        // add: mark
       }
       postsToShow = [];
-      updateStatusBar(`Searching for <b>"${term}"</b>, please wait...`);
+      updateStatusBar(`Searching for <b>"${newTerm}"</b>, please wait...`);
     };
 
     for (const post of $posts) {
-      if (term != term) { return; }
+      if (newTerm !== term) { return; }
       if (results >= maxResults) {
-        updateStatusBar(`Searching for <b>"${term}"</b>`);
+        updateStatusBar(`Searching for <b>"${newTerm}"</b>`);
         break;
       }
 
       // gonna just replace this with mark.js probably
-      let text = await getPostText(post);
+      const text = await getPostText(post);
       console.log(text);
 
-      if (text.toLowerCase().indexOf(term) > -1) {
+      if (text.toLowerCase().indexOf(newTerm) > -1) {
         postsToShow.push(post);
         results++;
 
         if (postsToShow.length >= renderChunkSize) {
-          if (term != term) {
-            //search term has changed while we were processing
+          if (newTerm !== term) {
+            // search term has changed while we were processing
             return;
           }
           renderChunkSize = 13;
@@ -217,97 +217,96 @@
       }
     }
     render();
-    updateStatusBar(`Searching for <b>"${term}"</b>`);
+    updateStatusBar(`Searching for <b>"${newTerm}"</b>`);
   };
 
   // gonna just replace this with mark.js probably
-  const getPostText = async function(post) {
+  const getPostText = async function (post) {
     const { timelineObject } = await fakeImport('/src/util/react_props.js');
-		var text = [];
-		const {blogName, rebloggedFromName, rebloggedRootname, sourceTitle, askingName, content, trail, postAuthor, tags} =
-			await timelineObject(post.getAttribute('data-id'));
-		text.push(blogName, rebloggedFromName, rebloggedRootname);
-		if (askingName) {
-			text.push(askingName + ' asked:');
-		}
+    var text = [];
+    const { blogName, rebloggedFromName, rebloggedRootname, sourceTitle, askingName, content, trail, postAuthor, tags } =
+      await timelineObject(post.getAttribute('data-id'));
+    text.push(blogName, rebloggedFromName, rebloggedRootname);
+    if (askingName) {
+      text.push(askingName + ' asked:');
+    }
 
-		const processContent = function(input) {
-			for (let block of input) {
-				if (block.attribution) {
-					text.push(block.attribution.appName, block.attribution.displayText, block.attribution.url);
-				}
-				if (block.description) {
-					text.push(block.description);
-				}
-				if (block.displayUrl) {
-					text.push(block.displayUrl);
-				}
-				if (block.title) {
-					text.push(block.title);
-				}
-				if (block.artist) {
-					text.push(block.artist);
-				}
-				if (block.artist) {
-					text.push(block.album);
-				}
-				if (block.text) {
-					text.push(block.text);
-				}
-				if (block.formatting) {
-					for (let formatblock of block.formatting) {
-						if (formatblock.url) {
-							// Follow tumblr-redirected URLs
-							if (formatblock.url.indexOf('t.umblr.com/redirect') > -1) {
-								text.push(new URL(formatblock.url).searchParams.get('z'));
-							} else {
-								text.push(formatblock.url);
-							}
-						}
-					}
-				}
-			}
-		};
+    const processContent = function (input) {
+      for (const block of input) {
+        if (block.attribution) {
+          text.push(block.attribution.appName, block.attribution.displayText, block.attribution.url);
+        }
+        if (block.description) {
+          text.push(block.description);
+        }
+        if (block.displayUrl) {
+          text.push(block.displayUrl);
+        }
+        if (block.title) {
+          text.push(block.title);
+        }
+        if (block.artist) {
+          text.push(block.artist);
+        }
+        if (block.artist) {
+          text.push(block.album);
+        }
+        if (block.text) {
+          text.push(block.text);
+        }
+        if (block.formatting) {
+          for (const formatblock of block.formatting) {
+            if (formatblock.url) {
+              // Follow tumblr-redirected URLs
+              if (formatblock.url.indexOf('t.umblr.com/redirect') > -1) {
+                text.push(new URL(formatblock.url).searchParams.get('z'));
+              } else {
+                text.push(formatblock.url);
+              }
+            }
+          }
+        }
+      }
+    };
 
-		if (trail) {
-			for (let reblog of trail) {
-				if (reblog.blog) {
-					text.push(reblog.blog.name);
-				}
-				if (reblog.brokenBlog) {
-					text.push(reblog.brokenBlog.name);
-				}
-				if (reblog.content) {
-					processContent(reblog.content);
-				}
-			}
-		}
-		if (content) {
-			processContent(content);
-		}
+    if (trail) {
+      for (const reblog of trail) {
+        if (reblog.blog) {
+          text.push(reblog.blog.name);
+        }
+        if (reblog.brokenBlog) {
+          text.push(reblog.brokenBlog.name);
+        }
+        if (reblog.content) {
+          processContent(reblog.content);
+        }
+      }
+    }
+    if (content) {
+      processContent(content);
+    }
 
-		if (sourceTitle) {
-			text.push("source: " + sourceTitle);
-		}
-		if (postAuthor) {
-			text.push("submitted by: " + postAuthor);
-		}
-		if (tags) {
-			for (let tag of tags) {
-				text.push('#' + tag);
-			}
-		}
-		return text.join('\n');
-	};
+    if (sourceTitle) {
+      text.push('source: ' + sourceTitle);
+    }
+    if (postAuthor) {
+      text.push('submitted by: ' + postAuthor);
+    }
+    if (tags) {
+      for (const tag of tags) {
+        text.push('#' + tag);
+      }
+    }
+    return text.join('\n');
+  };
 
-  const updateStatusBar = function(status) {
+  const updateStatusBar = function (status) {
     let statusHtml;
     if (results >= maxResults) {
       statusHtml = status +
         `<br/>Showing the first ${maxResults} results found out of ${postsLoaded} loaded posts.<br/>
         Increase the maximum result count in Search My Stuff's preferences.<br/>
         <a class='destroy-button'>Exit search and show all posts</a>`;
-
     } else if (endlessScrollingDisabled) {
       statusHtml = status +
         `<br/>${results} results on this page.<br/>
@@ -323,7 +322,7 @@
     if (results > 0 || endlessScrollingDisabled) {
       if ($('#xkit-search-status-bar-top').length > 0) {
         $('#xkit-search-status-bar-top').html(statusHtml);
-       } else {
+      } else {
         $('#xkit-search-timeline').before(`<div id='xkit-search-status-bar-top' class='xkit-search-status-bar'>${statusHtml}</div>`);
         $('#xkit-search-status-bar-top').on('click', '.destroy-button', searchEnd);
       }
@@ -333,19 +332,17 @@
 
     if ($('#xkit-search-status-bar-bottom').length > 0) {
       $('#xkit-search-status-bar-bottom').html(statusHtml);
-     } else {
+    } else {
       $('#xkit-search-loader').prepend(`<div id='xkit-search-status-bar-bottom' class='xkit-search-status-bar'>${statusHtml}</div>`);
       $('#xkit-search-status-bar-bottom').on('click', '.destroy-button', searchEnd);
     }
   };
 
   /**
-   * Returns a promise that resolves only once any changes previously made to the DOM have been
-   * rendered on the page.
-   *
-   * @return {Promise}
+   * @returns {Promise} Promise that resolves only once any changes previously made to the DOM have
+   *  been rendered on the page.
    */
-  const waitForRender = function() {
+  const waitForRender = function () {
     return new Promise((resolve) => {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
@@ -369,4 +366,4 @@
   // double check all asynchronous logic
 
   return { main, clean, stylesheet: true };
-  })();
+})();

--- a/src/scripts/search_boxes.js
+++ b/src/scripts/search_boxes.js
@@ -48,15 +48,15 @@
     const $sidebarContainer = $(await keyToCss('sidebar')).find('> aside');
 
     const searchBoxHtml =
-      `<div id='search-likes-box'>
-        <input type='text' placeholder='Search Posts...' id='search-likes-input'>
+      `<div id='xkit-search-box'>
+        <input type='text' placeholder='Search Posts...' id='xkit-search-input'>
       </div>`;
     $($sidebarContainer).prepend(searchBoxHtml);
-    $('#search-likes-input').keydown(event => event.stopPropagation());
-    $('#search-likes-input').click(newSearchTerm);
+    $('#xkit-search-input').keydown(event => event.stopPropagation());
+    $('#xkit-search-input').click(newSearchTerm);
 
     const newSearchDebounced = debounce(newSearchTerm, 500);
-		$('#search-likes-input').keyup(newSearchDebounced);
+		$('#xkit-search-input').keyup(newSearchDebounced);
   };
 
   // Stolen from mutations.js
@@ -96,15 +96,15 @@
       console.log(`new search term: ${newTerm}`);
       term = newTerm;
       results = 0;
-      const $allPosts = $('#search-likes-timeline [data-id]');
+      const $allPosts = $('#xkit-search-timeline [data-id]');
       postsLoaded = $allPosts.length;
       updateStatusBar(`Searching for <b>"${term}"</b>, please wait...`);
 
       waitForRender().then(() => {
         //add: unmark
         $allPosts
-          .removeClass('search-likes-done')
-          .removeClass('search-likes-shown');
+          .removeClass('xkit-search-done')
+          .removeClass('xkit-search-shown');
         filterPosts(term);
       });
     }
@@ -116,20 +116,20 @@
     const { keyToCss, descendantSelector } = await fakeImport('/src/util/css_map.js');
     const { addStyle } = await fakeImport('/src/util/interface.js');
     onNewPosts.addListener(processNewPosts);
-    $(await keyToCss('timeline')).attr('id', 'search-likes-timeline');
-    $(await descendantSelector('timeline', 'loader')).attr('id', 'search-likes-loader');
-    $('#search-likes-timeline').after(`<div id='prevent-load'></div>`);
+    $(await keyToCss('timeline')).attr('id', 'xkit-search-timeline');
+    $(await descendantSelector('timeline', 'loader')).attr('id', 'xkit-search-loader');
+    $('#xkit-search-timeline').after(`<div id='prevent-load'></div>`);
 
     updateStatusBar(`Searching for <b>"${term}"</b>`);
     waitForRender().then(() => {
       searchingCss =
-        `#search-likes-timeline {
-          min-height: calc(100vh - ${$('#search-likes-timeline').offset().top - 10}px);
+        `#xkit-search-timeline {
+          min-height: calc(100vh - ${$('#xkit-search-timeline').offset().top - 10}px);
         }
-        #search-likes-timeline article {
+        #xkit-search-timeline article {
           display: none;
         }
-        #search-likes-timeline .search-likes-shown article {
+        #xkit-search-timeline .xkit-search-shown article {
           display: block;
         }`;
         addStyle(searchingCss);
@@ -142,13 +142,13 @@
     onNewPosts.removeListener(processNewPosts);
 
     term = null;
-    $('#search-likes-input').val('');
-    $('#search-likes-timeline [data-id]')
-      .removeClass('search-likes-done')
-      .removeClass('search-likes-shown');
-    $('.search-likes-status-bar').remove();
+    $('#xkit-search-input').val('');
+    $('#xkit-search-timeline [data-id]')
+      .removeClass('xkit-search-done')
+      .removeClass('xkit-search-shown');
+    $('.xkit-search-status-bar').remove();
     $('#prevent-load').remove();
-    $('#search-likes-timeline').removeAttr('id');
+    $('#xkit-search-timeline').removeAttr('id');
 
     const { removeStyle } = await fakeImport('/src/util/interface.js');
     removeStyle(searchingCss);
@@ -157,7 +157,7 @@
   const processNewPosts = async function() {
     if (!searching) { return; }
     // add: don't run on the dashboard
-    const $allPosts = $('#search-likes-timeline [data-id]');
+    const $allPosts = $('#xkit-search-timeline [data-id]');
     if ($allPosts.length <= postsLoaded) { return; }
     postsLoaded = $allPosts.length;
     if (!term) {
@@ -176,15 +176,15 @@
       return;
     }
 
-    const $posts = $('#search-likes-timeline [data-id]:not(.search-likes-done)')
-      .addClass('search-likes-done');
+    const $posts = $('#xkit-search-timeline [data-id]:not(.xkit-search-done)')
+      .addClass('xkit-search-done');
 
     updateStatusBar(`Searching for <b>"${term}"</b>, please wait...`);
 
     let renderChunkSize = 3;
     const render = function() {
       for (const postToShow of postsToShow) {
-        postToShow.classList.add('search-likes-shown');
+        postToShow.classList.add('xkit-search-shown');
         //add: mark
       }
       postsToShow = [];
@@ -306,12 +306,12 @@
     if (results >= maxResults) {
       statusHtml = status +
         `<br/>Showing the first ${maxResults} results found out of ${postsLoaded} loaded posts.<br/>
-        Increase the maximum result count in Search Likes' preferences.<br/>
+        Increase the maximum result count in Search My Stuff's preferences.<br/>
         <a class='destroy-button'>Exit search and show all posts</a>`;
 
     } else if (endlessScrollingDisabled) {
       `<br/>${results} results on this page.<br/>
-        Enabling endless scrolling is recommended with the Search Likes extension.<br/>
+        Enabling endless scrolling is recommended with the Search My Stuff extension.<br/>
         <a class='destroy-button'>Exit search and show all posts</a>`;
     } else {
       statusHtml = status +
@@ -321,21 +321,21 @@
     }
 
     if (results > 0) {
-      if ($('#search-likes-status-bar-top').length > 0) {
-        $('#search-likes-status-bar-top').html(statusHtml);
+      if ($('#xkit-search-status-bar-top').length > 0) {
+        $('#xkit-search-status-bar-top').html(statusHtml);
        } else {
-        $('#search-likes-timeline').before(`<div id='search-likes-status-bar-top' class='search-likes-status-bar'>${statusHtml}</div>`);
-        $('#search-likes-status-bar-top').on('click', '.destroy-button', searchEnd);
+        $('#xkit-search-timeline').before(`<div id='xkit-search-status-bar-top' class='xkit-search-status-bar'>${statusHtml}</div>`);
+        $('#xkit-search-status-bar-top').on('click', '.destroy-button', searchEnd);
       }
     } else {
-      $('#search-likes-status-bar-top').remove();
+      $('#xkit-search-status-bar-top').remove();
     }
 
-    if ($('#search-likes-status-bar-bottom').length > 0) {
-      $('#search-likes-status-bar-bottom').html(statusHtml);
+    if ($('#xkit-search-status-bar-bottom').length > 0) {
+      $('#xkit-search-status-bar-bottom').html(statusHtml);
      } else {
-      $('#search-likes-loader').prepend(`<div id='search-likes-status-bar-bottom' class='search-likes-status-bar'>${statusHtml}</div>`);
-      $('#search-likes-status-bar-bottom').on('click', '.destroy-button', searchEnd);
+      $('#xkit-search-loader').prepend(`<div id='xkit-search-status-bar-bottom' class='xkit-search-status-bar'>${statusHtml}</div>`);
+      $('#xkit-search-status-bar-bottom').on('click', '.destroy-button', searchEnd);
     }
   };
 

--- a/src/scripts/search_boxes.js
+++ b/src/scripts/search_boxes.js
@@ -1,0 +1,370 @@
+(function () {
+  let maxResults;
+
+  let searching;
+  let term;
+  let results;
+  let postsLoaded;
+
+  let endlessScrollingDisabled;
+  let searchingCss;
+
+  const onStorageChanged = function (changes, areaName) {
+    if (areaName !== 'local') {
+    return;
+    }
+    // I have absolutely no idea, to be 100% honest with you
+  };
+
+  const main = async function () {
+    browser.storage.onChanged.addListener(onStorageChanged);
+    // add: don't run on the dashboard
+
+    const { getPreferences } = await fakeImport('/src/util/preferences.js');
+    const { keyToCss } = await fakeImport('/src/util/css_map.js');
+
+    const { maxResultsPref } = await getPreferences('search_boxes');
+
+    maxResults = parseInt(maxResultsPref);
+    maxResults = !isNaN(maxResults) && maxResults > 0 ? maxResults : 200;
+
+    searching = false;
+    term = null;
+    results = 0;
+    postsLoaded = 0;
+
+    const { translate } = await fakeImport('/src/util/language_data.js');
+    const nextAriaLabel = await translate('Next');
+    if ($(`button[aria-label='${nextAriaLabel}']`).length) {
+      endlessScrollingDisabled = true;
+    }
+
+    const $sidebarContainer = $(await keyToCss('sidebar')).find('> aside');
+
+    const searchBoxHtml =
+      `<div id='search-likes-box'>
+        <input type='text' placeholder='Search Posts...' id='search-likes-input'>
+      </div>`;
+    $($sidebarContainer).prepend(searchBoxHtml);
+    $('#search-likes-input').keydown(event => event.stopPropagation());
+    $('#search-likes-input').click(newSearchTerm);
+
+    const newSearchDebounced = debounce(newSearchTerm, 500);
+		$('#search-likes-input').keyup(newSearchDebounced);
+  };
+
+  // Stolen from mutations.js
+  // const debounce = (callback, ms) => {
+  //   let timeoutID;
+  //   return (...args) => {
+  //     clearTimeout(timeoutID);
+  //     timeoutID = setTimeout(() => callback(...args), ms);
+  //   };
+  // };
+
+  // Stolen from xkit 7
+  const debounce = function(func, wait) {
+    var timeout_id;
+    return function() {
+      var last_context = this;
+      var last_args = arguments;
+
+      var exec = function() {
+        timeout_id = null;
+        func.apply(last_context, last_args);
+      };
+      clearTimeout(timeout_id);
+      timeout_id = setTimeout(exec, wait);
+    };
+  };
+
+  const newSearchTerm = async function() {
+    var newTerm = $(this).val().toLowerCase().trim();
+    if (newTerm.length < 2) {
+      newTerm = '';
+    }
+    if (term != newTerm) {
+      if (!searching) {
+        await searchStart();
+      }
+      console.log(`new search term: ${newTerm}`);
+      term = newTerm;
+      results = 0;
+      const $allPosts = $('#search-likes-timeline [data-id]');
+      postsLoaded = $allPosts.length;
+      updateStatusBar(`Searching for <b>"${term}"</b>, please wait...`);
+
+      waitForRender().then(() => {
+        //add: unmark
+        $allPosts
+          .removeClass('search-likes-done')
+          .removeClass('search-likes-shown');
+        filterPosts(term);
+      });
+    }
+  };
+
+  const searchStart = async function() {
+    searching = true;
+    const { onNewPosts } = await fakeImport('/src/util/mutations.js');
+    const { keyToCss, descendantSelector } = await fakeImport('/src/util/css_map.js');
+    const { addStyle } = await fakeImport('/src/util/interface.js');
+    onNewPosts.addListener(processNewPosts);
+    $(await keyToCss('timeline')).attr('id', 'search-likes-timeline');
+    $(await descendantSelector('timeline', 'loader')).attr('id', 'search-likes-loader');
+    $('#search-likes-timeline').after(`<div id='prevent-load'></div>`);
+
+    updateStatusBar(`Searching for <b>"${term}"</b>`);
+    waitForRender().then(() => {
+      searchingCss =
+        `#search-likes-timeline {
+          min-height: calc(100vh - ${$('#search-likes-timeline').offset().top - 10}px);
+        }
+        #search-likes-timeline article {
+          display: none;
+        }
+        #search-likes-timeline .search-likes-shown article {
+          display: block;
+        }`;
+        addStyle(searchingCss);
+    });
+  };
+
+  const searchEnd = async function() {
+    searching = false;
+    const { onNewPosts } = await fakeImport('/src/util/mutations.js');
+    onNewPosts.removeListener(processNewPosts);
+
+    term = null;
+    $('#search-likes-input').val('');
+    $('#search-likes-timeline [data-id]')
+      .removeClass('search-likes-done')
+      .removeClass('search-likes-shown');
+    $('.search-likes-status-bar').remove();
+    $('#prevent-load').remove();
+    $('#search-likes-timeline').removeAttr('id');
+
+    const { removeStyle } = await fakeImport('/src/util/interface.js');
+    removeStyle(searchingCss);
+  };
+
+  const processNewPosts = async function() {
+    if (!searching) { return; }
+    // add: don't run on the dashboard
+    const $allPosts = $('#search-likes-timeline [data-id]');
+    if ($allPosts.length <= postsLoaded) { return; }
+    postsLoaded = $allPosts.length;
+    if (!term) {
+      updateStatusBar('...');
+      return;
+    }
+    waitForRender().then(() => {
+      filterPosts(term);
+    });
+  };
+
+  const filterPosts = async function(term) {
+    var postsToShow = [];
+    if (!term) {
+      updateStatusBar('...');
+      return;
+    }
+
+    const $posts = $('#search-likes-timeline [data-id]:not(.search-likes-done)')
+      .addClass('search-likes-done');
+
+    updateStatusBar(`Searching for <b>"${term}"</b>, please wait...`);
+
+    let renderChunkSize = 3;
+    const render = function() {
+      for (const postToShow of postsToShow) {
+        postToShow.classList.add('search-likes-shown');
+        //add: mark
+      }
+      postsToShow = [];
+      updateStatusBar(`Searching for <b>"${term}"</b>, please wait...`);
+    };
+
+    for (const post of $posts) {
+      if (term != term) { return; }
+      if (results >= maxResults) {
+        updateStatusBar(`Searching for <b>"${term}"</b>`);
+        break;
+      }
+
+      // gonna just replace this with mark.js probably
+      let text = await getPostText(post);
+      console.log(text);
+
+      if (text.toLowerCase().indexOf(term) > -1) {
+        postsToShow.push(post);
+        results++;
+
+        if (postsToShow.length >= renderChunkSize) {
+          if (term != term) {
+            //search term has changed while we were processing
+            return;
+          }
+          renderChunkSize = 13;
+          render();
+          await waitForRender();
+        }
+      }
+    }
+    render();
+    updateStatusBar(`Searching for <b>"${term}"</b>`);
+  };
+
+  // gonna just replace this with mark.js probably (if not, use real version from xkit 7)
+  const getPostText = async function(post) {
+    const { timelineObject } = await fakeImport('/src/util/react_props.js');
+		var text = [];
+		const {blogName, rebloggedFromName, rebloggedRootname, sourceTitle, askingName, content, trail, postAuthor, tags} =
+			await timelineObject(post.getAttribute('data-id'));
+		text.push(blogName, rebloggedFromName, rebloggedRootname);
+		if (askingName) {
+			text.push(askingName + ' asked:');
+		}
+
+		const processContent = function(input) {
+			for (let block of input) {
+				if (block.attribution) {
+					text.push(block.attribution.appName, block.attribution.displayText, block.attribution.url);
+				}
+				if (block.description) {
+					text.push(block.description);
+				}
+				if (block.displayUrl) {
+					text.push(block.displayUrl);
+				}
+				if (block.title) {
+					text.push(block.title);
+				}
+				if (block.artist) {
+					text.push(block.artist);
+				}
+				if (block.artist) {
+					text.push(block.album);
+				}
+				if (block.text) {
+					text.push(block.text);
+				}
+				if (block.formatting) {
+					for (let formatblock of block.formatting) {
+						if (formatblock.url) {
+							// Follow tumblr-redirected URLs
+							if (formatblock.url.indexOf('t.umblr.com/redirect') > -1) {
+								text.push(new URL(formatblock.url).searchParams.get('z'));
+							} else {
+								text.push(formatblock.url);
+							}
+						}
+					}
+				}
+			}
+		};
+
+		if (trail) {
+			for (let reblog of trail) {
+				if (reblog.blog) {
+					text.push(reblog.blog.name);
+				}
+				if (reblog.brokenBlog) {
+					text.push(reblog.brokenBlog.name);
+				}
+				if (reblog.content) {
+					processContent(reblog.content);
+				}
+			}
+		}
+		if (content) {
+			processContent(content);
+		}
+
+		if (sourceTitle) {
+			text.push("source: " + sourceTitle);
+		}
+		if (postAuthor) {
+			text.push("submitted by: " + postAuthor);
+		}
+		if (tags) {
+			for (let tag of tags) {
+				text.push('#' + tag);
+			}
+		}
+		return text.join('\n');
+	};
+
+  const updateStatusBar = function(status) {
+    let statusHtml;
+    if (results >= maxResults) {
+      statusHtml = status +
+        `<br/>Showing the first ${maxResults} results found out of ${postsLoaded} loaded posts.<br/>
+        Increase the maximum result count in Search Likes' preferences.<br/>
+        <a class='destroy-button'>Exit search and show all posts</a>`;
+
+    } else if (endlessScrollingDisabled) {
+      `<br/>${results} results on this page.<br/>
+        Enabling endless scrolling is recommended with the Search Likes extension.<br/>
+        <a class='destroy-button'>Exit search and show all posts</a>`;
+    } else {
+      statusHtml = status +
+        `<br/>${results} results found out of ${postsLoaded} loaded posts.<br/>
+        Scroll down to load more posts and results.<br/>
+        <a class='destroy-button'>Exit search and show all posts</a>`;
+    }
+
+    if (results > 0) {
+      if ($('#search-likes-status-bar-top').length > 0) {
+        $('#search-likes-status-bar-top').html(statusHtml);
+       } else {
+        $('#search-likes-timeline').before(`<div id='search-likes-status-bar-top' class='search-likes-status-bar'>${statusHtml}</div>`);
+        $('#search-likes-status-bar-top').on('click', '.destroy-button', searchEnd);
+      }
+    } else {
+      $('#search-likes-status-bar-top').remove();
+    }
+
+    if ($('#search-likes-status-bar-bottom').length > 0) {
+      $('#search-likes-status-bar-bottom').html(statusHtml);
+     } else {
+      $('#search-likes-loader').prepend(`<div id='search-likes-status-bar-bottom' class='search-likes-status-bar'>${statusHtml}</div>`);
+      $('#search-likes-status-bar-bottom').on('click', '.destroy-button', searchEnd);
+    }
+  };
+
+  /**
+   * Returns a promise that resolves only once any changes previously made to the DOM have been
+   * rendered on the page.
+   *
+   * @return {Promise}
+   */
+  const waitForRender = function() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => {
+        requestAnimationFrame(() => {
+          resolve();
+        });
+      });
+    });
+  };
+
+  const clean = async function () {
+    // browser.storage.onChanged.removeListener(onStorageChanged);
+    // const { onNewPosts } = await fakeImport('/src/util/mutations.js');
+    // onNewPosts.removeListener(removeRecommended);
+    // showRecommended();
+  };
+
+  // TODO:
+  // don't run literally everywhere lmao
+  // handle soft refresh/navigation
+  // handle preference change
+  // handle clean
+  // mark.js
+  // use mark.js instead of actually searching manually
+  // use sidebar function
+  // double check all asynchronous logic
+
+  return { main, clean, stylesheet: true };
+  })();

--- a/src/scripts/search_boxes.js
+++ b/src/scripts/search_boxes.js
@@ -93,7 +93,6 @@
       if (!searching) {
         await searchStart();
       }
-      console.log(`new search term: ${newTerm}`);
       term = newTerm;
       results = 0;
       const $allPosts = $('#xkit-search-timeline [data-id]');
@@ -221,7 +220,7 @@
     updateStatusBar(`Searching for <b>"${term}"</b>`);
   };
 
-  // gonna just replace this with mark.js probably (if not, use real version from xkit 7)
+  // gonna just replace this with mark.js probably
   const getPostText = async function(post) {
     const { timelineObject } = await fakeImport('/src/util/react_props.js');
 		var text = [];
@@ -310,8 +309,9 @@
         <a class='destroy-button'>Exit search and show all posts</a>`;
 
     } else if (endlessScrollingDisabled) {
-      `<br/>${results} results on this page.<br/>
-        Enabling endless scrolling is recommended with the Search My Stuff extension.<br/>
+      statusHtml = status +
+        `<br/>${results} results on this page.<br/>
+        Endless scrolling is recommended with the Search My Stuff extension.<br/>
         <a class='destroy-button'>Exit search and show all posts</a>`;
     } else {
       statusHtml = status +
@@ -320,7 +320,7 @@
         <a class='destroy-button'>Exit search and show all posts</a>`;
     }
 
-    if (results > 0) {
+    if (results > 0 || endlessScrollingDisabled) {
       if ($('#xkit-search-status-bar-top').length > 0) {
         $('#xkit-search-status-bar-top').html(statusHtml);
        } else {
@@ -362,11 +362,10 @@
   };
 
   // TODO:
-  // don't run literally everywhere lmao
-  // handle soft refresh/navigation
+  // don't run literally everywhere lmao (handle soft refresh/navigation)
   // mark.js
-  // use mark.js instead of actually searching manually
-  // use sidebar function
+  // use mark.js instead of actually searching manually?
+  // use sidebar function when availible
   // double check all asynchronous logic
 
   return { main, clean, stylesheet: true };

--- a/src/scripts/search_boxes.js
+++ b/src/scripts/search_boxes.js
@@ -356,16 +356,14 @@
   };
 
   const clean = async function () {
-    // browser.storage.onChanged.removeListener(onStorageChanged);
-    // const { onNewPosts } = await fakeImport('/src/util/mutations.js');
-    // onNewPosts.removeListener(removeRecommended);
-    // showRecommended();
+    browser.storage.onChanged.removeListener(onStorageChanged);
+    await searchEnd();
+    $('#xkit-search-box').remove();
   };
 
   // TODO:
   // don't run literally everywhere lmao
   // handle soft refresh/navigation
-  // handle clean
   // mark.js
   // use mark.js instead of actually searching manually
   // use sidebar function

--- a/src/scripts/search_boxes.json
+++ b/src/scripts/search_boxes.json
@@ -1,0 +1,16 @@
+{
+	"title": "Search My Stuff",
+	"description": "Search posted, liked, queued, and drafted posts",
+	"icon": {
+	  "class_name": "ri-search-line",
+	  "color": "white",
+	  "background_color": "#FE6E0B"
+	},
+	"preferences": {
+	  "maxResults": {
+		"type": "text",
+		"label": "Maximum search results (default: 200)",
+		"default": "200"
+	  }
+	}
+}


### PR DESCRIPTION
This ports my Search Likes PR from XKit 7. 

It loads posts via endless scrolling and hides all but the desired results. Because this can quickly result in unreasonably large amounts of loaded content (and because I wanted to learn this kind of thing anyway), I made an effort to take performance and responsiveness into account, hence things like rendering posts to the dom in chunks. Yes, this makes the code huge. Sorry :P

It also uses a manual scrape of the react props to get searchable text, which probably isn't worth it. (I was gonna just use mark.js and live with the oddities of finding the note count and etc.)

It's supposed to run on likes, channel, queue, and drafts, but right now it just runs everywhere. (It's sort of hilarious on the dashboard, but this obviously should never be given to the public :D)

I would personally probably close this to reduce PR clutter until more dependencies are implemented, but I'll submit it for the record and that can be up to you.

- [ ] don't run literally everywhere lmao (handle soft refresh/navigation)
- [ ] mark.js
- [ ] use mark.js instead of actually searching manually?
- [ ] use sidebar function when available
- [ ] remove unnecessary jquery
- [ ] double check all asynchronous logic