### PR TITLE
Improve behavior when extension is initialized twice

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -81,6 +81,10 @@
     installedScripts
       .filter(scriptName => enabledScripts.includes(scriptName))
       .forEach(runScript);
+
+    const checkRepeatInitPath = getURL('/util/check_repeat_init.js');
+    const { checkRepeatInit } = await import(checkRepeatInitPath);
+    checkRepeatInit();
   };
 
   const waitForReactLoaded = () => new Promise(resolve => {

--- a/src/util/check_repeat_init.js
+++ b/src/util/check_repeat_init.js
@@ -17,14 +17,15 @@ const getRunningXkit = async (currentVersion) => {
 export const checkRepeatInit = inject(getRunningXkit, [currentVersion])
   .then(result => {
     if (result) {
+      const updateMessage = result !== currentVersion
+        ? [`The extension appears to have been auto-updated to ${currentVersion}!`, document.createElement('br')]
+        : [];
+
       showModal({
         title: 'XKit Rewritten has been initialized multiple times',
         message: [
-          result === currentVersion
-            ? 'Not sure how this happened! Are you a developer?'
-            : `XKit Rewritten appears to been auto-updated to ${currentVersion}!`,
-          document.createElement('br'),
-          'Hard refreshing Tumblr via the refresh button or f5 key is recommended if you observe duplicate effects.'
+          ...updateMessage,
+          'Hard refreshing this browser tab via the refresh button or f5 key is recommended.'
         ],
         buttons: [modalCompleteButton]
       });

--- a/src/util/check_repeat_init.js
+++ b/src/util/check_repeat_init.js
@@ -1,5 +1,5 @@
 import { inject } from './inject.js';
-import { showModal, modalCompleteButton } from './modals.js';
+import { showModal, modalCancelButton } from './modals.js';
 
 const currentVersion = browser.runtime.getManifest().version;
 
@@ -25,9 +25,16 @@ export const checkRepeatInit = inject(getRunningXkit, [currentVersion])
         title: 'XKit Rewritten has been initialized multiple times',
         message: [
           ...updateMessage,
-          'Hard refreshing this browser tab via the refresh button or f5 key is recommended.'
+          'Refreshing this browser tab is recommended to avoid unexpected behavior.'
         ],
-        buttons: [modalCompleteButton]
+        buttons: [modalCancelButton,
+          Object.assign(document.createElement('button'), {
+            textContent: 'Reload',
+            className: 'blue',
+            onclick: () => {
+              location.reload(true);
+            }
+          })]
       });
     }
   });

--- a/src/util/check_repeat_init.js
+++ b/src/util/check_repeat_init.js
@@ -9,7 +9,7 @@ const getRunningXkit = async (currentVersion) => {
     value: currentVersion,
     writable: false,
     enumerable: false,
-    configurable: false
+    configurable: true
   });
   return runningVersion;
 };

--- a/src/util/check_repeat_init.js
+++ b/src/util/check_repeat_init.js
@@ -14,7 +14,7 @@ const getRunningXkit = async (currentVersion) => {
   return runningVersion;
 };
 
-export const checkRepeatInit = inject(getRunningXkit, [currentVersion])
+export const checkRepeatInit = () => inject(getRunningXkit, [currentVersion])
   .then(result => {
     if (result) {
       const updateMessage = result !== currentVersion

--- a/src/util/check_repeat_init.js
+++ b/src/util/check_repeat_init.js
@@ -1,0 +1,32 @@
+import { inject } from './inject.js';
+import { showModal, modalCompleteButton } from './modals.js';
+
+const currentVersion = browser.runtime.getManifest().version;
+
+const getRunningXkit = async (currentVersion) => {
+  const runningVersion = window.xkitRunning;
+  Object.defineProperty(window, 'xkitRunning', {
+    value: currentVersion,
+    writable: false,
+    enumerable: false,
+    configurable: false
+  });
+  return runningVersion;
+};
+
+export const checkRepeatInit = inject(getRunningXkit, [currentVersion])
+  .then(result => {
+    if (result) {
+      showModal({
+        title: 'XKit Rewritten has been initialized multiple times',
+        message: [
+          result === currentVersion
+            ? 'Not sure how this happened! Are you a developer?'
+            : `XKit Rewritten appears to been auto-updated to ${currentVersion}!`,
+          document.createElement('br'),
+          'Hard refreshing Tumblr via the refresh button or f5 key is recommended if you observe duplicate effects.'
+        ],
+        buttons: [modalCompleteButton]
+      });
+    }
+  });

--- a/src/util/check_repeat_init.js
+++ b/src/util/check_repeat_init.js
@@ -27,14 +27,16 @@ export const checkRepeatInit = inject(getRunningXkit, [currentVersion])
           ...updateMessage,
           'Refreshing this browser tab is recommended to avoid unexpected behavior.'
         ],
-        buttons: [modalCancelButton,
+        buttons: [
+          modalCancelButton,
           Object.assign(document.createElement('button'), {
             textContent: 'Reload',
             className: 'blue',
             onclick: () => {
               location.reload(true);
             }
-          })]
+          })
+        ]
       });
     }
   });


### PR DESCRIPTION
#### User-facing changes
- Displays an informational modal if XKit Rewritten is loaded on a page more than once, usually due to an automatic background update or the user toggling the extension off and on in Firefox.

#### Technical explanation
This injects a script that sets a(nother) property on the `window` object when XKit Rewritten initializes, and checks if it has been previously set. If so, the extension has been previously run on this page, so we may as well inform the user (or remind the developer) that surprising behavior may occur.

(I'm not actually familiar with how extension updates work, but I assume this method should work. Not sure of the best UI copy to describe this or the best place to put code of this kind.)

#### Issues this closes
#449