### PR TITLE
Quick reblog: Save last selected blog in local storage

### DIFF
--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -222,7 +222,7 @@ const updateQuickTags = (changes, areaName) => {
 };
 
 /**
- * adapted from https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest#basic_example
+ * adapted from https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest#converting_a_digest_to_a_hex_string
  *
  * @param {string} data - String to hash
  * @returns {Promise<string>} Hexadecimal string of a unique hash of the input

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -270,11 +270,8 @@ export const main = async function () {
   );
 
   if (rememberLastBlog) {
-    const hashToUuid = {};
     for (const { uuid } of userBlogs) {
-      const hash = await sha256(uuid);
-      uuidToHash[uuid] = hash;
-      hashToUuid[hash] = uuid;
+      uuidToHash[uuid] = await sha256(uuid);
     }
 
     const mainBlog = userBlogs.find(blog => blog.primary === true);
@@ -284,10 +281,8 @@ export const main = async function () {
       await browser.storage.local.get(rememberedBlogStorageKey);
 
     const savedBlogHash = rememberedBlogs[accountKey];
-
-    if (savedBlogHash && hashToUuid[savedBlogHash]) {
-      blogSelector.value = hashToUuid[savedBlogHash];
-    }
+    const savedBlogUuid = Object.keys(uuidToHash).find(uuid => uuidToHash[uuid] === savedBlogHash);
+    if (savedBlogUuid) blogSelector.value = savedBlogUuid;
 
     blogSelector.addEventListener('change', updateRememberedBlog);
   }

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -235,13 +235,13 @@ const sha256 = async (data) => {
   return hashHex;
 };
 
-const updateRememberedBlog = async event => {
+const updateRememberedBlog = async ({ currentTarget: { value: selectedBlog } }) => {
   if (!rememberLastBlog) return;
 
-  const { [rememberedBlogStorageKey]: rememberedBlogs = {} } =
-    await browser.storage.local.get(rememberedBlogStorageKey);
+  const {
+    [rememberedBlogStorageKey]: rememberedBlogs = {}
+  } = await browser.storage.local.get(rememberedBlogStorageKey);
 
-  const selectedBlog = event.target.value;
   const selectedBlogHash = blogHashes[selectedBlog];
 
   rememberedBlogs[accountKey] = selectedBlogHash;
@@ -274,11 +274,12 @@ export const main = async function () {
       blogHashes[uuid] = await sha256(uuid);
     }
 
-    const mainBlog = userBlogs.find(blog => blog.primary === true);
-    accountKey = blogHashes[mainBlog.uuid];
+    const { uuid: primaryUuid } = userBlogs.find(({ primary }) => primary === true);
+    accountKey = blogHashes[primaryUuid];
 
-    const { [rememberedBlogStorageKey]: rememberedBlogs = {} } =
-      await browser.storage.local.get(rememberedBlogStorageKey);
+    const {
+      [rememberedBlogStorageKey]: rememberedBlogs = {}
+    } = await browser.storage.local.get(rememberedBlogStorageKey);
 
     const savedBlogHash = rememberedBlogs[accountKey];
     const savedBlogUuid = Object.keys(blogHashes).find(uuid => blogHashes[uuid] === savedBlogHash);

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -48,7 +48,7 @@ let queueTag;
 let alreadyRebloggedEnabled;
 let alreadyRebloggedLimit;
 
-const storageKey = 'quick_reblog.alreadyRebloggedList';
+const alreadyRebloggedStorageKey = 'quick_reblog.alreadyRebloggedList';
 const quickTagsStorageKey = 'quick_tags.preferences.tagBundles';
 
 const renderTagSuggestions = () => {
@@ -155,13 +155,13 @@ const reblogPost = async function ({ currentTarget }) {
       notify(response.displayText);
 
       if (alreadyRebloggedEnabled) {
-        const { [storageKey]: alreadyRebloggedList = [] } = await browser.storage.local.get(storageKey);
+        const { [alreadyRebloggedStorageKey]: alreadyRebloggedList = [] } = await browser.storage.local.get(alreadyRebloggedStorageKey);
         const rootID = rebloggedRootId || postID;
 
         if (alreadyRebloggedList.includes(rootID) === false) {
           alreadyRebloggedList.push(rootID);
           alreadyRebloggedList.splice(0, alreadyRebloggedList.length - alreadyRebloggedLimit);
-          await browser.storage.local.set({ [storageKey]: alreadyRebloggedList });
+          await browser.storage.local.set({ [alreadyRebloggedStorageKey]: alreadyRebloggedList });
         }
       }
     }
@@ -178,7 +178,7 @@ const reblogPost = async function ({ currentTarget }) {
 });
 
 const processPosts = async function (postElements) {
-  const { [storageKey]: alreadyRebloggedList = [] } = await browser.storage.local.get(storageKey);
+  const { [alreadyRebloggedStorageKey]: alreadyRebloggedList = [] } = await browser.storage.local.get(alreadyRebloggedStorageKey);
   filterPostElements(postElements).forEach(async postElement => {
     const { id } = postElement.dataset;
     const { rebloggedRootId } = await timelineObjectMemoized(id);

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -283,8 +283,8 @@ export const main = async function () {
       hashToUuid[hash] = uuid;
     }
 
-    const mainBlog = userBlogs[0].uuid;
-    accountKey = uuidToHash[mainBlog];
+    const mainBlog = userBlogs.find(blog => blog.primary === true);
+    accountKey = uuidToHash[mainBlog.uuid];
 
     const { [rememberedBlogStorageKey]: rememberedBlogs = {} } =
       await browser.storage.local.get(rememberedBlogStorageKey);

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -236,8 +236,6 @@ const sha256 = async (data) => {
 };
 
 const updateRememberedBlog = async ({ currentTarget: { value: selectedBlog } }) => {
-  if (!rememberLastBlog) return;
-
   const {
     [rememberedBlogStorageKey]: rememberedBlogs = {}
   } = await browser.storage.local.get(rememberedBlogStorageKey);

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -271,10 +271,6 @@ export const main = async function () {
   );
 
   if (rememberLastBlog) {
-    // const userBlogHashEntries = await Promise.all(userBlogs.map(async ({ uuid }) => [uuid, await sha256(uuid)]));
-    // userBlogHashes = Object.fromEntries(userBlogHashEntries);
-    // accountKey = userBlogHashEntries[0][1];
-
     uuidToHash = {};
     const hashToUuid = {};
     for (const { uuid } of userBlogs) {
@@ -291,16 +287,8 @@ export const main = async function () {
 
     const savedBlogHash = rememberedBlogs[accountKey];
 
-    console.log(userBlogs.map(({ name, uuid }) => ({ name, uuid })));
-    console.log('userBlogHashes', uuidToHash);
-    console.log('mainBlogHash', accountKey);
-    console.log('savedBlogHash', savedBlogHash);
-
-    // const [savedBlog] = userBlogHashEntries.find(([key, value]) => value === savedBlogHash) || [];
-
     if (savedBlogHash && hashToUuid[savedBlogHash]) {
       blogSelector.value = hashToUuid[savedBlogHash];
-      console.log('userblogUUIDs[savedBlogHash]', hashToUuid[savedBlogHash]);
     }
 
     blogSelector.addEventListener('change', updateRememberedBlog);

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -53,6 +53,7 @@ const alreadyRebloggedStorageKey = 'quick_reblog.alreadyRebloggedList';
 const rememberedBlogStorageKey = 'quick_reblog.rememberedBlogs';
 const quickTagsStorageKey = 'quick_tags.preferences.tagBundles';
 const uuidToHash = {};
+
 const renderTagSuggestions = () => {
   tagSuggestions.textContent = '';
   if (!showTagSuggestions) return;

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -36,7 +36,6 @@ draftButton.dataset.state = 'draft';
 let lastPostID;
 let timeoutID;
 let suggestableTags;
-let uuidToHash;
 let accountKey;
 
 let popupPosition;
@@ -53,7 +52,7 @@ let alreadyRebloggedLimit;
 const alreadyRebloggedStorageKey = 'quick_reblog.alreadyRebloggedList';
 const rememberedBlogStorageKey = 'quick_reblog.rememberedBlogs';
 const quickTagsStorageKey = 'quick_tags.preferences.tagBundles';
-
+const uuidToHash = {};
 const renderTagSuggestions = () => {
   tagSuggestions.textContent = '';
   if (!showTagSuggestions) return;
@@ -270,7 +269,6 @@ export const main = async function () {
   );
 
   if (rememberLastBlog) {
-    uuidToHash = {};
     const hashToUuid = {};
     for (const { uuid } of userBlogs) {
       const hash = await sha256(uuid);

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -52,7 +52,7 @@ let alreadyRebloggedLimit;
 const alreadyRebloggedStorageKey = 'quick_reblog.alreadyRebloggedList';
 const rememberedBlogStorageKey = 'quick_reblog.rememberedBlogs';
 const quickTagsStorageKey = 'quick_tags.preferences.tagBundles';
-const uuidToHash = {};
+const blogHashes = {};
 
 const renderTagSuggestions = () => {
   tagSuggestions.textContent = '';
@@ -242,7 +242,7 @@ const updateRememberedBlog = async event => {
     await browser.storage.local.get(rememberedBlogStorageKey);
 
   const selectedBlog = event.target.value;
-  const selectedBlogHash = uuidToHash[selectedBlog];
+  const selectedBlogHash = blogHashes[selectedBlog];
 
   rememberedBlogs[accountKey] = selectedBlogHash;
   browser.storage.local.set({ [rememberedBlogStorageKey]: rememberedBlogs });
@@ -271,17 +271,17 @@ export const main = async function () {
 
   if (rememberLastBlog) {
     for (const { uuid } of userBlogs) {
-      uuidToHash[uuid] = await sha256(uuid);
+      blogHashes[uuid] = await sha256(uuid);
     }
 
     const mainBlog = userBlogs.find(blog => blog.primary === true);
-    accountKey = uuidToHash[mainBlog.uuid];
+    accountKey = blogHashes[mainBlog.uuid];
 
     const { [rememberedBlogStorageKey]: rememberedBlogs = {} } =
       await browser.storage.local.get(rememberedBlogStorageKey);
 
     const savedBlogHash = rememberedBlogs[accountKey];
-    const savedBlogUuid = Object.keys(uuidToHash).find(uuid => uuidToHash[uuid] === savedBlogHash);
+    const savedBlogUuid = Object.keys(blogHashes).find(uuid => blogHashes[uuid] === savedBlogHash);
     if (savedBlogUuid) blogSelector.value = savedBlogUuid;
 
     blogSelector.addEventListener('change', updateRememberedBlog);

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -36,12 +36,12 @@ draftButton.dataset.state = 'draft';
 let lastPostID;
 let timeoutID;
 let suggestableTags;
+let uuidToHash;
+let accountKey;
 
 let popupPosition;
 let showBlogSelector;
 let rememberLastBlog;
-let uuidToHash;
-let accountKey;
 let showCommentInput;
 let quickTagsIntegration;
 let showTagsInput;
@@ -245,7 +245,6 @@ const updateRememberedBlog = async event => {
   const selectedBlogHash = uuidToHash[selectedBlog];
 
   rememberedBlogs[accountKey] = selectedBlogHash;
-  console.log('setting', rememberedBlogs);
   browser.storage.local.set({ [rememberedBlogStorageKey]: rememberedBlogs });
 };
 

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -222,10 +222,10 @@ const updateQuickTags = (changes, areaName) => {
 };
 
 /**
- * adapted from https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest
+ * adapted from https://developer.mozilla.org/en-US/docs/Web/API/SubtleCrypto/digest#basic_example
  *
- * @param {string} data - string to hash
- * @returns {Promise<string>} hash - hexadecimal string of a unique hash of the input
+ * @param {string} data - String to hash
+ * @returns {Promise<string>} Hexadecimal string of a unique hash of the input
  */
 const sha256 = async (data) => {
   const msgUint8 = new TextEncoder().encode(data);


### PR DESCRIPTION
Honestly, I'm not sure if this was something you wanted to work on yourself, and if so, I am 100% fine with that! I just wanted to learn about the crypto functions available in javascript and the way XKit Rewritten interfaces with storage... and then wound up learning about attaching event listeners and how to convert an ArrayBuffer to base64.*

*hope you're in Node; if not, reject all of the solutions as awful and do something entirely different.

Pretty sure there are ways to do this in less code. (Honestly, if you want to use any of this, feel free to copy-paste/I could make it a branch in this repo if you want.)

#### User-facing changes
- Quick reblog's "remember the last selected blog in the popup" option persists through page reloads, yet the local storage contains no record of who the user is.

#### Technical explanation
Instead of saving the UUID of the most recently selected blog (and the UUID of your main, so your preferences are remembered on a per-account basis), this saves the SHA256 hash of both UUIDs instead. This identifies them without storing them (unless you can break SHA256, in which case you have better things to do).

I guess if the UUID of your main blog changes, this forgets your preference? Can that happen? Oh well, pretty minor if it does.

This adds an onChange listener to the blog selector so that it can update local storage immediately when you select a blog.

I spent way too long trying to think of an elegant, easily-comprehendable-without-a-comment syntax to search through the values of an object to get the matching key before just saying screw it and also storing the object in reverse ¯\\\_(ツ)\_/¯ 

#### Issues this closes
#429; #220, #317, #412.