### PR TITLE
ESLint: Lint for incorrect import paths

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -7,7 +7,8 @@
   },
   "extends": [
     "semistandard",
-    "plugin:jsdoc/recommended"
+    "plugin:jsdoc/recommended",
+    "plugin:import/recommended"
   ],
   "parserOptions": {
     "ecmaVersion": 12,


### PR DESCRIPTION
#### User-facing changes
- None

#### Technical explanation
This enables eslint-plugin-import's recommended options. This includes import/no-unresolved, which will check for import paths that are mistyped.

Apparently the Standard JS ESLint config doesn't enable this rule, despite including the plugin. Not sure why, but I could imagine a reason.

#### Issues this closes
n/a