### PR TITLE
Quick Reblog: Add default blog text preference

### DIFF
--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -249,10 +249,12 @@ export const main = async function () {
   if (defaultBlogs.length) {
     for (const defaultBlog of defaultBlogs.split(/[\s,]+/).filter(Boolean)) {
       activeDefaultBlog = userBlogs.find(({ name }) => name.toUpperCase() === defaultBlog.toUpperCase())?.uuid;
-      if (activeDefaultBlog) break;
+      if (activeDefaultBlog) {
+        blogSelector.value = activeDefaultBlog;
+        break;
+      }
     }
   }
-  if (activeDefaultBlog) blogSelector.value = activeDefaultBlog;
 
   blogSelector.hidden = !showBlogSelector;
   commentInput.hidden = !showCommentInput;

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -39,6 +39,7 @@ let suggestableTags;
 
 let popupPosition;
 let showBlogSelector;
+let defaultBlogs;
 let rememberLastBlog;
 let showCommentInput;
 let quickTagsIntegration;
@@ -47,6 +48,8 @@ let showTagSuggestions;
 let queueTag;
 let alreadyRebloggedEnabled;
 let alreadyRebloggedLimit;
+
+let activeDefaultBlog;
 
 const storageKey = 'quick_reblog.alreadyRebloggedList';
 const excludeClass = 'xkit-quick-reblog-alreadyreblogged-done';
@@ -91,7 +94,7 @@ const showPopupOnHover = ({ currentTarget }) => {
   const thisPostID = currentTarget.closest('[data-id]').dataset.id;
   if (thisPostID !== lastPostID) {
     if (!rememberLastBlog) {
-      blogSelector.value = blogSelector.options[0].value;
+      blogSelector.value = activeDefaultBlog || blogSelector.options[0].value;
     }
     commentInput.value = '';
     tagsInput.value = '';
@@ -222,6 +225,7 @@ export const main = async function () {
   ({
     popupPosition,
     showBlogSelector,
+    defaultBlogs,
     rememberLastBlog,
     showCommentInput,
     quickTagsIntegration,
@@ -241,6 +245,14 @@ export const main = async function () {
     option.textContent = name;
     blogSelector.appendChild(option);
   }
+
+  if (defaultBlogs.length) {
+    for (const defaultBlog of defaultBlogs.split(/[\s,]+/).filter(Boolean)) {
+      activeDefaultBlog = userBlogs.find(({ name }) => name.toUpperCase() === defaultBlog.toUpperCase())?.uuid;
+      if (activeDefaultBlog) break;
+    }
+  }
+  if (activeDefaultBlog) blogSelector.value = activeDefaultBlog;
 
   blogSelector.hidden = !showBlogSelector;
   commentInput.hidden = !showCommentInput;
@@ -266,6 +278,8 @@ export const clean = async function () {
   popupElement.remove();
 
   blogSelector.textContent = '';
+
+  activeDefaultBlog = undefined;
 
   browser.storage.onChanged.removeListener(updateQuickTags);
 

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -21,6 +21,11 @@
       "label": "Show the blog selector",
       "default": true
     },
+    "defaultBlogs": {
+      "type": "text",
+      "label": "Default blog(s)",
+      "default": ""
+    },
     "rememberLastBlog": {
       "type": "checkbox",
       "label": "Remember the last selected blog in the popup",


### PR DESCRIPTION
I recognize the desire not to silently store information about the user's account within extension storage, but I also think having to remember to toggle Quick Reblog's blog selection every time you open a new tab is quite inconvenient for people who do not use their main blogs. Here is a sort of "please all and you will please none" solution, in which the user explicitly opts in to the extension storing their data by manually typing in their preferred default blog... or blogs, if they have multiple accounts.

#### User-facing changes
- Adds a textbox preference to Quick Reblog allowing the default-selected blog to be customized.

#### Technical explanation
The script searches the user's blog list for a matching preference entry in main(), doing nothing if no entry matches.

I looked at `Intl.Collator.prototype.compare` as a fancier version of `a.toUpperCase() === b.toUpperCase()` with better internationalization/special character apparently, though because Tumblr usernames are URL-safe, I think it makes no difference whatsoever. Could be nice to know about for some future use case though,

#### Issues this closes
Addresses core request of #220, #317, #412. 