### PR TITLE
Cache react props

### DIFF
--- a/src/scripts/cleanfeed.js
+++ b/src/scripts/cleanfeed.js
@@ -6,7 +6,7 @@
 
   const processPosts = async function () {
     const { getPostElements } = await fakeImport('/src/util/interface.js');
-    const { timelineObject } = await fakeImport('/src/util/react_props.js');
+    const { timelineObjectMemoized } = await fakeImport('/src/util/react_props.js');
 
     getPostElements({ excludeClass }).forEach(async postElement => {
       if (blockingMode === 'all') {
@@ -14,7 +14,7 @@
         return;
       }
 
-      const postTimelineObject = await timelineObject(postElement.dataset.id);
+      const postTimelineObject = await timelineObjectMemoized(postElement.dataset.id);
 
       {
         const { blog: { isAdult } } = postTimelineObject;

--- a/src/scripts/timestamps.js
+++ b/src/scripts/timestamps.js
@@ -28,10 +28,10 @@
 
   const addPostTimestamps = async function () {
     const { getPostElements } = await fakeImport('/src/util/interface.js');
-    const { timelineObject } = await fakeImport('/src/util/react_props.js');
+    const { timelineObjectMemoized } = await fakeImport('/src/util/react_props.js');
 
     getPostElements({ excludeClass: 'xkit-timestamps-done' }).forEach(async postElement => {
-      const { timestamp, postUrl } = await timelineObject(postElement.dataset.id);
+      const { timestamp, postUrl } = await timelineObjectMemoized(postElement.dataset.id);
 
       const noteCountElement = postElement.querySelector(noteCountSelector);
 
@@ -52,11 +52,11 @@
 
   const addReblogTimestamps = async function () {
     const { getPostElements } = await fakeImport('/src/util/interface.js');
-    const { timelineObject } = await fakeImport('/src/util/react_props.js');
+    const { timelineObjectMemoized } = await fakeImport('/src/util/react_props.js');
     const { apiFetch } = await fakeImport('/src/util/tumblr_helpers.js');
 
     getPostElements({ excludeClass: 'xkit-reblog-timestamps-done' }).forEach(async postElement => {
-      let { trail } = await timelineObject(postElement.dataset.id);
+      let { trail } = await timelineObjectMemoized(postElement.dataset.id);
       if (!trail.length) {
         return;
       }

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -1,11 +1,25 @@
 (function () {
+  const cache = {};
+
+  /**
+   * @param {string} postID - The post ID of an on-screen post
+   * @returns {object} - The post's buried timelineObject property (cached; use
+   *  timelineObject if you need up-to-date properties that may have changed)
+   */
+  const timelineObjectMemoized = async function (postID) {
+    if (Object.prototype.hasOwnProperty.call(cache, postID)) {
+      return cache[postID];
+    }
+    return timelineObject(postID);
+  };
+
   /**
    * @param {string} postID - The post ID of an on-screen post
    * @returns {object} - The post's buried timelineObject property
    */
   const timelineObject = async function (postID) {
     const { inject } = await fakeImport('/src/util/inject.js');
-    return inject(async id => {
+    cache[postID] = inject(async id => {
       const postElement = document.querySelector(`[data-id="${id}"]`);
       const reactKey = Object.keys(postElement).find(key => key.startsWith('__reactInternalInstance'));
       let fiber = postElement[reactKey];
@@ -18,7 +32,8 @@
 
       return fiber.memoizedProps.timelineObject;
     }, [postID]);
+    return cache[postID];
   };
 
-  return { timelineObject };
+  return { timelineObject, timelineObjectMemoized };
 })();


### PR DESCRIPTION
This lets extensions that don't need updated-up-to-the-moment react props save on a few function calls. Pretty insignificant now, but might be nice when other interface functions start needing react props.