### PR TITLE
Refactor exposeTimelines and NotificationBlock's injected code

### DIFF
--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -16,7 +16,7 @@ let blockedPostTargetIDs;
 
 const buildStyles = () => blockedPostTargetIDs.map(id => `[data-target-post-id="${id}"]`).join(', ').concat(' { display: none; }');
 
-const notificationBlockInjected = async (notificationSelector) => {
+const unburyTargetPostIds = async (notificationSelector) => {
   [...document.querySelectorAll(notificationSelector)].forEach(async notificationElement => {
     const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactInternalInstance'));
     let fiber = notificationElement[reactKey];
@@ -41,7 +41,7 @@ const processNotifications = async () => {
     .join(', ');
 
   if (document.querySelectorAll(notificationSelector).length) {
-    inject(notificationBlockInjected, [notificationSelector]);
+    inject(unburyTargetPostIds, [notificationSelector]);
   }
 };
 

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -2,6 +2,7 @@ import { addStyle, removeStyle } from '../util/interface.js';
 import { registerMeatballItem, unregisterMeatballItem } from '../util/meatballs.js';
 import { onBaseContainerMutated } from '../util/mutations.js';
 import { inject } from '../util/inject.js';
+import { keyToClasses } from '../util/css_map.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 
 const storageKey = 'notificationblock.blockedPostTargetIDs';
@@ -15,10 +16,7 @@ let blockedPostTargetIDs;
 
 const buildStyles = () => blockedPostTargetIDs.map(id => `[data-target-post-id="${id}"]`).join(', ').concat(' { display: none; }');
 
-const processNotifications = () => inject(async () => {
-  const cssMap = await window.tumblr.getCssMap();
-  const notificationSelector = cssMap.notification.map(className => `.${className}:not([data-target-post-id])`).join(', ');
-
+const notificationBlockInjected = async (notificationSelector) => {
   [...document.querySelectorAll(notificationSelector)].forEach(async notificationElement => {
     const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactInternalInstance'));
     let fiber = notificationElement[reactKey];
@@ -34,7 +32,18 @@ const processNotifications = () => inject(async () => {
       }
     }
   });
-});
+};
+
+const processNotifications = async () => {
+  const notificationClasses = await keyToClasses('notification');
+  const notificationSelector = notificationClasses
+    .map((className) => `.${className}:not([data-target-post-id])`)
+    .join(', ');
+
+  if (document.querySelectorAll(notificationSelector).length) {
+    inject(notificationBlockInjected, [notificationSelector]);
+  }
+};
 
 const onButtonClicked = async function ({ currentTarget }) {
   const postElement = currentTarget.closest('[data-id]');

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -32,7 +32,7 @@ export const timelineObject = async function (postID) {
   return cache[postID];
 };
 
-const exposeTimelinesInjected = async (selector) => {
+const unburyGivenPaths = async (selector) => {
   [...document.querySelectorAll(selector)].forEach(timelineElement => {
     const reactKey = Object.keys(timelineElement).find(key => key.startsWith('__reactInternalInstance'));
     let fiber = timelineElement[reactKey];
@@ -59,7 +59,7 @@ export const exposeTimelines = async () => {
   const selector = timelineClasses.map(className => `.${className}:not([data-timeline])`).join(',');
 
   if (document.querySelectorAll(selector).length) {
-    inject(exposeTimelinesInjected, [selector]);
+    inject(unburyGivenPaths, [selector]);
   }
 };
 


### PR DESCRIPTION
#### User-facing changes
- None (slight potential for reducing flicker along with other changes; insignificant performance gain)

#### Technical explanation
This adjusts a pattern that gets used twice in the codebase: once in the exposeTimelines util, and once in NotificationBlock's custom inject callback.

Right now, both callbacks always inject a function that get the CSS map and use a querySelectorAll to see if they actually have to do anything. Most of the time, though, these functions should do nothing (new timelines are infrequent; most of the time mutations are not new notification drawer elements).

This:

- Generates the CSS selector outside of the inject call. (This isn't a performance gain - tumblr.getCssMap is ~free - but it's nice, and an excuse to use the previously-unused ability to give an injected function arguments.)

- Skips the inject() if the selector doesn't match anything. Now that we improved inject callback performance, this only saves like a millisecond, which is irrelevant. It does, though, make exposeTimelines potentially synchronous if there's nothing for it to do.

  Sadly, this currently removes on-load flickering from exactly zero extensions: the Hide My Posts tweak and Show Originals use `timelineObjectMemoized`, so they're still async on fresh posts, and Seen Posts queries browser storage, which if removed would bring back potential race condition bugs with having XKit Rewritten in multiple tabs.

- Names the injected functions, I suppose, so you get a nicer stack trace in the off chance one breaks. (Not sure what to name these, actually - you tend to be much better at that than I.)

#### Issues this closes
 - n/a