### PR TITLE
Inject util: remove unnecessary use of .removeChild() 

### DIFF
--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -47,5 +47,5 @@ export const inject = (asyncFunc, args = []) => new Promise((resolve, reject) =>
 
   window.addEventListener('message', callback);
   document.documentElement.appendChild(script);
-  document.documentElement.removeChild(script);
+  script.remove();
 });


### PR DESCRIPTION
#### User-facing changes
- None

#### Technical explanation
Just as in https://github.com/AprilSylph/XKit-Rewritten/commit/68dc2e3d0ee66609c46307a485c5ec7b8e4147ed, this replaces `removeChild` with `remove`, this time in the `inject` function.

Interestingly, this appears to be a [significant*/insignificant**] performance benefit. It looks like, because `removeChild` returns the removed element, it compiles the script again.

*On a percentage basis!

**It's 2 milliseconds in a process that takes around 450ms and we already memoized it, soooo

![Screen Shot 2021-08-26 at 12 00 47 AM ia2](https://user-images.githubusercontent.com/8336245/130917320-4718d619-ee8c-48b8-955c-1a213290411b.png)

#### Issues this closes
- None
