### PR TITLE
CSS utilities: Accept multiple keys

### DIFF
--- a/src/scripts/accesskit/no_user_fonts.js
+++ b/src/scripts/accesskit/no_user_fonts.js
@@ -4,11 +4,9 @@ import { buildStyle } from '../../util/interface.js';
 const styleElement = buildStyle();
 
 export const main = async function () {
-  const quoteSelector = await resolveExpressions`${keyToCss('textBlock')} ${keyToCss('quote')}`;
-  const chatSelector = await resolveExpressions`${keyToCss('textBlock')} ${keyToCss('chat')}`;
-  const quirkySelector = await resolveExpressions`${keyToCss('textBlock')} ${keyToCss('quirky')}`;
+  const selector = await resolveExpressions`${keyToCss('textBlock')} ${keyToCss('quote', 'chat', 'quirky')}`;
 
-  styleElement.textContent = `${quoteSelector}, ${chatSelector}, ${quirkySelector} { font-family: var(--font-family); }`;
+  styleElement.textContent = `${selector} { font-family: var(--font-family); }`;
   document.head.append(styleElement);
 };
 

--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -10,7 +10,7 @@ export const keyToClasses = async function (...keys) {
 };
 
 /**
- * @param {...string} keys - The source name of an element
+ * @param {...string} keys - One or more element source names
  * @returns {Promise<string>} - A CSS :is() selector which targets all elements that match any of the given source names
  */
 export const keyToCss = async function (...keys) {

--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -13,8 +13,9 @@ export const keyToClasses = async function (key) {
  * @param {string} key - The source name of an element
  * @returns {Promise<string>} - A CSS :is() selector which targets all elements with that source name
  */
-export const keyToCss = async function (key) {
-  const classes = await keyToClasses(key);
+export const keyToCss = async function (...keys) {
+  const classArrays = await Promise.all(keys.map(keyToClasses));
+  const classes = classArrays.flat(1);
   return `:is(${classes.map(className => `.${className}`).join(', ')})`;
 };
 

--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -1,20 +1,20 @@
 import { getCssMap } from './tumblr_helpers.js';
 
 /**
- * @param {string} key - The source name of an element
+ * @param {...string} keys - The source name of an element
  * @returns {Promise<string[]>} An array of generated classnames from the CSS map
  */
-export const keyToClasses = async function (key) {
+export const keyToClasses = async function (...keys) {
   const cssMap = await getCssMap;
-  return cssMap[key];
+  return keys.flatMap(key => cssMap[key]);
 };
 
 /**
- * @param {string} key - The source name of an element
- * @returns {Promise<string>} - A CSS :is() selector which targets all elements with that source name
+ * @param {...string} keys - The source name of an element
+ * @returns {Promise<string>} - A CSS :is() selector which targets all elements that match any of the given source names
  */
-export const keyToCss = async function (key) {
-  const classes = await keyToClasses(key);
+export const keyToCss = async function (...keys) {
+  const classes = await keyToClasses(...keys);
   return `:is(${classes.map(className => `.${className}`).join(', ')})`;
 };
 

--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -13,9 +13,8 @@ export const keyToClasses = async function (key) {
  * @param {string} key - The source name of an element
  * @returns {Promise<string>} - A CSS :is() selector which targets all elements with that source name
  */
-export const keyToCss = async function (...keys) {
-  const classArrays = await Promise.all(keys.map(keyToClasses));
-  const classes = classArrays.flat(1);
+export const keyToCss = async function (key) {
+  const classes = await keyToClasses(key);
   return `:is(${classes.map(className => `.${className}`).join(', ')})`;
 };
 

--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -1,7 +1,7 @@
 import { getCssMap } from './tumblr_helpers.js';
 
 /**
- * @param {...string} keys - The source name of an element
+ * @param {...string} keys - One or more element source names
  * @returns {Promise<string[]>} An array of generated classnames from the CSS map
  */
 export const keyToClasses = async function (...keys) {


### PR DESCRIPTION
- [x] fix jsdoc

#### User-facing changes
- n/a

#### Technical explanation
This modifies the keyToClasses/keyToCss utilities to optionally accept multiple keys as multiple arguments, any of which their output classes/output selector will match. This is useful for things like the no user fonts accesskit script and anti-capitalism.

This also applies the change to no user fonts.

Honestly, though, use cases for this are incredibly rare, so I could see the argument that it's not really worth it.

#### Issues this closes
n/a