### PR TITLE
add .prettierrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ release-notes.md
 **.less
 .vscode/
 .DS_Store
+.prettierrc


### PR DESCRIPTION
#### User-facing changes
- None

#### Technical explanation

This adds .prettierrc to the .gitignore, since we don't use prettier-on-save or anything, but I have a config for quick formats of new code.

Alternately I could just commit it:
```json
{
  "singleQuote": true,
  "arrowParens": "avoid",
  "printWidth": 95,
  "trailingComma": "none"
}
```
Alternately I could just put it one directory level higher than the repository, so this is 100% optional.

#### Issues this closes
 - n/a