### PR TITLE
Page Modifications utility: Fix rare theoretical lag in inactive tabs(?)

### DIFF
--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -86,7 +86,10 @@ const onBeforeRepaint = () => {
 const observer = new MutationObserver(mutations => {
   mutationsPool.push(...mutations);
   if (repaintQueued === false) {
-    window.requestAnimationFrame(onBeforeRepaint);
+    Promise.race([
+      new Promise(resolve => window.requestAnimationFrame(resolve)),
+      new Promise(resolve => setTimeout(resolve, 0))
+    ]).then(onBeforeRepaint);
     repaintQueued = true;
   }
 });

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -88,7 +88,7 @@ const observer = new MutationObserver(mutations => {
   if (repaintQueued === false) {
     Promise.race([
       new Promise(resolve => window.requestAnimationFrame(resolve)),
-      new Promise(resolve => setTimeout(resolve, 0))
+      new Promise(resolve => setTimeout(resolve, 500))
     ]).then(onBeforeRepaint);
     repaintQueued = true;
   }

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -83,12 +83,30 @@ const onBeforeRepaint = () => {
   }
 };
 
+const test = {};
+
 const observer = new MutationObserver(mutations => {
   mutationsPool.push(...mutations);
   if (repaintQueued === false) {
+    const id = Math.random();
+    const timer = performance.now();
+
     Promise.race([
-      new Promise(resolve => window.requestAnimationFrame(resolve)),
-      new Promise(resolve => setTimeout(resolve, 0))
+      new Promise(resolve => window.requestAnimationFrame(() => {
+        console.log(id, 'time until rAF:', performance.now() - timer);
+        test[id] = true;
+        resolve();
+      })),
+      new Promise(resolve => setTimeout(() => {
+        if (test[id]) {
+          // console.log(id, 'unneeded setTimeout');
+        } else {
+          console.log('wow the repaint is still queued at the end of setTimeout');
+          console.log(id, 'time until setTimeout, which was first:', performance.now() - timer);
+          performance.mark(Math.random());
+        }
+        resolve();
+      }, 500))
     ]).then(onBeforeRepaint);
     repaintQueued = true;
   }

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -83,30 +83,12 @@ const onBeforeRepaint = () => {
   }
 };
 
-const test = {};
-
 const observer = new MutationObserver(mutations => {
   mutationsPool.push(...mutations);
   if (repaintQueued === false) {
-    const id = Math.random();
-    const timer = performance.now();
-
     Promise.race([
-      new Promise(resolve => window.requestAnimationFrame(() => {
-        console.log(id, 'time until rAF:', performance.now() - timer);
-        test[id] = true;
-        resolve();
-      })),
-      new Promise(resolve => setTimeout(() => {
-        if (test[id]) {
-          // console.log(id, 'unneeded setTimeout');
-        } else {
-          console.log('wow the repaint is still queued at the end of setTimeout');
-          console.log(id, 'time until setTimeout, which was first:', performance.now() - timer);
-          performance.mark(Math.random());
-        }
-        resolve();
-      }, 500))
+      new Promise(resolve => window.requestAnimationFrame(resolve)),
+      new Promise(resolve => setTimeout(resolve, 0))
     ]).then(onBeforeRepaint);
     repaintQueued = true;
   }


### PR DESCRIPTION
So... I have absolutely no idea how to test this.

#### User-facing changes
- Fixes a potential bug where page modifications that occur when the window is not focused might not be processed by XKit until the next mutation. (I think this would only occur when Tumblr background-fetches to do things like add notification badges on the menu icons or fetches ads, neither of which XKit Rewritten currently does anything with... so, practically, nothing.)

#### Technical explanation

I noticed this happening with my personal "hide the activity badge on the notification icon" userstyle/userscript combination, which works essentially the same way as XKit Rewritten's page modification engine.

`window.requestAnimationFrame` is not fired on inactive tabs, since it's... not exactly designed for this use case. So page modification updates could be skipped until the next mutation that happens when the tab is active again. XKit Rewritten's mutationsPool system ensures that no mutations get lost in the wash, unlike my personal script, but this could still have a slight visual effect in theory.

This fixes the problem by falling back to a setTimeout if rAF hasn't been called ~~by the time the event loop empties~~ after a delay.

#### Issues this closes
n/a