### PR TITLE
Popup: Autofocus the search box

### DIFF
--- a/src/browser_action/popup.html
+++ b/src/browser_action/popup.html
@@ -23,7 +23,7 @@
       </nav>
       <section id="configuration" class="open">
         <div class="finder">
-          <input id="search" type="text" placeholder="Search" autocomplete="off" spellcheck="false">
+          <input id="search" type="text" placeholder="Search" autocomplete="off" spellcheck="false" autofocus>
           <label for="filter">Filter by</label>
           <select id="filter">
             <option value="all" selected>All</option>


### PR DESCRIPTION
To be clear, there are definitely ups and downs to this proposal!

#### User-facing changes

Focuses the search box when the extension's popup is opened. The user can thus click the menu button and immediately begin typing the name of the script one desires to toggle/change a preference in. This is really convenient when you get used to it.

The downside of this is that the up and down arrows' previous functionality of scrolling the popup is removed, so users who don't use the trackpad or mousewheel to scroll must use the scroll bar. I wish we had analytics data for how much people scroll with up/down, because if I had to guess I'd assume it's very few, but I also wouldn't be at all surprised if it's a significant number. (Also I rather dislike the aesthetics.)

Note that the escape key cannot be used to lose focus on the search box, as it just closes the popup.

I think this is okay for keyboard accessibility, as tab and shift tab work, though maybe it's a bit confusing to have to go backwards to access the top tabs.

I think this is probably bad for screen reader accessibility, as you'd be jumped past the top tabs. Not sure if there is a way to improve that.

#### Technical explanation

Uses the HTML `autofocus` property.

A more hidden and power-user-y way to do this would be not to focus the search box, but add a Javascript listener that focuses the box the first time you press a letter key without any focused element in the configuration tab (and enters that letter into the search box), which would leave arrow key navigation and the clean look of the unfocused popup intact, but that's getting a bit ridiculous.

#### Issues this closes
Discussion: #112