### PR TITLE
Experiment: Create navigation utility

### DIFF
--- a/src/util/navigation.js
+++ b/src/util/navigation.js
@@ -1,0 +1,38 @@
+import { inject } from './inject.js';
+
+export const onNavigation = Object.freeze({
+  listeners: new Set(),
+  addListener (callback) {
+    if (this.listeners.has(callback) === false) {
+      this.listeners.add(callback);
+    }
+  },
+  removeListener (callback) {
+    this.listeners.delete(callback);
+  }
+});
+
+const waitForNavigation = async () => new Promise(resolve => {
+  const navigationHandler = () => {
+    window.tumblr.off('navigation', navigationHandler);
+    resolve();
+  };
+  window.tumblr.on('navigation', navigationHandler);
+});
+
+let previousLocation = new URL(location);
+(async () => {
+  while (true) {
+    try {
+      await inject(waitForNavigation);
+    } catch (e) {
+      console.log(e);
+      break;
+    }
+    const currentLocation = new URL(location);
+    for (const callback of onNavigation.listeners) {
+      callback(currentLocation, previousLocation);
+    }
+    previousLocation = currentLocation;
+  }
+})();

--- a/src/util/navigation.js
+++ b/src/util/navigation.js
@@ -21,18 +21,15 @@ const waitForNavigation = async () => new Promise(resolve => {
 });
 
 let previousLocation = new URL(location);
-(async () => {
-  while (true) {
-    try {
-      await inject(waitForNavigation);
-    } catch (e) {
-      console.log(e);
-      break;
-    }
+
+const handleNavigationRecursive = () => {
+  inject(waitForNavigation).then(() => {
     const currentLocation = new URL(location);
     for (const callback of onNavigation.listeners) {
       callback(currentLocation, previousLocation);
     }
     previousLocation = currentLocation;
-  }
-})();
+    handleNavigationRecursive();
+  });
+};
+handleNavigationRecursive();


### PR DESCRIPTION
```js
import { onNavigation } from '../util/navigation.js';
onNavigation.addListener((currentLocation, previousLocation) =>
  console.log(`whoa, you soft navigated to ${currentLocation} from ${previousLocation}`)
);
```
This implements a (somewhat clunky, implementation-wise) wrapper around window.tumblr.on('navigation') so that XKit Rewritten can subscribe to soft navigation events.

It's somewhat clunky because we don't currently have a framework for injecting functions and giving them a way to call a repeatable callback, something that I have tried writing and given up on various times (it worked great, but the resulting code was nigh-incomprehensible.) Of course, this isn't that comprehensible either ~~- maybe recursion with then() would work better than a looping await - but I digress. (Let me know if you want me to write the recursive version; should be quite easy.)~~

More interestingly, what would you use this for? I thought of using it to clear caches (see #452). Now that more Tumblr pages like some of the settings pages are React, and thus use soft navigation, it becomes harder to ensure that caches' contents continue to make sense as they navigate the UI.

As discussed, for example, Mutual Checker can display slightly out of date results right after you follow/unfollow someone. That feels fine, and in line with user expectations... but if they keep that tab open, navigate a bit, refresh a few times by clicking the Tumblr logo, and things are still not up to date, maybe that doesn't feel as fine.