### PR TITLE
Condensed Reblogs: remove css class on reblogs

### DIFF
--- a/src/scripts/condensed_reblogs.js
+++ b/src/scripts/condensed_reblogs.js
@@ -10,7 +10,6 @@ let trimAdditions;
 let trimRebloggedCommentary;
 
 const excludeClass = 'xkit-condensed-reblogs-done';
-const reblogClass = 'xkit-condensed-reblogs-reblog';
 const contextItemClass = 'xkit-condensed-reblogs-context';
 
 const expandButton = Object.assign(document.createElement('button'), { className: 'xkit-condensed-reblogs-expand' });
@@ -20,8 +19,6 @@ const processPosts = async function () {
   getPostElements({ excludeClass }).forEach(async postElement => {
     const reblogs = [...postElement.querySelectorAll(reblogSelector)];
     if (reblogs.length < 2) { return; }
-
-    reblogs.forEach(reblog => reblog.classList.add(reblogClass));
 
     const contributedContent = postElement.querySelector('[data-is-contributed-content]');
     const firstReblog = reblogs[0];
@@ -58,7 +55,6 @@ export const clean = async function () {
   $('.xkit-condensed-reblogs-expand').remove();
 
   $(`.${excludeClass}`).removeClass(excludeClass);
-  $(`.${reblogClass}`).removeClass(reblogClass);
   $(`.${contextItemClass}`).removeClass(contextItemClass);
 };
 


### PR DESCRIPTION
#### User-facing changes
- None

#### Technical explanation
I am not confident in this, but I ~~think this is an unnecessary `async`?~~ think this is leftover code from an older implementation?

Script seems to still work fine, though I had to scroll 60 posts down my dash to test it. Apparently I don't follow a lot of people who reblog things.

#### Issues this closes
 - None