### PR TITLE
No Recommended: CSS optimization

### DIFF
--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -4,7 +4,7 @@ import { onNewPosts } from '../../util/mutations.js';
 
 const hiddenClass = 'xkit-no-recommended-blog-carousels-hidden';
 
-const css = `.${hiddenClass} > div { display: none; }`;
+const css = `.${hiddenClass} > div { visibility: hidden; position: absolute }`;
 
 let blogCarouselSelector;
 let listTimelineObjectSelector;

--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -4,7 +4,10 @@ import { onNewPosts } from '../../util/mutations.js';
 
 const hiddenClass = 'xkit-no-recommended-blog-carousels-hidden';
 
-const css = `.${hiddenClass} > div { visibility: hidden; position: absolute }`;
+const css = `
+  .${hiddenClass} { position: relative; }
+  .${hiddenClass} > div { visibility: hidden; position: absolute; max-width: 100%; }
+`;
 
 let blogCarouselSelector;
 let listTimelineObjectSelector;


### PR DESCRIPTION
#### User-facing changes
- Dashboard should generally perform better if the "hide blog carousels" option is enabled

#### Technical explanation

This slightly changes the way No Recommended's option to hide blog carousels works. The current CSS causes Tumblr's code to get a bit confused: the recommended blogs carousel has infinite scrolling, and certain CSS manipulations confuse its "distance to the right edge" calculation into loading new posts in the background constantly. This fixes this behavior, which reduces the total amount of content loaded on the dash by about half.

![image](https://user-images.githubusercontent.com/8336245/134292497-e244f809-8934-4cda-8577-f8c12e827453.png)
(image shows results of loading page with fix, then reverting fix and waiting for about a minute)

#### Issues this closes
- n/a
