### PR TITLE
[AccessKit] New script: display alt text below images

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -37,3 +37,24 @@ body.accesskit-blue-links article a[target="_blank"][href^="https://href.li/"] {
 body.accesskit-no-user-colours article span[style^="color"] {
   color: inherit !important;
 }
+
+
+figure.accesskit-visible-alt-text {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+figure.accesskit-visible-alt-text figcaption {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-top: 2px;
+  padding: 5px;
+
+  line-height: 1;
+  text-align: center;
+  background: #ddd;
+  color: #111;
+}

--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -50,9 +50,9 @@ figure.accesskit-visible-alt-text figcaption {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: 5px;
+  padding: .75ch;
 
-  line-height: 1;
+  line-height: 1.25;
   text-align: center;
   background-color: rgb(var(--secondary-accent));
   color: rgb(var(--black));

--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -50,9 +50,10 @@ figure.accesskit-visible-alt-text figcaption {
   display: flex;
   justify-content: center;
   align-items: center;
-  padding: .75ch;
+  padding: .75ch 1ch;
 
-  line-height: 1.25;
+  font-size: .875rem;
+  line-height: 1.5;
   text-align: center;
   background-color: rgb(var(--secondary-accent));
   color: rgb(var(--black));

--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -50,11 +50,10 @@ figure.accesskit-visible-alt-text figcaption {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 2px;
   padding: 5px;
 
   line-height: 1;
   text-align: center;
-  background: #ddd;
-  color: #111;
+  background-color: rgb(var(--secondary-accent));
+  color: rgb(var(--black));
 }

--- a/src/scripts/accesskit.json
+++ b/src/scripts/accesskit.json
@@ -31,6 +31,11 @@
       "type": "checkbox",
       "label": "Remove user-set fonts from text in posts",
       "default": false
+    },
+    "visible_alt_text": {
+      "type": "checkbox",
+      "label": "Show alt text as captions below images",
+      "default": false
     }
   }
 }

--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -1,0 +1,46 @@
+import { descendantSelector, keyToCss } from '../../util/css_map.js';
+import { addStyle, removeStyle } from '../../util/interface.js';
+import { onPostsMutated } from '../../util/mutations.js';
+
+let imageBlockSelector;
+let css;
+
+const className = 'accesskit-visible-alt-text';
+
+const processImages = function () {
+  [...document.querySelectorAll(`${imageBlockSelector}:not(.${className})`)]
+    .forEach(imageBlock => {
+      const image = imageBlock.querySelector('img');
+      if (image) {
+        imageBlock.classList.add(className);
+
+        if (image.alt && image.alt.toLowerCase() !== 'image') {
+          const caption = document.createElement('figcaption');
+          caption.textContent = image.alt;
+          imageBlock.appendChild(caption);
+        }
+      }
+    });
+};
+
+export const main = async function () {
+  imageBlockSelector = await keyToCss('imageBlock');
+
+  const imageBlockButtonInnerSelector = await descendantSelector('imageBlockButton', 'buttonInner');
+
+  // Setting this for all images ensures side-by-side images align vertically even if one has a caption and the other doesn't
+  css = `${imageBlockButtonInnerSelector} { height: 100%; }`;
+  addStyle(css);
+
+  onPostsMutated.addListener(processImages);
+  processImages();
+};
+
+export const clean = async function () {
+  onPostsMutated.removeListener(processImages);
+
+  removeStyle(css);
+
+  document.querySelectorAll(`.${className} figcaption`).forEach(caption => caption.remove());
+  document.querySelectorAll(`.${className}`).forEach(element => element.classList.remove(className));
+};

--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -5,15 +5,15 @@ import { onPostsMutated } from '../../util/mutations.js';
 let imageBlockSelector;
 let css;
 
-const className = 'accesskit-visible-alt-text';
+const processedClass = 'accesskit-visible-alt-text';
 
 const processImages = function () {
   [...document.querySelectorAll(imageBlockSelector)]
-    .filter(imageBlock => imageBlock.classList.contains(className) === false)
+    .filter(imageBlock => imageBlock.classList.contains(processedClass) === false)
     .forEach(imageBlock => {
       const image = imageBlock.querySelector('img');
       if (image) {
-        imageBlock.classList.add(className);
+        imageBlock.classList.add(processedClass);
 
         if (image.alt) {
           const caption = document.createElement('figcaption');
@@ -42,6 +42,6 @@ export const clean = async function () {
 
   removeStyle(css);
 
-  $(`.${className} figcaption`).remove();
-  $(`.${className}`).removeClass(className);
+  $(`.${processedClass} figcaption`).remove();
+  $(`.${processedClass}`).removeClass(processedClass);
 };

--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -8,7 +8,8 @@ let css;
 const className = 'accesskit-visible-alt-text';
 
 const processImages = function () {
-  [...document.querySelectorAll(`${imageBlockSelector}:not(.${className})`)]
+  [...document.querySelectorAll(imageBlockSelector)]
+    .filter(imageBlock => imageBlock.classList.contains(className) === false)
     .forEach(imageBlock => {
       const image = imageBlock.querySelector('img');
       if (image) {
@@ -41,6 +42,6 @@ export const clean = async function () {
 
   removeStyle(css);
 
-  document.querySelectorAll(`.${className} figcaption`).forEach(caption => caption.remove());
-  document.querySelectorAll(`.${className}`).forEach(element => element.classList.remove(className));
+  $(`.${className} figcaption`).remove();
+  $(`.${className}`).removeClass(className);
 };

--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -14,7 +14,7 @@ const processImages = function () {
       if (image) {
         imageBlock.classList.add(className);
 
-        if (image.alt && image.alt.toLowerCase() !== 'image') {
+        if (image.alt) {
           const caption = document.createElement('figcaption');
           caption.textContent = image.alt;
           imageBlock.appendChild(caption);


### PR DESCRIPTION
#### User-facing changes
Adds an option to AccessKit that displays any (non-default) image alt text in posts as a caption below the image.

#### Technical explanation
It checks for any not-yet-processed imageBlocks in onPostsMutated (skipping blocks where the image hasn't loaded yet); if the alt text isn't the default "Image" text, it inserts a caption into the block (I used figcaption since imageBlock is a figure, but div would probably work too)

Like I mentioned in #192, the styling probably needs some work, haha. I also haven't spent much time testing in Chrome yet, though a quick check in tumblr.com/search/alt+text seemed OK.

#### Issues this closes
closes #192 
