### PR TITLE
Anti-Capitalism: Optionally allow native ads

### DIFF
--- a/src/scripts/anti_capitalism.js
+++ b/src/scripts/anti_capitalism.js
@@ -1,5 +1,54 @@
-import { keyToCss } from '../util/css_map.js';
+import { keyToCss, resolveExpressions } from '../util/css_map.js';
 import { buildStyle } from '../util/interface.js';
+import { getPreferences } from '../util/preferences.js';
+
+/*
+import { pageModifications } from '../util/mutations.js';
+import { translate } from '../util/language_data.js';
+
+const hiddenClass = 'xkit-anti-capitalism';
+const shownClass = 'xkit-anti-capitalism-allowed';
+
+const liteStyleElement = buildStyle();
+resolveExpressions`
+  ${keyToCss('mrecContainer')}, .${hiddenClass} {
+    display: none !important;
+  }
+  .${shownClass} {
+    outline: 3px solid RGBA(var(--white-on-dark), 0.3)
+  }
+`.then(css => { liteStyleElement.textContent = css; });
+
+const adSelector = keyToCss('adTimelineObject', 'instreamAd', 'nativeIponWebAd', 'takeoverBanner');
+let sponsoredText;
+
+const processAds = (adElements) => {
+  adElements.forEach(adElement => {
+    const text = adElement?.innerText?.trim() || '';
+    if (text.length <= sponsoredText.length) {
+      adElement.classList.add(hiddenClass);
+    } else {
+      adElement.classList.add(shownClass);
+    }
+  });
+};
+*/
+
+const thirdPartyAds = ['adTimelineObject', 'instreamAd', 'mrecContainer'];
+const firstPartyAds = ['nativeIponWebAd', 'takeoverBanner'];
+const liteStyleElement = buildStyle();
+resolveExpressions`
+  ${keyToCss(...thirdPartyAds)} {
+    display: none !important;
+  }
+  [data-id] ${keyToCss(...thirdPartyAds)} {
+    display: inherit !important;
+    outline: 3px solid RGBA(var(--white-on-dark), 0.3)
+  }
+  ${keyToCss(...firstPartyAds)} {
+    outline: 3px solid RGBA(var(--white-on-dark), 0.3)
+  }
+`.then(css => { liteStyleElement.textContent = css; });
 
 const styleElement = buildStyle();
 keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner')
@@ -7,5 +56,20 @@ keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', '
     styleElement.textContent = `${selector} { display: none !important; }`;
   });
 
-export const main = async () => document.head.append(styleElement);
-export const clean = async () => styleElement.remove();
+export const main = async () => {
+  const { allowFirstParty } = await getPreferences('anti_capitalism');
+
+  if (allowFirstParty) {
+    document.head.append(liteStyleElement);
+    // sponsoredText = await translate('Sponsored');
+    // pageModifications.register(await adSelector, processAds);
+  } else {
+    document.head.append(styleElement);
+  }
+};
+
+export const clean = async () => {
+  styleElement.remove();
+  liteStyleElement.remove();
+  // pageModifications.unregister(processAds);
+};

--- a/src/scripts/anti_capitalism.json
+++ b/src/scripts/anti_capitalism.json
@@ -6,5 +6,12 @@
     "color": "#ffd800",
     "background_color": "#cd0000"
   },
-  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#anti-capitalism"
+  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#anti-capitalism",
+  "preferences": {
+    "allowFirstParty": {
+      "type": "checkbox",
+      "label": "Allow certain Tumblr-hosted ads",
+      "default": false
+    }
+  }
 }


### PR DESCRIPTION
I recognize that if this or any feature resembling it gets merged, the conspiracy theories about how Staff has some kind of dirt on you will only get more ridiculous, April, but I figure I'll PR it anyway. I was going to do the testing and implementation regardless of my opinion of the likelihood that you would want it in the extension.

For the record, anyone reading this: no one has influenced me to do this in any way. I have never heard any user or staff member speak negatively about unconditional ad blocking. I just don't like it ¯\\\_(ツ)\_/¯

#### User-facing changes
Adds a preference to Anti-Capitalism which causes it not to hide certain kinds of ad containers whose contents are loaded from Tumblr's servers (i.e. the ones which will still appear if you disable third party JavaScript or run UBlock Origin without cosmetic filtering), but will still hide ad containers which become empty in those cases.

The preference is, naturally, disabled by default. If it were my project and I were merging this, I would probably push an extension version first which wrote the preference into localstorage as disabled for current installs, then push another version with the implementation removing that code and and making the default for any new installs enabled, but in the interest of not being [developer who shall not be named] I obviously don't think we should do that.

#### Technical explanation

After quite some testing, I have two successful implementations of this: one is pure CSS, and one uses the `postModifications` engine and an innerText query (relying on the fact that iframes don't show up in innerText). The initial commit has the CSS method implemented and the `postModifications` method commented out. I would probably pick the former.

Pure CSS drawbacks:
- Less robust against new Tumblr ad types being added.
- Hides a rare ad type I found once that doesn't need to be hidden.

`postModifications` drawbacks:
- More code.
- Slower, though I keep going back and forth on whether it's perceptible (difficult to test).
- Possibility that hidden ads can't tell they've been hidden, if they use synchronous DOM size queries (very difficult to test).
- Less robust against Tumblr adding more descriptive text to the ad containers.

The obvious third method would involve querying for iframes in some way, but they are inserted into the ad containers asynchronously, which results in a host of problems.

<details>
<summary>copy of my old notes about all the ad types I've seen</summary>
types of tumblr ads that I have seen, from a technical standpoint:

very much like a regular post:
 - white container that looks like a post
 - uses no external javascript
 - no iframe
 - listTimelineObject has data-id
 - listTimelineObject contains listTimelineObject >  instreamAd, which contains an article just like a normal post 
 - the inner listTimelineObject has an untranslated "moatContainer" class

just a nativeIponWebAd:
 - sharp edges
 - uses no external javascript
 - no iframe
 - listTimelineObject contains listTimelineObject, which contains nativeIponWebAd

the really common one except it has a nativeIponWebAd (only seen once):
 - white rounded container
 - uses no external javascript
 - no iframe
 - listTimelineObject contains listTimelineObject >  instreamAd > nativeIponWebAd
 - the inner listTimelineObject has an untranslated "moatContainer" class

---

the really common one:
 - white rounded container
 - uses external javascript
 - contains an iframe
 - listTimelineObject contains listTimelineObject >  instreamAd > adtimelineobject
 - adtimelineobject has an untranslated "moatContainer" class and data-is-resizable=true

just an adtimelineobject
 - blank space if blocked; sharp edges if not
 - uses external javascript
 - contains an iframe
 - listTimelineObject contains adtimelineobject
 - adtimelineobject has an untranslated "moatContainer" class and data-is-resizable=false

a) wow I really don't want to see the source code that can produce this many variations
b) wow I am not confident that I have seen them all... maybe I was somewhat, but then I encountered "the really common one except it has a nativeIponWebAd" (and anyways I'm sure other accounts in other locales could get variants I don't)
c) wow there really is no obvious way to distinguish between the ones that use external javascript and the ones that don't
d) even if there was, if the really common one can dynamically change its contents between "iframe" and "nativeIponWebAd; no iframe" then that answer might not even stay consistent on a per-container basis

so, what have I done so far?
 - the goal of this project is to hide ad containers that are actually empty. the tracking protection built into many browsers these days will kill some of the external-javascript ads, which results in "just an adtimelineobject" yielding a blank space in the dash. and I want to make an option that hides empty ad containers from blocking all external javascript, but keeps tumblr's native ads.
 - idea 0) just query the innerText/textContent of ad containers to see if they are empty. fails (sort of); iframes don't show up. then again, we probably want to hide those anyway. come back to this.
 - idea 1) use all available methods to actually look at the ad content. fails; iframes' contents cannot be read for security reasons.
 - idea 2) okay, fine, for the sake of our purposes, explicitly hide all containers containing iframes. great; none of the ones I want to keep have iframes anyway. problem: iframes are inserted dynamically. complex listener system that identifies iframes in real time, searches up the tree for their parent containers, and hides them works, but is way too complicated and finicky for proposing as a public script, plus I dunno if it would cause random page reflow.
 - idea 3) well, we can go back to idea 0: iframes don't show up as textcontent/innertext, so if an ad container looks empty, block it. this might work, but I need to test it on "just a nativeIponWebAd" to see if it looks empty when it's inserted, and I only get like 2 of those per day.
 - idea 4) okay, can we avoid dynamic code entirely and use pure css? maybe; we just need to identify a foolproof way to distinguish between these 5 cases... and it has to actually target the correct part of the tree to hide, since you can't hide the parent listTimelineObject (it breaks j/k scrolling) and you can't target too far down the tree since we don't have ultra-powerful css selectors like has:.

I think...? idea 4 can work, but the logic looks fairly complicated; you can't use `:not()` on parent selectors. Unless you can just override a previous rule with... wait hold on

</details>

#### Issues this closes
n/a. To the contrary, it's quite possible no one on earth but me wants this.

