### PR TITLE
Experiment: add array override to descendentSelector

### DIFF
--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -48,18 +48,3 @@ export const descendantSelector = async function (...keys) {
     .map(selectors => selectors.join(' '))
     .join(', ');
 };
-
-// tests
-(async () => {
-  const test1 = await descendantSelector('post', 'footer', 'controls');
-  console.log(test1);
-  console.log([...document.querySelectorAll(test1)]);
-  const test2 = await descendantSelector(['article'], ['footer'], 'controls');
-  console.log(test2);
-  console.log([...document.querySelectorAll(test2)]);
-
-  const specificTimelineClasses = (await keyToClasses('timeline'))
-    .map(className => `.${className}:not[data-timeline="whatever"]`);
-  const test3 = await descendantSelector(specificTimelineClasses, 'listTimelineObject');
-  console.log(test3);
-})();

--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -36,8 +36,12 @@ export const descendantSelector = async function (...keys) {
   const sets = [];
 
   for (const key of keys) {
-    const set = await keyToClasses(key);
-    sets.push(set.map(className => `.${className}`));
+    if (Array.isArray(key)) {
+      sets.push(key);
+    } else {
+      const set = await keyToClasses(key);
+      sets.push(set.map(className => `.${className}`));
+    }
   }
 
   return cartesian(...sets)

--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -48,3 +48,18 @@ export const descendantSelector = async function (...keys) {
     .map(selectors => selectors.join(' '))
     .join(', ');
 };
+
+// tests
+(async () => {
+  const test1 = await descendantSelector('post', 'footer', 'controls');
+  console.log(test1);
+  console.log([...document.querySelectorAll(test1)]);
+  const test2 = await descendantSelector(['article'], ['footer'], 'controls');
+  console.log(test2);
+  console.log([...document.querySelectorAll(test2)]);
+
+  const specificTimelineClasses = (await keyToClasses('timeline'))
+    .map(className => `.${className}:not[data-timeline="whatever"]`);
+  const test3 = await descendantSelector(specificTimelineClasses, 'listTimelineObject');
+  console.log(test3);
+})();


### PR DESCRIPTION
- [ ] update jsdoc

#### User-facing changes
- none

#### Technical explanation
This adds functionality to the descendantSelector utility function allowing developers to pass arrays of strings, which will not be translated. This is primarily to facilitate a concise way to use element name selectors in descendantSelector i.e. `await descendantSelector(['article'], ['footer'], 'controls')`.

(It also has the side benefit of allowing descendantSelector to be used to compose intermediate-complexity selector arrays with plain translated selectors in a somewhat more readable way than directly invoking `cartesian`, if that ever becomes necessary. This complexity is obviously to be avoided where possible, of course.)

I also thought of and played with e.g. `await descendantSelector('element:article', 'element:footer', 'controls')` / `await descendantSelector('untranslated:article', 'untranslated:footer', 'controls')`, which is arguably easier to comprehend, though it's less clean to type and doesn't allow for the bonus composition behavior.

_Yes, it's a slippery slope to creating 15 utility functions for CSS selector composition that wind up being substantially more complex than just composing strings manually or giving up and writing translated classes into the dom directly with a mutationObserver, but this by itself feels okay to me._ 

#### Issues this closes
n/a