### PR TITLE
Test: Debounce mutations only to the next DOM render

### DIFF
--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -37,10 +37,10 @@ const debounce = (func, ms) => {
 };
 
 const debounceDOM = (func) => {
-  let timeoutID;
+  let requestID;
   return (...args) => {
-    cancelAnimationFrame(timeoutID);
-    timeoutID = requestAnimationFrame(() => func(...args));
+    cancelAnimationFrame(requestID);
+    requestID = requestAnimationFrame(() => func(...args));
   };
 };
 

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -36,10 +36,22 @@ const debounce = (func, ms) => {
   };
 };
 
-const runOnNewPosts = debounce(() => onNewPosts.trigger(), 10);
-const runOnPostsMutated = debounce(() => onPostsMutated.trigger(), 100);
-const runOnBaseContainerMutated = debounce(() => onBaseContainerMutated.trigger(), 100);
-const runOnGlassContainerMutated = debounce(() => onGlassContainerMutated.trigger(), 100);
+const debounceDOM = (func) => {
+  let queued = false;
+  return (...args) => {
+    if (queued) return;
+    queued = true;
+    requestAnimationFrame(() => {
+      queued = false;
+      func(...args);
+    });
+  };
+};
+
+const runOnNewPosts = debounceDOM(() => onNewPosts.trigger());
+const runOnPostsMutated = debounceDOM(() => onPostsMutated.trigger());
+const runOnBaseContainerMutated = debounceDOM(() => onBaseContainerMutated.trigger());
+const runOnGlassContainerMutated = debounceDOM(() => onGlassContainerMutated.trigger());
 
 const observer = new MutationObserver(mutations => {
   if (onNewPosts.listeners.length !== 0 || onPostsMutated.listeners.length !== 0) {

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -37,14 +37,10 @@ const debounce = (func, ms) => {
 };
 
 const debounceDOM = (func) => {
-  let queued = false;
+  let timeoutID;
   return (...args) => {
-    if (queued) return;
-    queued = true;
-    requestAnimationFrame(() => {
-      queued = false;
-      func(...args);
-    });
+    cancelAnimationFrame(timeoutID);
+    timeoutID = requestAnimationFrame(() => func(...args));
   };
 };
 


### PR DESCRIPTION
#### User-facing changes
- Potential for slightly reduced UI flickering

#### Technical explanation
Playing around with this. This implements a "debounce" function that runs all callbacks before the next DOM update/render, ensuring that (the synchronous parts of) the callbacks won't immediately cause a second rerender.

This means, for example, that with notificationblock enabled, the notification drawer immediately opens with blocked notifications missing, rather than appearing with all notifications visible and then popping the blocked ones away.

This has the potential to lag the UI, though, if callbacks put lots of expensive calculation in their synchronous portions. (Note that the `async` keyword doesn't make a function asynchronous automatically; only the portions of the function after an await statement are, and only if that await statement resolves after the microtask queue is empty!)

On the other hand, the "flickering" process is in itself a source of (a different kind of) lag, as rerendering the DOM twice is often more expensive than the code. So, it depends!

In theory this technique could be used on only some of the callbacks or something, etc.

#### Issues this closes
n/a