### PR TITLE
Notifications framework: tiny optimization

### DIFF
--- a/src/util/notifications.js
+++ b/src/util/notifications.js
@@ -1,4 +1,3 @@
-import { pageModifications } from './mutations.js';
 import { keyToCss } from './css_map.js';
 
 const toastContainer = Object.assign(document.createElement('div'), { id: 'xkit-toasts' });
@@ -21,14 +20,13 @@ const addToastContainerToPage = async () => {
   }
 };
 
-pageModifications.register('*', addToastContainerToPage);
-
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 /**
  * @param {string} textContent - Text to display to the user as a notification
  */
 export const notify = async textContent => {
+  await addToastContainerToPage();
   const toast = Object.assign(document.createElement('div'), { textContent, className: 'visible' });
   toastContainer.append(toast);
   await sleep(4000);


### PR DESCRIPTION
I don't know that I would actually make this change! It is a bit silly, but it works.

#### User-facing changes
Plus: Completely insignificant performance gain (<1ms) when Tumblr does any DOM mutations.
Minus: Changing to/from mobile view/peepr while a notification popup is active does not transfer the notification popup to the new UI. Anyone who finds the toast container with dev tools when it's not in the right place will be confused.

#### Technical explanation
This defers moving the toast container to the right place until it actually gets used to display a notification.

#### Issues this closes
n/a