### PR TITLE
Shorten Posts: add 4x viewport height multiplier option

### DIFF
--- a/src/scripts/shorten_posts.json
+++ b/src/scripts/shorten_posts.json
@@ -21,7 +21,8 @@
         { "value": "0.5", "label": "0.5x viewport height" },
         { "value": "1", "label": "1x viewport height" },
         { "value": "1.5", "label": "1.5x viewport height" },
-        { "value": "2", "label": "2x viewport height" }
+        { "value": "2", "label": "2x viewport height" },
+        { "value": "4", "label": "4x viewport height" }
       ],
       "default": "1"
     }


### PR DESCRIPTION
#### User-facing changes
- Adds larger 4x viewport height multiplier to the Shorten Posts script options.

#### Technical explanation
For me, the viewport height options for Shorten Posts are too small for my liking. I mostly want to limit posts with annoyingly lengthy discussions or any of the infamously long posts floating around, but the current highest 2x option ends up limiting like, most GIF-set posts for example. 4x seems to cover that use, after testing a bit.

I was originally going to add an input field for a custom multiplier instead, but I couldn't think of a concise way to explain how to use it. I think that may be why you went with a dropdown here?

#### Issues this closes
None.