### PR TITLE
Popup: use background color to indicate browser focus

### DIFF
--- a/src/browser_action/configuration.css
+++ b/src/browser_action/configuration.css
@@ -61,7 +61,7 @@
   color: #444444;
 }
 
-.script:hover summary {
+.script summary:hover {
   background-color: #efefef;
 }
 

--- a/src/browser_action/configuration.css
+++ b/src/browser_action/configuration.css
@@ -61,11 +61,11 @@
   color: #444444;
 }
 
-.script:hover:not([open]) summary {
+.script:hover summary {
   background-color: #efefef;
 }
 
-.script[open] summary {
+.script summary:focus {
   background-color: #d9eefc;
 }
 


### PR DESCRIPTION
#### User-facing changes
- Use the blue highlight color on the focused script preference title element, rather than on any open script preference title element. I think this is less visually confusing and makes tab navigation more clear.
- Make the grey highlight on hover only active when the title element is hovered, not when the dropdown contents are hovered. (Not sure if this is better or not? It feels a bit more natural to me. Revert 1f5b422 to see the difference.) 

#### Technical explanation
The blue highlight css has priority over the grey highlight css (only) because it comes second.

#### Issues this closes
n/a
