### PR TITLE
Disable Gifs: Fix console error

### DIFF
--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -6,6 +6,7 @@ const pauseGif = function (gifElement) {
   const image = new Image();
   image.src = gifElement.currentSrc;
   image.onload = () => {
+    if (gifElement.parentNode === null) { return; }
     const canvas = document.createElement('canvas');
     canvas.width = image.naturalWidth;
     canvas.height = image.naturalHeight;


### PR DESCRIPTION
#### User-facing changes
- n/a

#### Technical explanation
This fixes a console error when Disable Gifs' asynchronous `onload` callback fires after the gifElement has been unmounted from the page by Tumblr's placeholder code.

There appears to be no functionality problem because of this or functionality change due to the fix, that I can tell; `processGifs` gets fired again when the image is re-mounted.

#### Issues this closes
n/a