### PR TITLE
Render scripts synchronously

### DIFF
--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -115,6 +115,7 @@ const renderPreferences = async function ({ scriptName, preferences, preferenceL
 };
 
 const renderScripts = async function () {
+  const scriptTemplateClones = [];
   const installedScripts = await getInstalledScripts();
   const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
 
@@ -160,8 +161,9 @@ const renderScripts = async function () {
       renderPreferences({ scriptName, preferences, preferenceList });
     }
 
-    scriptsDiv.appendChild(scriptTemplateClone);
+    scriptTemplateClones.push(scriptTemplateClone);
   }
+  scriptTemplateClones.forEach(scriptTemplateClone => scriptsDiv.appendChild(scriptTemplateClone));
 
   const $makeSpectrum = $(scriptsDiv).find('.makeSpectrum');
 

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -126,7 +126,7 @@ const renderPreferences = async function ({ scriptName, preferences, preferenceL
 };
 
 const renderScripts = async function () {
-  const scriptTemplateClones = [];
+  scriptsDiv.style.display = 'none';
   const installedScripts = await getInstalledScripts();
   const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
 
@@ -172,9 +172,10 @@ const renderScripts = async function () {
       renderPreferences({ scriptName, preferences, preferenceList });
     }
 
-    scriptTemplateClones.push(scriptTemplateClone);
+    scriptsDiv.appendChild(scriptTemplateClone);
   }
-  scriptTemplateClones.forEach(scriptTemplateClone => scriptsDiv.appendChild(scriptTemplateClone));
+
+  scriptsDiv.style.display = '';
 };
 
 renderScripts().then(() => {


### PR DESCRIPTION
#### User-facing changes
- When the popup is opened to the default "configuration" tab, all scripts pop in at once rather than one at a time. This is quite a bit faster in Chrome and Edge (tested on MacOS), which re-render the popup at a different height each time a script is added in a fairly janky animated process, but - rather annoyingly - a bit slower in Firefox (though the animation is still cleaner).

#### Technical explanation
- `scriptTemplateClone`s are appended synchronously after all are generated. Preferences are still asynchronous, which is fine since they don't affect the popup size.
- If you wanted to, you could probably get rid of some of the ~8 frame delay on Firefox by rendering them all as blank and fetching the JSON asynchronously afterward? but yeah it's 8 frames

#### Issues this closes
- n/a

(Fun aside: apparently if you open and close a webextension popup enough times in Firefox, Stylus and uBlock Origin break!)