### PR TITLE
Add textarea-type preference

### DIFF
--- a/src/browser_action/popup.css
+++ b/src/browser_action/popup.css
@@ -80,3 +80,8 @@ input:not(:first-child),
 select:not(:first-child) {
   margin-left: 1ch;
 }
+
+textarea {
+  resize: none;
+  width: 100%;
+}

--- a/src/browser_action/popup.html
+++ b/src/browser_action/popup.html
@@ -113,6 +113,15 @@
       </li>
     </template>
 
+    <template id="textarea-preference">
+      <li>
+        <label></label>
+      </li>
+      <li>
+        <textarea rows="5"></textarea>
+      </li>
+    </template>
+
     <script src="/lib/browser-polyfill.min.js"></script>
     <script src="/lib/jquery.min.js"></script>
     <script src="/lib/spectrum.js"></script>

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -40,6 +40,7 @@ const writePreference = async function (event) {
     case 'text':
     case 'color':
     case 'select':
+    case 'textarea':
       browser.storage.local.set({ [storageKey]: event.target.value });
       break;
   }
@@ -104,6 +105,7 @@ const renderScripts = async function () {
         text: 'input',
         color: 'input',
         select: 'select',
+        textarea: 'textarea',
       }[preference.type];
 
       const preferenceInput = preferenceTemplateClone.querySelector(inputType);
@@ -116,6 +118,7 @@ const renderScripts = async function () {
           break;
         case 'text':
         case 'color':
+        case 'textarea':
           preferenceInput.value = preference.value;
           break;
         case 'select':


### PR DESCRIPTION
#### User-facing changes
- Allows developers to use textarea controls in their extension preferences.

#### Technical explanation
Adds textarea controls in a similar way to other controls, with the label above the textarea for legibility purposes.

#### Issues this closes
None, though there is a project card for this which is currently in the To-Do stage.