### PR TITLE
add pageModifications engine

### DIFF
--- a/src/scripts/timeformat.js
+++ b/src/scripts/timeformat.js
@@ -1,5 +1,5 @@
 import moment from '../lib/moment.js';
-import { onBaseContainerMutated } from '../util/mutations.js';
+import { pageModifications } from '../util/mutations.js';
 import { getPreferences } from '../util/preferences.js';
 
 let format;
@@ -31,8 +31,8 @@ const constructRelativeTimeString = function (unixTime) {
   return relativeTimeFormat.format(-0, 'second');
 };
 
-const formatTimeElements = function () {
-  [...document.querySelectorAll('time[datetime]:not([data-formatted-time]')].forEach(timeElement => {
+const formatTimeElements = function (timeElements) {
+  timeElements.forEach(timeElement => {
     const momentDate = moment(timeElement.dateTime, moment.ISO_8601);
     timeElement.dataset.formattedTime = momentDate.format(format);
     if (displayRelative) timeElement.dataset.formattedTime += `\u2002\u00B7\u2002${constructRelativeTimeString(momentDate.unix())}`;
@@ -41,12 +41,12 @@ const formatTimeElements = function () {
 
 export const main = async function () {
   ({ format, displayRelative } = await getPreferences('timeformat'));
-  onBaseContainerMutated.addListener(formatTimeElements);
+  pageModifications.register('time[datetime]:not([data-formatted-time]', formatTimeElements);
   formatTimeElements();
 };
 
 export const clean = async function () {
-  onBaseContainerMutated.removeListener(formatTimeElements);
+  pageModifications.unregister(formatTimeElements);
   $('[data-formatted-time]').removeAttr('data-formatted-time');
 };
 

--- a/src/scripts/timeformat.js
+++ b/src/scripts/timeformat.js
@@ -41,7 +41,7 @@ const formatTimeElements = function (timeElements) {
 
 export const main = async function () {
   ({ format, displayRelative } = await getPreferences('timeformat'));
-  pageModifications.register('time[datetime]:not([data-formatted-time]', formatTimeElements);
+  pageModifications.register('time[datetime]', formatTimeElements);
   formatTimeElements();
 };
 

--- a/src/scripts/timeformat.js
+++ b/src/scripts/timeformat.js
@@ -42,7 +42,6 @@ const formatTimeElements = function (timeElements) {
 export const main = async function () {
   ({ format, displayRelative } = await getPreferences('timeformat'));
   pageModifications.register('time[datetime]', formatTimeElements);
-  formatTimeElements();
 };
 
 export const clean = async function () {

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -47,6 +47,8 @@ const onBeforeRepaint = () => {
     .filter(addedNode => addedNode instanceof Element);
   mutationsPool = [];
 
+  if (addedNodes.length === 0) return;
+
   for (const [modifierFunction, selector] of pageModifications.listeners) {
     const matchingElements = [
       ...addedNodes.filter(addedNode => addedNode.matches(selector)),

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -28,14 +28,14 @@ let repaintQueued = false;
 
 export const pageModifications = Object.freeze({
   listeners: new Map(),
-  register (selector, callback) {
-    if (this.listeners.has(callback) === false) {
-      this.listeners.set(callback, selector);
-      callback(document.querySelectorAll(selector));
+  register (selector, modifierFunction) {
+    if (this.listeners.has(modifierFunction) === false) {
+      this.listeners.set(modifierFunction, selector);
+      modifierFunction([...document.querySelectorAll(selector)]);
     }
   },
-  unregister (callback) {
-    this.listeners.delete(callback);
+  unregister (modifierFunction) {
+    this.listeners.delete(modifierFunction);
   }
 });
 
@@ -47,13 +47,13 @@ const onBeforeRepaint = () => {
     .filter(addedNode => addedNode instanceof Element);
   mutationsPool = [];
 
-  for (const [callback, selector] of pageModifications.listeners) {
+  for (const [modifierFunction, selector] of pageModifications.listeners) {
     const matchingElements = [
       ...addedNodes.filter(addedNode => addedNode.matches(selector)),
       ...addedNodes.flatMap(addedNode => [...addedNode.querySelectorAll(selector)])
     ];
     if (matchingElements.length !== 0) {
-      callback(matchingElements);
+      modifierFunction(matchingElements);
     }
   }
 };


### PR DESCRIPTION
#### User-facing changes
- TimeFormat no longer waits for the page to stop mutating before formatting Tumblr's timestamps. This eliminates the brief time where Tumblr's unformatted timestamps are visible, but may make post rendering technically slower. Overall, this is visually interpretable as a performance improvement.

#### Technical explanation
Adds a new export, `pageModifications`, to `util/mutations.js`. This new object exposes two functions:
- `register(selector, modifierFunction)`: Adds the callback to the listener list and associates the selector with it, then runs the callback, passing all matching elements on the page as an Array argument.
- `unregister(modifierFunction)`: Removes the callback from the listener list.

Once a modifier function is registered, the ever-active MutationObserver will compile an array of every mutation between frames, and queue `onBeforeRepaint()` for before the next frame using [`Window.requestAnimationFrame()`](https://developer.mozilla.org/en-US/docs/Web/API/window/requestAnimationFrame) (if it's not queued already). This function creates a flat array of every added node since the last frame, and then passes those added nodes (using `Array.prototype.filter()`) and their descendants which match the associated selector (using `Element.querySelectorAll()`) to the modifier functions.

I am aware of the mild performance drawback of `Element.querySelectorAll()`, but right now the code merely matches the concept: to run a function on every matching element as they're added. It also eliminates the need for building exclusions into selectors for some functions (where running the modification again, i.e. from the addon being reloaded in Firefox, has no effect on the user experience).

I don't know if this will end up replacing `onBaseContainerMutated` or any other of the current exports, but for now, I think this is a good way for features to opt into between-frame code execution.

#### Issues this closes
- closes #275