### PR TITLE
 Shorten Posts: fix avatars in Chrome, part 3

### DIFF
--- a/src/scripts/shorten_posts.css
+++ b/src/scripts/shorten_posts.css
@@ -6,8 +6,7 @@
 
 .xkit-shorten-posts-shortened article {
   position: static;
-
-  overflow: hidden;
+  overflow-y: clip;
   max-height: var(--shortened-post-height);
 }
 

--- a/src/scripts/shorten_posts.css
+++ b/src/scripts/shorten_posts.css
@@ -6,6 +6,8 @@
 
 .xkit-shorten-posts-shortened article {
   position: static;
+
+  overflow-y: hidden;
   overflow-y: clip;
   max-height: var(--shortened-post-height);
 }


### PR DESCRIPTION
#### User-facing changes
- Shorten posts doesn't break sticky avatars in Chrome

#### Technical explanation
- Goes back to (only using) `overflow-y: clip`, which now that [https://github.com/AprilSylph/XKit-Rewritten/commit/f6ffb57776c129d611327328af70e8211bb8a611](https://github.com/AprilSylph/XKit-Rewritten/commit/f6ffb57776c129d611327328af70e8211bb8a611) is implemented, seems to work on both browsers.