### PR TITLE
Quick Reblog: Remember last selected blog

### DIFF
--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -33,12 +33,12 @@ let timeoutID;
 
 let popupPosition;
 let showBlogSelector;
+let rememberLastBlog;
 let showCommentInput;
 let quickTagsIntegration;
 let showTagsInput;
 let alreadyRebloggedEnabled;
 let alreadyRebloggedLimit;
-let rememberLastBlog;
 
 const storageKey = 'quick_reblog.alreadyRebloggedList';
 const excludeClass = 'xkit-quick-reblog-alreadyreblogged-done';
@@ -179,12 +179,12 @@ export const main = async function () {
   ({
     popupPosition,
     showBlogSelector,
+    rememberLastBlog,
     showCommentInput,
     quickTagsIntegration,
     showTagsInput,
     alreadyRebloggedEnabled,
-    alreadyRebloggedLimit,
-    rememberLastBlog
+    alreadyRebloggedLimit
   } = await getPreferences('quick_reblog'));
 
   popupElement.className = popupPosition;

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -38,6 +38,7 @@ let quickTagsIntegration;
 let showTagsInput;
 let alreadyRebloggedEnabled;
 let alreadyRebloggedLimit;
+let lastSelectedBlog;
 
 const storageKey = 'quick_reblog.alreadyRebloggedList';
 const excludeClass = 'xkit-quick-reblog-alreadyreblogged-done';
@@ -52,7 +53,7 @@ const showPopupOnHover = ({ currentTarget }) => {
 
   const thisPostID = currentTarget.closest('[data-id]').dataset.id;
   if (thisPostID !== lastPostID) {
-    blogSelector.value = blogSelector.options[0].value;
+    blogSelector.value = lastSelectedBlog;
     commentInput.value = '';
     tagsInput.value = '';
   }
@@ -192,6 +193,11 @@ export const main = async function () {
     option.textContent = name;
     blogSelector.appendChild(option);
   }
+
+  lastSelectedBlog = blogSelector.options[0].value;
+  blogSelector.addEventListener('change', () => {
+    lastSelectedBlog = blogSelector.value;
+  });
 
   blogSelector.hidden = !showBlogSelector;
   commentInput.hidden = !showCommentInput;

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -29,7 +29,6 @@ draftButton.dataset.state = 'draft';
 [blogSelector, commentInput, quickTagsList, tagsInput, actionButtons].forEach(element => popupElement.appendChild(element));
 
 let lastPostID;
-let lastBlogID;
 let timeoutID;
 
 let popupPosition;
@@ -54,7 +53,9 @@ const showPopupOnHover = ({ currentTarget }) => {
 
   const thisPostID = currentTarget.closest('[data-id]').dataset.id;
   if (thisPostID !== lastPostID) {
-    blogSelector.value = rememberLastBlog ? lastBlogID : blogSelector.options[0].value;
+    if (!rememberLastBlog) {
+      blogSelector.value = blogSelector.options[0].value;
+    }
     commentInput.value = '';
     tagsInput.value = '';
   }
@@ -211,13 +212,6 @@ export const main = async function () {
   if (alreadyRebloggedEnabled) {
     onNewPosts.addListener(processPosts);
     processPosts();
-  }
-
-  if (rememberLastBlog) {
-    lastBlogID = blogSelector.options[0].value;
-    blogSelector.addEventListener('change', () => {
-      lastBlogID = blogSelector.value;
-    });
   }
 };
 

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -29,6 +29,7 @@ draftButton.dataset.state = 'draft';
 [blogSelector, commentInput, quickTagsList, tagsInput, actionButtons].forEach(element => popupElement.appendChild(element));
 
 let lastPostID;
+let lastBlogID;
 let timeoutID;
 
 let popupPosition;
@@ -38,7 +39,7 @@ let quickTagsIntegration;
 let showTagsInput;
 let alreadyRebloggedEnabled;
 let alreadyRebloggedLimit;
-let lastSelectedBlog;
+let rememberLastBlog;
 
 const storageKey = 'quick_reblog.alreadyRebloggedList';
 const excludeClass = 'xkit-quick-reblog-alreadyreblogged-done';
@@ -53,7 +54,7 @@ const showPopupOnHover = ({ currentTarget }) => {
 
   const thisPostID = currentTarget.closest('[data-id]').dataset.id;
   if (thisPostID !== lastPostID) {
-    blogSelector.value = lastSelectedBlog;
+    blogSelector.value = rememberLastBlog ? lastBlogID : blogSelector.options[0].value;
     commentInput.value = '';
     tagsInput.value = '';
   }
@@ -181,7 +182,8 @@ export const main = async function () {
     quickTagsIntegration,
     showTagsInput,
     alreadyRebloggedEnabled,
-    alreadyRebloggedLimit
+    alreadyRebloggedLimit,
+    rememberLastBlog
   } = await getPreferences('quick_reblog'));
 
   popupElement.className = popupPosition;
@@ -193,11 +195,6 @@ export const main = async function () {
     option.textContent = name;
     blogSelector.appendChild(option);
   }
-
-  lastSelectedBlog = blogSelector.options[0].value;
-  blogSelector.addEventListener('change', () => {
-    lastSelectedBlog = blogSelector.value;
-  });
 
   blogSelector.hidden = !showBlogSelector;
   commentInput.hidden = !showCommentInput;
@@ -214,6 +211,13 @@ export const main = async function () {
   if (alreadyRebloggedEnabled) {
     onNewPosts.addListener(processPosts);
     processPosts();
+  }
+
+  if (rememberLastBlog) {
+    lastBlogID = blogSelector.options[0].value;
+    blogSelector.addEventListener('change', () => {
+      lastBlogID = blogSelector.value;
+    });
   }
 };
 

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -20,6 +20,11 @@
       "label": "Show the blog selector",
       "default": true
     },
+    "rememberLastBlog": {
+      "type": "checkbox",
+      "label": "Remember the last selected blog in the popup",
+      "default": false
+    },
     "showCommentInput": {
       "type": "checkbox",
       "label": "Show the comment field",


### PR DESCRIPTION
#### User-facing changes
- Remembers the last selected blog in the Quick Reblogs popup. The selection persists across navigation in the React page, but not across full page reloads - I admittedly haven't looked much into how saving user data in XKit works yet, but I'd be down to look into storing the selection more persistently if anyone thinks it'd be a good idea.
(Edit: the more I think about this, the more I think it probably should persist across reloads if possible, so I'll keep this as a draft until I've looked into that more - open to any feedback in the meantime though!)

#### Technical explanation
- Probably worth noting that the event listener on blogSelector sticks around when this option is disabled and could theoretically get attached multiple times if you toggle the setting a lot (doesn't affect behavior, though) - I doubt it's worth the extra lines of code to clean up properly, but it could be done.

#### Issues this closes
Resolves #220 