### PR TITLE
[Painter] Add tag highlighting

### DIFF
--- a/src/scripts/painter.js
+++ b/src/scripts/painter.js
@@ -3,29 +3,61 @@
   let originalColour;
   let reblogColour;
   let likedColour;
+  let tagColour;
+  let colouredTags;
+  let colourSourceTags;
 
   const excludeClass = 'xkit-painter-done';
 
   const paint = async function () {
     const { getPostElements } = await fakeImport('/src/util/interface.js');
     const { timelineObject } = await fakeImport('/src/util/react_props.js');
+    const { apiFetch } = await fakeImport('/src/util/tumblr_helpers.js');
+    const tagArray = colouredTags.split(',').map(tag => tag.trim().replace(/#/g, '').toLowerCase());
 
     getPostElements({ excludeClass }).forEach(async postElement => {
-      const { canDelete, liked, rebloggedFromId } = await timelineObject(postElement.dataset.id);
+      const { canDelete, liked, rebloggedFromId, rebloggedRootId, rebloggedRootUuid, tags } = await timelineObject(postElement.dataset.id);
 
       const coloursToApply = [];
       if (canDelete && ownColour) {
         coloursToApply.push(ownColour);
       }
+
       if (liked && likedColour) {
         coloursToApply.push(likedColour);
       }
+
       if (rebloggedFromId) {
         if (reblogColour) {
           coloursToApply.push(reblogColour);
         }
       } else if (originalColour) {
         coloursToApply.push(originalColour);
+      }
+
+      if (tagColour) {
+        let tagColourFound = false;
+        for (const tag of tags) {
+          if (tagArray.includes(tag.toLowerCase())) {
+            coloursToApply.push(tagColour);
+            tagColourFound = true;
+            break;
+          }
+        }
+        if (!tagColourFound && colourSourceTags) {
+          try {
+            const sourcePost = await apiFetch(`/v2/blog/${rebloggedRootUuid}/posts?id=${rebloggedRootId}`);
+            for (const sourceTag of sourcePost.response.posts[0].tags) {
+              if (tagArray.includes(sourceTag.toLowerCase())) {
+                coloursToApply.push(tagColour);
+                break;
+              }
+            }
+          } catch (e) {
+            // The source post can't be found, so we can't extract tags from it either.
+            // This means we don't have to do anything else with it, and we can quit quietly.
+          }
+        }
       }
 
       if (!coloursToApply.length) {
@@ -54,38 +86,21 @@
     $(`.${excludeClass}`).removeClass(excludeClass);
   };
 
-  const onStorageChanged = async function (changes, areaName) {
-    if (areaName !== 'local') {
-      return;
-    }
-
-    if (Object.keys(changes).some(key => key.startsWith('painter'))) {
-      const { getPreferences } = await fakeImport('/src/util/preferences.js');
-
-      ({ ownColour, originalColour, reblogColour, likedColour } = await getPreferences('painter'));
-
-      strip();
-      paint();
-    }
-  };
-
   const main = async function () {
-    browser.storage.onChanged.addListener(onStorageChanged);
     const { getPreferences } = await fakeImport('/src/util/preferences.js');
     const { onNewPosts } = await fakeImport('/src/util/mutations.js');
 
-    ({ ownColour, originalColour, reblogColour, likedColour } = await getPreferences('painter'));
+    ({ ownColour, originalColour, reblogColour, likedColour, tagColour, colouredTags, colourSourceTags } = await getPreferences('painter'));
 
     onNewPosts.addListener(paint);
     paint();
   };
 
   const clean = async function () {
-    browser.storage.onChanged.removeListener(onStorageChanged);
     const { onNewPosts } = await fakeImport('/src/util/mutations.js');
     onNewPosts.removeListener(paint);
     strip();
   };
 
-  return { main, clean };
+  return { main, clean, autoRestart: true };
 })();

--- a/src/scripts/painter.js
+++ b/src/scripts/painter.js
@@ -44,7 +44,7 @@
             break;
           }
         }
-        if (!tagColourFound && colourSourceTags) {
+        if (!tagColourFound && colourSourceTags && rebloggedRootId && rebloggedRootUuid) {
           try {
             const sourcePost = await apiFetch(`/v2/blog/${rebloggedRootUuid}/posts?id=${rebloggedRootId}`);
             for (const sourceTag of sourcePost.response.posts[0].tags) {

--- a/src/scripts/painter.json
+++ b/src/scripts/painter.json
@@ -26,6 +26,21 @@
       "type": "color",
       "label": "Liked post colour",
       "default": ""
+    },
+    "tagColour": {
+      "type": "color",
+      "label": "Tag highlighting colour",
+      "default": ""
+    },
+    "colouredTags": {
+      "type": "textarea",
+      "label": "Tags to highlight (comma separated)",
+      "default": ""
+    },
+    "colourSourceTags": {
+      "type": "checkbox",
+      "label": "Also highlight for tags on source posts",
+      "default": true
     }
   }
 }


### PR DESCRIPTION
#### User-facing changes
- Users may now select a colour for highlighting user-input tags using the Painter extension.
- There is also a functionality for highlighting tags from the source post, in a similar way to how Tumblr's tag filtering works.

#### Technical explanation
If the tag colour is set, the script loops through every tag on the post to see if any in the textarea match it, and applies the colour to the post if so. If this initial search doesn't get a result, and the checkbox for searching the source post is ticked, it will fetch the source post and look through its tags in a similar way, colouring the post if a match is found.

#### Issues this closes
None.