### PR TITLE
Implement inject utility without return callback

### DIFF
--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -1,7 +1,7 @@
 import { buildStyle } from '../util/interface.js';
 import { registerMeatballItem, unregisterMeatballItem } from '../util/meatballs.js';
 import { pageModifications } from '../util/mutations.js';
-import { inject } from '../util/inject.js';
+import { injectVoid } from '../util/inject.js';
 import { keyToCss } from '../util/css_map.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 
@@ -19,7 +19,7 @@ const buildCss = () => blockedPostTargetIDs.length === 0
   ? ''
   : blockedPostTargetIDs.map(id => `[data-target-post-id="${id}"]`).join(', ').concat(' { display: none; }');
 
-const unburyTargetPostIds = async (notificationSelector) => {
+const unburyTargetPostIds = (notificationSelector) => {
   [...document.querySelectorAll(notificationSelector)]
     .filter(({ dataset: { targetPostId } }) => targetPostId === undefined)
     .forEach(async notificationElement => {
@@ -39,7 +39,7 @@ const unburyTargetPostIds = async (notificationSelector) => {
     });
 };
 
-const processNotifications = () => inject(unburyTargetPostIds, [notificationSelector]);
+const processNotifications = () => injectVoid(unburyTargetPostIds, [notificationSelector]);
 
 const onButtonClicked = async function ({ currentTarget }) {
   const postElement = currentTarget.closest('[data-id]');

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -39,7 +39,7 @@ const unburyTargetPostIds = async (notificationSelector) => {
     });
 };
 
-const processNotifications = () => inject(unburyTargetPostIds, [notificationSelector]);
+const processNotifications = () => inject(unburyTargetPostIds, [notificationSelector], { returnsVoid: true });
 
 const onButtonClicked = async function ({ currentTarget }) {
   const postElement = currentTarget.closest('[data-id]');

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -1,7 +1,7 @@
 import { buildStyle } from '../util/interface.js';
 import { registerMeatballItem, unregisterMeatballItem } from '../util/meatballs.js';
 import { pageModifications } from '../util/mutations.js';
-import { injectVoid } from '../util/inject.js';
+import { inject } from '../util/inject.js';
 import { keyToCss } from '../util/css_map.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 
@@ -19,7 +19,7 @@ const buildCss = () => blockedPostTargetIDs.length === 0
   ? ''
   : blockedPostTargetIDs.map(id => `[data-target-post-id="${id}"]`).join(', ').concat(' { display: none; }');
 
-const unburyTargetPostIds = (notificationSelector) => {
+const unburyTargetPostIds = async (notificationSelector) => {
   [...document.querySelectorAll(notificationSelector)]
     .filter(({ dataset: { targetPostId } }) => targetPostId === undefined)
     .forEach(async notificationElement => {
@@ -39,7 +39,7 @@ const unburyTargetPostIds = (notificationSelector) => {
     });
 };
 
-const processNotifications = () => injectVoid(unburyTargetPostIds, [notificationSelector]);
+const processNotifications = () => inject(unburyTargetPostIds, [notificationSelector]);
 
 const onButtonClicked = async function ({ currentTarget }) {
   const postElement = currentTarget.closest('[data-id]');

--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -57,9 +57,14 @@ const init = new Promise(resolve => {
 /**
  * @param {Function} asyncFunc - Asynchronous function to run in the page context
  * @param {Array} args - Array of arguments to pass to the function via spread
+ * @param {object} [options] - Destructured
+ * @param {boolean} [options.returnsVoid] - If true, resolve immediately and discard the return value
  * @returns {Promise<any>} The return value of the async function, or the caught exception
  */
-export const inject = (asyncFunc, args = []) => new Promise((resolve, reject) => {
+export const inject = (asyncFunc, args = [], { returnsVoid = false } = {}) =>
+  returnsVoid ? injectVoid(asyncFunc, args) : injectWithReturn(asyncFunc, args);
+
+const injectWithReturn = (asyncFunc, args = []) => new Promise((resolve, reject) => {
   const callbackId = Math.random();
   callbacks.set(callbackId, [resolve, reject]);
 
@@ -89,13 +94,7 @@ export const inject = (asyncFunc, args = []) => new Promise((resolve, reject) =>
   });
 });
 
-/**
- * Injects a function into the page context, discarding its result.
- *
- * @param {Function} func - Function to run in the page context
- * @param {Array} args - Array of arguments to pass to the function via spread
- */
-export const injectVoid = (func, args = []) => {
+const injectVoid = async (func, args = []) => {
   const script = document.createElement('script');
   const name = `xkit$${func.name || 'injected'}`;
 

--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -57,12 +57,13 @@ const init = new Promise(resolve => {
 /**
  * @param {Function} asyncFunc - Asynchronous function to run in the page context
  * @param {Array} args - Array of arguments to pass to the function via spread
- * @param {object} [options] - Destructured
+ * @param {object} [options] - Injection options
  * @param {boolean} [options.returnsVoid] - If true, resolve immediately and discard the return value
  * @returns {Promise<any>} The return value of the async function, or the caught exception
  */
-export const inject = (asyncFunc, args = [], { returnsVoid = false } = {}) =>
-  returnsVoid ? injectVoid(asyncFunc, args) : injectWithReturn(asyncFunc, args);
+export const inject = (asyncFunc, args = [], { returnsVoid = false } = {}) => returnsVoid
+  ? injectVoid(asyncFunc, args)
+  : injectWithReturn(asyncFunc, args);
 
 const injectWithReturn = (asyncFunc, args = []) => new Promise((resolve, reject) => {
   const callbackId = Math.random();

--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -88,3 +88,23 @@ export const inject = (asyncFunc, args = []) => new Promise((resolve, reject) =>
     script.remove();
   });
 });
+
+/**
+ * Injects a function into the page context, discarding its result.
+ *
+ * @param {Function} func - Function to run in the page context
+ * @param {Array} args - Array of arguments to pass to the function via spread
+ */
+export const injectVoid = (func, args = []) => {
+  const script = document.createElement('script');
+  const name = `xkit$${func.name || 'injected'}`;
+
+  script.setAttribute('nonce', nonce);
+  script.textContent = `{
+    const ${name} = ${func.toString()};
+    ${name}(...${JSON.stringify(args)})
+  }`;
+
+  document.documentElement.appendChild(script);
+  script.remove();
+};

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -1,4 +1,4 @@
-import { inject, injectVoid } from './inject.js';
+import { inject } from './inject.js';
 import { keyToCss, resolveExpressions } from './css_map.js';
 
 const cache = {};
@@ -34,7 +34,7 @@ export const timelineObject = async function (postID) {
   return cache[postID];
 };
 
-const unburyGivenPaths = (selector) => {
+const unburyGivenPaths = async (selector) => {
   [...document.querySelectorAll(selector)].forEach(timelineElement => {
     const reactKey = Object.keys(timelineElement).find(key => key.startsWith('__reactFiber'));
     let fiber = timelineElement[reactKey];
@@ -59,11 +59,11 @@ const unburyGivenPaths = (selector) => {
 export const exposeTimelines = async () => {
   const timelineSelector = await resolveExpressions`${keyToCss('timeline')}:not([data-timeline])`;
   if (document.querySelector(timelineSelector) !== null) {
-    injectVoid(unburyGivenPaths, [timelineSelector]);
+    return inject(unburyGivenPaths, [timelineSelector]);
   }
 };
 
-const controlTagsInput = ({ add, remove }) => {
+const controlTagsInput = async ({ add, remove }) => {
   add = add.map(tag => tag.trim()).filter((tag, index, array) => array.indexOf(tag) === index);
 
   const selectedTagsElement = document.getElementById('selected-tags');
@@ -93,4 +93,4 @@ const controlTagsInput = ({ add, remove }) => {
  * @param {string[]} [options.remove] - Tags to remove
  * @returns {Promise<void>} Resolves when finished
  */
-export const editPostFormTags = ({ add = [], remove = [] }) => injectVoid(controlTagsInput, [{ add, remove }]);
+export const editPostFormTags = async ({ add = [], remove = [] }) => inject(controlTagsInput, [{ add, remove }]);

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -59,7 +59,7 @@ const unburyGivenPaths = async (selector) => {
 export const exposeTimelines = async () => {
   const timelineSelector = await resolveExpressions`${keyToCss('timeline')}:not([data-timeline])`;
   if (document.querySelector(timelineSelector) !== null) {
-    return inject(unburyGivenPaths, [timelineSelector]);
+    return inject(unburyGivenPaths, [timelineSelector], { returnsVoid: true });
   }
 };
 
@@ -93,4 +93,5 @@ const controlTagsInput = async ({ add, remove }) => {
  * @param {string[]} [options.remove] - Tags to remove
  * @returns {Promise<void>} Resolves when finished
  */
-export const editPostFormTags = async ({ add = [], remove = [] }) => inject(controlTagsInput, [{ add, remove }]);
+export const editPostFormTags = async ({ add = [], remove = [] }) =>
+  inject(controlTagsInput, [{ add, remove }], { returnsVoid: true });

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -1,4 +1,4 @@
-import { inject } from './inject.js';
+import { inject, injectVoid } from './inject.js';
 import { keyToCss, resolveExpressions } from './css_map.js';
 
 const cache = {};
@@ -34,7 +34,7 @@ export const timelineObject = async function (postID) {
   return cache[postID];
 };
 
-const unburyGivenPaths = async (selector) => {
+const unburyGivenPaths = (selector) => {
   [...document.querySelectorAll(selector)].forEach(timelineElement => {
     const reactKey = Object.keys(timelineElement).find(key => key.startsWith('__reactFiber'));
     let fiber = timelineElement[reactKey];
@@ -59,11 +59,11 @@ const unburyGivenPaths = async (selector) => {
 export const exposeTimelines = async () => {
   const timelineSelector = await resolveExpressions`${keyToCss('timeline')}:not([data-timeline])`;
   if (document.querySelector(timelineSelector) !== null) {
-    return inject(unburyGivenPaths, [timelineSelector]);
+    injectVoid(unburyGivenPaths, [timelineSelector]);
   }
 };
 
-const controlTagsInput = async ({ add, remove }) => {
+const controlTagsInput = ({ add, remove }) => {
   add = add.map(tag => tag.trim()).filter((tag, index, array) => array.indexOf(tag) === index);
 
   const selectedTagsElement = document.getElementById('selected-tags');
@@ -93,4 +93,4 @@ const controlTagsInput = async ({ add, remove }) => {
  * @param {string[]} [options.remove] - Tags to remove
  * @returns {Promise<void>} Resolves when finished
  */
-export const editPostFormTags = async ({ add = [], remove = [] }) => inject(controlTagsInput, [{ add, remove }]);
+export const editPostFormTags = ({ add = [], remove = [] }) => injectVoid(controlTagsInput, [{ add, remove }]);


### PR DESCRIPTION
Yep, it's another weird one.

#### User-facing changes
- n/a

#### Technical explanation
This implements a version of `inject()` without the callback functionality, for injecting functions which don't have a meaningful return value. This has two essentially-meaningless benefits:
 - Injected functions can be synchronous, and will be passed through synchronously just as one would expect. (Script tags are evaluated immediately when they're added to the DOM, it turns out.) This improves a minor performance inefficiency with the `exposeTimelines` utility, in which a newly added timeline triggers inject being called up to 4 times in a row, as the normal `inject` function is asynchronous and thus all scripts that immediately call `exposeTimelines` will run their querySelectorAll checks before any of them have injected the function to update the DOM, all finding that their injection is necessary. With a synchronous injection, the first call has its desired effect immediately, and the rest will see that they are unneeded. (This is still a few unnecessary querySelectorAll calls, but oh well. The ways that I thought of to improve that are easy but clunky.)
 - Naturally, the unnecessary postMessage and messageHandler calls are avoided. No meaningful performance benefit, though, thanks to the MessageChannel implementation.

Worthwhile? Eh. Shrug emoji.

#### Issues this closes
n/a