### PR TITLE
Experiment: Synchronous/0-QSA timelineObjectMemoized

### DIFF
--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -1,6 +1,6 @@
 const baseContainerNode = document.getElementById('base-container');
 const dialogSelector = '[role="dialog"][aria-modal="true"]';
-const postSelector = '[tabindex="-1"][data-id]';
+export const postSelector = '[tabindex="-1"][data-id]';
 
 const ListenerTracker = function () {
   this.listeners = [];


### PR DESCRIPTION
#### User-facing changes
- Even less "flickering" effect/performance impact when loading new posts (besides initial page load).

#### Technical explanation

Here's the basic idea:

Reading react props isn't, in itself, asynchronous. The only thing making timelineObject asynchronous (and this requiring a double browser repaint each time a script that needs timelineObject data wants to make a DOM mutation) is that the communication between the XKit extension context and the Tumblr page context is asynchronous. The only way to communicate synchronously between these two contexts that I know of is via DOM mutation.

Thus, this test injects a constantly running script that communicates timelineObject data synchronously via DOM mutation. Oh, and because it's a constantly running script, it uses the #407 method to avoid page-wide QSA calls, so synchronous/asynchronous aside, it's a decent performance gain.

I had three ideas for this:
- Add the timelineObject data as a data attribute on the post itself. Oh, hey, we're back in pre-redpop. Drawback: devtools element view becomes basically unusable.
- Add a dummy DOM element, put a mutationObserver on it from both sides, and communicate messages bidirectionally by writing/reading it instead of using MessageChannel. I think this could work, but it's sort of ridiculous.
- Screw it; add a dummy DOM element and just write all of the timelineObject data to it. XKit can just read the relevant data attribute whenever it needs it. Drawback: must elegantly handle race conditions or failure of the injected script on XKit's side by waiting/re-injecting it/etc. ~~_(I have not observed this being necessary, yet, actually, but still)_~~

This implements the third (without the race/failure handling logic, at the moment, and only for timelineObjectMemoized). Non-memoized timelineObject is... probably doable, though synchronously informing the page script it needs to re-query the props seems nontrivial (more like option 2).

Anyways, this all might not be worthwhile. Sure makes Show Originals feel darn fast, though, when combined with patching out the callback debounce!