### PR TITLE
Quick Reblog: Fix console error on drafts page

### DIFF
--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -189,7 +189,7 @@ const processPosts = async function () {
 
     if (alreadyRebloggedList.includes(rootID)) {
       const reblogLink = postElement.querySelector('footer a[href*="/reblog/"]');
-      if (!reblogLink) { return; }
+      if (!reblogLink) { continue; }
       const buttonDiv = reblogLink.parentNode;
       makeButtonReblogged({ buttonDiv, state: 'published' });
     }

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -189,6 +189,7 @@ const processPosts = async function () {
 
     if (alreadyRebloggedList.includes(rootID)) {
       const reblogLink = postElement.querySelector('footer a[href*="/reblog/"]');
+      if (!reblogLink) { return; }
       const buttonDiv = reblogLink.parentNode;
       makeButtonReblogged({ buttonDiv, state: 'published' });
     }


### PR DESCRIPTION
#### User-facing changes
- n/a

#### Technical explanation
This fixes a console error when alreadyReblogged tries to process the reblog link on posts that don't have one, like when viewing the drafts page.

#### Issues this closes
n/a
