### PR TITLE
Show Originals: Ensure user can scroll

### DIFF
--- a/src/scripts/show_originals.css
+++ b/src/scripts/show_originals.css
@@ -1,3 +1,7 @@
 .xkit-show-originals-hidden article {
   display: none;
 }
+
+.xkit-show-originals-lengthened {
+  min-height: 100vh;
+}

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -2,9 +2,27 @@ import { getPostElements } from '../util/interface.js';
 import { timelineObjectMemoized, exposeTimelines } from '../util/react_props.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
+import { keyToCss } from '../util/css_map.js';
 
 const excludeClass = 'xkit-show-originals-done';
 const hiddenClass = 'xkit-show-originals-hidden';
+const lengthenedClass = 'xkit-show-originals-lengthened';
+
+const dashboardTimeline = '/v2/timeline/dashboard';
+
+const lengthenTimelines = async () => {
+  const timeline =
+    document.querySelector(`[data-timeline="${dashboardTimeline}"]:not(.${excludeClass})`);
+
+  if (timeline) {
+    timeline.classList.add(excludeClass);
+    const paginationCss = await keyToCss('manualPaginatorButtons');
+
+    if (!timeline.querySelector(paginationCss)) {
+      timeline.classList.add(lengthenedClass);
+    }
+  }
+};
 
 let showOwnReblogs;
 let showReblogsWithContributedContent;
@@ -14,6 +32,7 @@ const processPosts = async function () {
   const whitelist = whitelistedUsernames.split(',').map(username => username.trim());
 
   await exposeTimelines();
+  lengthenTimelines();
 
   getPostElements({ excludeClass, timeline: /\/v2\/timeline\/dashboard/, includeFiltered: true }).forEach(async postElement => {
     const { rebloggedRootId, canEdit, content, blogName } = await timelineObjectMemoized(postElement.dataset.id);

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -9,6 +9,7 @@ const hiddenClass = 'xkit-show-originals-hidden';
 const lengthenedClass = 'xkit-show-originals-lengthened';
 
 const dashboardTimeline = '/v2/timeline/dashboard';
+const dashboardTimelineRegExp = new RegExp(dashboardTimeline);
 
 const lengthenTimelines = async () => {
   const timeline =
@@ -34,7 +35,7 @@ const processPosts = async function () {
   await exposeTimelines();
   lengthenTimelines();
 
-  getPostElements({ excludeClass, timeline: /\/v2\/timeline\/dashboard/, includeFiltered: true }).forEach(async postElement => {
+  getPostElements({ excludeClass, timeline: dashboardTimelineRegExp, includeFiltered: true }).forEach(async postElement => {
     const { rebloggedRootId, canEdit, content, blogName } = await timelineObjectMemoized(postElement.dataset.id);
 
     if (!rebloggedRootId) { return; }


### PR DESCRIPTION
#### User-facing changes

In rare cases with large displays, Show Originals could result in a user's timeline rendering as short enough vertically that it fits in the browser viewport, resulting in nowhere to scroll to trigger infinite scrolling. This ensures this does not happen.

#### Technical explanation

The timeline is set to a minimum height of 100vh, or 100% of the browser viewport height, if it does not contain pagination controls. It is not right at the top of the page, so this always results in the page height being at least a bit taller than the viewport.

Duplicating `/v2/timeline/dashboard` as both string and regex doesn't feel very DRY. `getPostElements` could be overloaded to take a string for its `timeline` prop but I remember you preferring to avoid `typeof`.

#### Issues this closes
None, but discussed in discussion #107