### PR TITLE
exposeTimelines util: handle >1 CSS class

### DIFF
--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -43,9 +43,10 @@ export const timelineObject = async function (postID) {
  */
 export const exposeTimelines = async () => inject(async () => {
   const cssMap = await window.tumblr.getCssMap();
-  const [timelineClass] = cssMap.timeline;
+  const timelineClasses = cssMap.timeline;
+  const selector = timelineClasses.map(className => `.${className}:not([data-timeline])`).join(',');
 
-  [...document.querySelectorAll(`.${timelineClass}:not([data-timeline])`)].forEach(timelineElement => {
+  [...document.querySelectorAll(selector)].forEach(timelineElement => {
     const reactKey = Object.keys(timelineElement).find(key => key.startsWith('__reactInternalInstance'));
     let fiber = timelineElement[reactKey];
 


### PR DESCRIPTION
#### User-facing changes
- Fixes seen posts, show originals, and the hide my posts tweak.

#### Technical explanation
`exposeTimelines`'s css selector used to be created from only the first entry in the CSS map for `timeline`. Tumblr was, at the time of this writing, using the second entry, so this selector would fail.

Normally this would be more obvious, as one would usually call `keyToClasses` and the plural function name is a good hint that there can be more than one class, but as this code is in an `inject()` call it cannot use other utility functions.

#### Issues this closes
resolves #210 
