### PR TITLE
Scroll to Bottom: Query performance optimization

### DIFF
--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -10,8 +10,9 @@ let active = false;
 
 const scrollToBottom = () => {
   window.scrollTo({ top: document.documentElement.scrollHeight });
-  if ([...document.querySelectorAll(knightRiderLoaderSelector)]
-    .some(element => element.matches(loaderSelector)) === false) {
+  const knightRiderLoaders = [...document.querySelectorAll(knightRiderLoaderSelector)];
+  const shouldKeepScrolling = knightRiderLoaders.some(element => element.matches(loaderSelector));
+  if (!shouldKeepScrolling) {
     stopScrolling();
   }
 };

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -1,15 +1,17 @@
-import { keyToClasses, descendantSelector } from '../util/css_map.js';
+import { keyToClasses, keyToCss, descendantSelector } from '../util/css_map.js';
 import { translate } from '../util/language_data.js';
 import { pageModifications } from '../util/mutations.js';
 
 let knightRiderLoaderSelector;
+let loaderSelector;
 let scrollToBottomButton;
 let scrollToBottomIcon;
 let active = false;
 
 const scrollToBottom = () => {
   window.scrollTo({ top: document.documentElement.scrollHeight });
-  if (document.querySelector(knightRiderLoaderSelector) === null) {
+  if ([...document.querySelectorAll(knightRiderLoaderSelector)]
+    .some(element => element.matches(loaderSelector)) === false) {
     stopScrolling();
   }
 };
@@ -61,7 +63,8 @@ const addButtonToPage = async function ([scrollToTopButton]) {
 };
 
 export const main = async function () {
-  knightRiderLoaderSelector = await descendantSelector('main', 'loader', 'knightRiderLoader');
+  knightRiderLoaderSelector = await keyToCss('knightRiderLoader');
+  loaderSelector = await descendantSelector('main', 'loader', 'knightRiderLoader');
 
   const scrollToTopLabel = await translate('Scroll to top');
   pageModifications.register(`button[aria-label="${scrollToTopLabel}"]`, addButtonToPage);


### PR DESCRIPTION
#### User-facing changes
- Scroll to Bottom is 20-25% faster.

#### Technical explanation
- Scroll to Bottom's knightRiderLoader check is 100-150x faster.

Sounds cooler that way, but meh. Amdahl's law strikes again.

(`knightRiderLoader` is currently one css class; `descendantSelector('main', 'loader', 'knightRiderLoader')` is currently about 250 rules, so even though CSS selectors are evaluated right to left there's a lot of duplicate work going on if the full selector is fed to QSA. Certainly not the most elegant looking PR diff, I have to admit, but I didn't think of a way to do this in fewer lines.)

#### Issues this closes
n/a