### PR TITLE
Control buttons util: Cache remix icon JSON

### DIFF
--- a/src/util/control_buttons.js
+++ b/src/util/control_buttons.js
@@ -1,3 +1,5 @@
+let iconsPromise;
+
 /**
  * Fetch the SVG belonging to a specific RemixIcon.
  *
@@ -5,11 +7,12 @@
  * @returns {Promise<string|undefined>} The SVG path of the associated RemixIcon if it exists
  */
 export const getIconPath = async function (cssClass) {
-  const url = browser.runtime.getURL('/lib/remixicon_svg.json');
-  const file = await fetch(url);
-  const icons = await file.json();
+  if (!iconsPromise) {
+    const url = browser.runtime.getURL('/lib/remixicon_svg.json');
+    iconsPromise = fetch(url).then((file) => file.json());
+  }
 
-  return icons[cssClass];
+  return (await iconsPromise)[cssClass];
 };
 
 /**


### PR DESCRIPTION
#### User-facing changes
- None

#### Technical explanation
This caches the remix icon JSON so it doesn't have to be fetched and parsed again if multiple scripts use it. This is, practically speaking, fairly negligible, so it might not even be worth it.

I really don't like this syntax, but I can't think of a way to make it... not, you know, kind of a mess. 