### PR TITLE
Debounce preference input

### DIFF
--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -36,7 +36,7 @@ const debounce = (callback, ms) => {
   };
 };
 
-const writePreference = debounce(async function (event) {
+const writePreference = async function (event) {
   const { id } = event.target;
   const [scriptName, preferenceType, preferenceName] = id.split('.');
   const storageKey = `${scriptName}.preferences.${preferenceName}`;
@@ -52,7 +52,7 @@ const writePreference = debounce(async function (event) {
       browser.storage.local.set({ [storageKey]: event.target.value });
       break;
   }
-}, 500);
+};
 
 const renderScripts = async function () {
   const installedScripts = await getInstalledScripts();
@@ -118,7 +118,7 @@ const renderScripts = async function () {
 
       const preferenceInput = preferenceTemplateClone.querySelector(inputType);
       preferenceInput.id = `${scriptName}.${preference.type}.${key}`;
-      preferenceInput.addEventListener('input', writePreference);
+      preferenceInput.addEventListener('input', debounce(writePreference, 500));
 
       switch (preference.type) {
         case 'checkbox':

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -28,7 +28,15 @@ const writeEnabled = async function (event) {
   browser.storage.local.set({ enabledScripts });
 };
 
-const writePreference = async function (event) {
+const debounce = (callback, ms) => {
+  let timeoutID;
+  return (...args) => {
+    clearTimeout(timeoutID);
+    timeoutID = setTimeout(() => callback(...args), ms);
+  };
+};
+
+const writePreference = debounce(async function (event) {
   const { id } = event.target;
   const [scriptName, preferenceType, preferenceName] = id.split('.');
   const storageKey = `${scriptName}.preferences.${preferenceName}`;
@@ -44,7 +52,7 @@ const writePreference = async function (event) {
       browser.storage.local.set({ [storageKey]: event.target.value });
       break;
   }
-};
+}, 500);
 
 const renderScripts = async function () {
   const installedScripts = await getInstalledScripts();

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -118,7 +118,7 @@ const renderScripts = async function () {
 
       const preferenceInput = preferenceTemplateClone.querySelector(inputType);
       preferenceInput.id = `${scriptName}.${preference.type}.${key}`;
-      preferenceInput.addEventListener('input', debounce(writePreference, 500));
+      preferenceInput.addEventListener('input', ['text', 'textarea'].includes(preference.type) ? debounce(writePreference, 500) : writePreference);
 
       switch (preference.type) {
         case 'checkbox':


### PR DESCRIPTION
#### User-facing changes
- None

#### Technical explanation
All preference writes are debounced by half a second, which means that changing preferences (especially of `text` and `textarea` types) will no longer create restart spam among preferences.

#### Issues this closes
None.