### PR TITLE
No Recommended: Hide blogs in sidebar on tag pages

### DIFF
--- a/src/scripts/no_recommended/hide_recommended_blogs.js
+++ b/src/scripts/no_recommended/hide_recommended_blogs.js
@@ -1,11 +1,15 @@
 import { onBaseContainerMutated } from '../../util/mutations.js';
 import { translate } from '../../util/language_data.js';
 import { addStyle, removeStyle } from '../../util/interface.js';
+import { descendantSelector } from '../../util/css_map.js';
 
 const excludeClass = 'xkit-no-recommended-blogs-done';
 const hiddenClass = 'xkit-no-recommended-blogs-hidden';
 
 let recommendedBlogsLabel;
+let recommendedBlogsPattern;
+
+let tagPageTitleSelector;
 
 const css = `.${hiddenClass} { display: none; }`;
 
@@ -16,10 +20,24 @@ const checkForRecommendedBlogs = function () {
       return h1.textContent === recommendedBlogsLabel;
     })
     .forEach(h1 => h1.parentNode.classList.add(hiddenClass));
+
+  [...document.querySelectorAll(tagPageTitleSelector)]
+    .filter(title => !title.classList.contains(excludeClass))
+    .filter(title => {
+      title.classList.add(excludeClass);
+      return recommendedBlogsPattern.test(title.textContent);
+    })
+    .forEach(title => title.parentNode.classList.add(hiddenClass));
 };
 
 export const main = async function () {
   recommendedBlogsLabel = await translate('Check out these blogs');
+
+  const tagPageLabel = await translate('Top %1$s blogs');
+  recommendedBlogsPattern = new RegExp(`^${tagPageLabel.replace('%1$s', '.*')}$`);
+
+  tagPageTitleSelector = await descendantSelector('desktopContainer', 'title');
+
   onBaseContainerMutated.addListener(checkForRecommendedBlogs);
   checkForRecommendedBlogs();
   addStyle(css);

--- a/src/scripts/no_recommended/hide_recommended_blogs.js
+++ b/src/scripts/no_recommended/hide_recommended_blogs.js
@@ -1,15 +1,12 @@
 import { onBaseContainerMutated } from '../../util/mutations.js';
 import { translate } from '../../util/language_data.js';
 import { addStyle, removeStyle } from '../../util/interface.js';
-import { descendantSelector } from '../../util/css_map.js';
 
 const excludeClass = 'xkit-no-recommended-blogs-done';
 const hiddenClass = 'xkit-no-recommended-blogs-hidden';
 
-let recommendedBlogsLabel;
-let recommendedBlogsPattern;
-
-let tagPageTitleSelector;
+let checkOutTheseBlogsLabel;
+let topBlogsSelector;
 
 const css = `.${hiddenClass} { display: none; }`;
 
@@ -17,26 +14,23 @@ const checkForRecommendedBlogs = function () {
   [...document.querySelectorAll(`aside > div > h1:not(.${excludeClass})`)]
     .filter(h1 => {
       h1.classList.add(excludeClass);
-      return h1.textContent === recommendedBlogsLabel;
+      return h1.textContent === checkOutTheseBlogsLabel;
     })
     .forEach(h1 => h1.parentNode.classList.add(hiddenClass));
 
-  [...document.querySelectorAll(tagPageTitleSelector)]
-    .filter(title => !title.classList.contains(excludeClass))
-    .filter(title => {
-      title.classList.add(excludeClass);
-      return recommendedBlogsPattern.test(title.textContent);
-    })
-    .forEach(title => title.parentNode.classList.add(hiddenClass));
+  [...document.querySelectorAll(`${topBlogsSelector}:not(.${excludeClass})`)]
+    .forEach(ul => {
+      ul.classList.add(excludeClass);
+      ul.parentNode.classList.add(hiddenClass);
+    });
 };
 
 export const main = async function () {
-  recommendedBlogsLabel = await translate('Check out these blogs');
+  checkOutTheseBlogsLabel = await translate('Check out these blogs');
 
-  const tagPageLabel = await translate('Top %1$s blogs');
-  recommendedBlogsPattern = new RegExp(`^${tagPageLabel.replace('%1$s', '.*')}$`);
-
-  tagPageTitleSelector = await descendantSelector('desktopContainer', 'title');
+  const topBlogsLabel = await translate('Top %1$s blogs');
+  const [topBlogsPrefix, topBlogsSuffix] = topBlogsLabel.split('%1$s');
+  topBlogsSelector = `aside ul${topBlogsPrefix ? `[aria-label^="${topBlogsPrefix}"]` : ''}${topBlogsSuffix ? `[aria-label$="${topBlogsSuffix}"]` : ''}`;
 
   onBaseContainerMutated.addListener(checkForRecommendedBlogs);
   checkForRecommendedBlogs();

--- a/src/scripts/no_recommended/hide_recommended_blogs.js
+++ b/src/scripts/no_recommended/hide_recommended_blogs.js
@@ -1,30 +1,42 @@
 import { onBaseContainerMutated } from '../../util/mutations.js';
 import { translate } from '../../util/language_data.js';
 import { addStyle, removeStyle } from '../../util/interface.js';
+import { descendantSelector } from '../../util/css_map.js';
 
 const excludeClass = 'xkit-no-recommended-blogs-done';
 const hiddenClass = 'xkit-no-recommended-blogs-hidden';
 
-let checkOutTheseBlogsSelector;
-let topBlogsSelector;
+let recommendedBlogsLabel;
+let recommendedBlogsPattern;
+
+let tagPageTitleSelector;
 
 const css = `.${hiddenClass} { display: none; }`;
 
 const checkForRecommendedBlogs = function () {
-  [...document.querySelectorAll(`${checkOutTheseBlogsSelector}:not(.${excludeClass}), ${topBlogsSelector}:not(.${excludeClass})`)]
-    .forEach(ul => {
-      ul.classList.add(excludeClass);
-      ul.parentNode.classList.add(hiddenClass);
-    });
+  [...document.querySelectorAll(`aside > div > h1:not(.${excludeClass})`)]
+    .filter(h1 => {
+      h1.classList.add(excludeClass);
+      return h1.textContent === recommendedBlogsLabel;
+    })
+    .forEach(h1 => h1.parentNode.classList.add(hiddenClass));
+
+  [...document.querySelectorAll(tagPageTitleSelector)]
+    .filter(title => !title.classList.contains(excludeClass))
+    .filter(title => {
+      title.classList.add(excludeClass);
+      return recommendedBlogsPattern.test(title.textContent);
+    })
+    .forEach(title => title.parentNode.classList.add(hiddenClass));
 };
 
 export const main = async function () {
-  const checkOutTheseBlogsLabel = await translate('Check out these blogs');
-  checkOutTheseBlogsSelector = `aside ul[aria-label="${checkOutTheseBlogsLabel}"]`;
+  recommendedBlogsLabel = await translate('Check out these blogs');
 
-  const topBlogsLabel = await translate('Top %1$s blogs');
-  const [topBlogsPrefix, topBlogsSuffix] = topBlogsLabel.split('%1$s');
-  topBlogsSelector = `aside ul${topBlogsPrefix ? `[aria-label^="${topBlogsPrefix}"]` : ''}${topBlogsSuffix ? `[aria-label$="${topBlogsSuffix}"]` : ''}`;
+  const tagPageLabel = await translate('Top %1$s blogs');
+  recommendedBlogsPattern = new RegExp(`^${tagPageLabel.replace('%1$s', '.*')}$`);
+
+  tagPageTitleSelector = await descendantSelector('desktopContainer', 'title');
 
   onBaseContainerMutated.addListener(checkForRecommendedBlogs);
   checkForRecommendedBlogs();

--- a/src/scripts/no_recommended/hide_recommended_blogs.js
+++ b/src/scripts/no_recommended/hide_recommended_blogs.js
@@ -1,42 +1,30 @@
 import { onBaseContainerMutated } from '../../util/mutations.js';
 import { translate } from '../../util/language_data.js';
 import { addStyle, removeStyle } from '../../util/interface.js';
-import { descendantSelector } from '../../util/css_map.js';
 
 const excludeClass = 'xkit-no-recommended-blogs-done';
 const hiddenClass = 'xkit-no-recommended-blogs-hidden';
 
-let recommendedBlogsLabel;
-let recommendedBlogsPattern;
-
-let tagPageTitleSelector;
+let checkOutTheseBlogsSelector;
+let topBlogsSelector;
 
 const css = `.${hiddenClass} { display: none; }`;
 
 const checkForRecommendedBlogs = function () {
-  [...document.querySelectorAll(`aside > div > h1:not(.${excludeClass})`)]
-    .filter(h1 => {
-      h1.classList.add(excludeClass);
-      return h1.textContent === recommendedBlogsLabel;
-    })
-    .forEach(h1 => h1.parentNode.classList.add(hiddenClass));
-
-  [...document.querySelectorAll(tagPageTitleSelector)]
-    .filter(title => !title.classList.contains(excludeClass))
-    .filter(title => {
-      title.classList.add(excludeClass);
-      return recommendedBlogsPattern.test(title.textContent);
-    })
-    .forEach(title => title.parentNode.classList.add(hiddenClass));
+  [...document.querySelectorAll(`${checkOutTheseBlogsSelector}:not(.${excludeClass}), ${topBlogsSelector}:not(.${excludeClass})`)]
+    .forEach(ul => {
+      ul.classList.add(excludeClass);
+      ul.parentNode.classList.add(hiddenClass);
+    });
 };
 
 export const main = async function () {
-  recommendedBlogsLabel = await translate('Check out these blogs');
+  const checkOutTheseBlogsLabel = await translate('Check out these blogs');
+  checkOutTheseBlogsSelector = `aside ul[aria-label="${checkOutTheseBlogsLabel}"]`;
 
-  const tagPageLabel = await translate('Top %1$s blogs');
-  recommendedBlogsPattern = new RegExp(`^${tagPageLabel.replace('%1$s', '.*')}$`);
-
-  tagPageTitleSelector = await descendantSelector('desktopContainer', 'title');
+  const topBlogsLabel = await translate('Top %1$s blogs');
+  const [topBlogsPrefix, topBlogsSuffix] = topBlogsLabel.split('%1$s');
+  topBlogsSelector = `aside ul${topBlogsPrefix ? `[aria-label^="${topBlogsPrefix}"]` : ''}${topBlogsSuffix ? `[aria-label$="${topBlogsSuffix}"]` : ''}`;
 
   onBaseContainerMutated.addListener(checkForRecommendedBlogs);
   checkForRecommendedBlogs();


### PR DESCRIPTION
#### User-facing changes
Extends No Recommended's "Hide recommended blogs in the sidebar" setting to also hide the sidebar blogs widget on /tagged pages (XKit 7 currently does this with the Tweaks > Sidebar > Hide Recommended blogs option).

#### Technical explanation
Checking for the widget is a little different on tag pages than on the dashboard (the label includes the tag name so checking it requires a regex, and I also used a cssmap class selector to avoid something like `aside > div > div > div > div`). I was torn between trying to merge the two blocks in checkForRecommendedBlogs together vs. duplicating some code to try and keep the code more straightforward(?); went with the latter, but could definitely change that if needed.

Was also wondering about renaming recommendedBlogsLabel and recommendedBlogsPattern to something that indicates one is used on the dashboard and the other on tag pages, but I wanted to err on the side of not messing with existing variables (and also most of my ideas were excruciatingly long lol).

(In hindsight I'm wondering if I should have opened an issue to discuss this first - if so, sorry about that ^^ Definitely open to discussion here, and of course don't hesitate to close this if it's not needed atm~)