### PR TITLE
Revert "Scroll to Bottom: Query performance optimization (#431)"

### DIFF
--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -3,16 +3,13 @@ import { translate } from '../util/language_data.js';
 import { pageModifications } from '../util/mutations.js';
 
 let knightRiderLoaderSelector;
-let loaderSelector;
 let scrollToBottomButton;
 let scrollToBottomIcon;
 let active = false;
 
 const scrollToBottom = () => {
   window.scrollTo({ top: document.documentElement.scrollHeight });
-  const knightRiderLoaders = [...document.querySelectorAll(knightRiderLoaderSelector)];
-  const shouldKeepScrolling = knightRiderLoaders.some(element => element.matches(loaderSelector));
-  if (!shouldKeepScrolling) {
+  if (document.querySelector(knightRiderLoaderSelector) === null) {
     stopScrolling();
   }
 };
@@ -64,8 +61,7 @@ const addButtonToPage = async function ([scrollToTopButton]) {
 };
 
 export const main = async function () {
-  knightRiderLoaderSelector = await keyToCss('knightRiderLoader');
-  loaderSelector = await resolveExpressions`main ${keyToCss('loader')} ${keyToCss('knightRiderLoader')}`;
+  knightRiderLoaderSelector = await resolveExpressions`main ${keyToCss('loader')} ${keyToCss('knightRiderLoader')}`;
 
   const scrollToTopLabel = await translate('Scroll to top');
   pageModifications.register(`button[aria-label="${scrollToTopLabel}"]`, addButtonToPage);


### PR DESCRIPTION
#### User-facing changes
- Scroll to Bottom is 0.02% slower. I think it'll survive.

#### Technical explanation
This reverts the performance-optimization-at-the-expense-of-clean-code of #431, as the (single) selector created by the new resolveExpressions function makes it unnecessary. (I haven't done what I would consider exhaustive tests of `:is()` performance yet, but the original 4-level cartesian took 500ms, the 3-level cartesian took 130ms, and both the single selector in #431 and the new singly nested :is() take less than 1.5ms, so... yeah.)

#### Issues this closes
n/a