### PR TITLE
Add tweak to hide note count type indicators

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -13,6 +13,11 @@
       "label": "Attempt to revert the post footer redesign",
       "default": false
     },
+    "hide_note_count_types": {
+      "type": "checkbox",
+      "label": "Hide the type indicators next to the note count",
+      "default": false
+    },
     "slim_filtered_screens": {
       "type": "checkbox",
       "label": "Use a slim layout for filtered posts",

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -15,7 +15,7 @@
     },
     "hide_note_count_types": {
       "type": "checkbox",
-      "label": "Hide the type indicators next to the note count",
+      "label": "Hide the note type badges next to the note count",
       "default": false
     },
     "slim_filtered_screens": {

--- a/src/scripts/tweaks/hide_note_count_types.js
+++ b/src/scripts/tweaks/hide_note_count_types.js
@@ -4,5 +4,5 @@ import { buildStyle } from '../../util/interface.js';
 const styleElement = buildStyle();
 keyToCss('noteCountTypes').then(selector => { styleElement.textContent = `${selector} { display: none !important; }`; });
 
-export const main = async ()  => document.head.append(styleElement);
+export const main = async () => document.head.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/hide_note_count_types.js
+++ b/src/scripts/tweaks/hide_note_count_types.js
@@ -1,0 +1,14 @@
+import { keyToCss } from '../../util/css_map.js';
+import { buildStyle } from '../../util/interface.js';
+
+const styleElement = buildStyle();
+
+export const main = async function () {
+  const selector = await keyToCss('noteCountTypes');
+  styleElement.textContent = `${selector} { display: none !important; }`;
+  document.head.append(styleElement);
+};
+
+export const clean = async function () {
+  styleElement.remove();
+};

--- a/src/scripts/tweaks/hide_note_count_types.js
+++ b/src/scripts/tweaks/hide_note_count_types.js
@@ -2,13 +2,7 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle();
+keyToCss('noteCountTypes').then(selector => { styleElement.textContent = `${selector} { display: none !important; }`; });
 
-export const main = async function () {
-  const selector = await keyToCss('noteCountTypes');
-  styleElement.textContent = `${selector} { display: none !important; }`;
-  document.head.append(styleElement);
-};
-
-export const clean = async function () {
-  styleElement.remove();
-};
+export const main = async ()  => document.head.append(styleElement);
+export const clean = async () => styleElement.remove();


### PR DESCRIPTION
#### User-facing changes
- Adds a tweak to hide the colorful note count type indicators next to the note count on posts.

#### Technical explanation
Are you supposed to add a co-author credit to your merge commit if 99% of your PR is copy-pasted? It seems polite, right? :D

Anyways, I've been running `.📝noteCountTypes { display: none !important; }` in Stylus with my translation script pretty much ever since I got this a/b test.

#### Issues this closes
n/a
