### PR TITLE
Footer redesign revert tweak: Fix gap at bottom of posts

### DIFF
--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -1,42 +1,33 @@
-import { keyToClasses, keyToCss, resolveExpressions } from '../../util/css_map.js';
+import { keyToClasses, keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
 
 let footerRedesignClasses;
 let footerRedesignSelector;
 
-const keyToNot = async function (...keys) {
-  const classes = await keyToClasses(...keys);
-  return classes.map(className => `:not(.${className})`).join('');
-};
+const styleElement = buildStyle(`
+.xkit-control-button-container {
+  margin-left: 20px;
+}
 
-const styleElement = buildStyle();
-resolveExpressions`
-  ${keyToCss('postActivityWrapper')}${keyToNot('postActivityWrapperOpen')} {
-    margin-top: 0;
-  }
-  .xkit-control-button-container {
-    margin-left: 20px;
-  }
+[role="dialog"] #quick-reblog,
+[role="dialog"] #quick-tags {
+  top: 50% !important;
+  bottom: unset !important;
+  right: 100% !important;
+  transform: translate(-20px, -50%) !important;
+}
 
-  [role="dialog"] #quick-reblog,
-  [role="dialog"] #quick-tags {
+@media only screen and (max-width: 650px) {
+  #quick-reblog,
+  #quick-tags {
     top: 50% !important;
     bottom: unset !important;
     right: 100% !important;
     transform: translate(-20px, -50%) !important;
   }
-
-  @media only screen and (max-width: 650px) {
-    #quick-reblog,
-    #quick-tags {
-      top: 50% !important;
-      bottom: unset !important;
-      right: 100% !important;
-      transform: translate(-20px, -50%) !important;
-    }
-  }
-`.then(css => { styleElement.textContent = css; console.log(styleElement.textContent); });
+}
+`);
 
 const removeFooterRedesign = elements => {
   elements.forEach(element => {

--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -2,10 +2,16 @@ import { keyToClasses, keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
 
+const removePaddingClass = 'xkit-footer-padding-fix';
+
 let footerRedesignClasses;
 let footerRedesignSelector;
+let postActivityWrapperSelector;
 
 const styleElement = buildStyle(`
+.${removePaddingClass} {
+  padding-bottom: 0;
+}
 .xkit-control-button-container {
   margin-left: 20px;
 }
@@ -33,12 +39,16 @@ const removeFooterRedesign = elements => {
   elements.forEach(element => {
     element.dataset.oldClassName = element.className;
     element.classList.remove(...footerRedesignClasses);
+    if (element.querySelector(postActivityWrapperSelector)) {
+      element.classList.add(removePaddingClass);
+    }
   });
 };
 
 export const main = async function () {
   footerRedesignClasses = await keyToClasses('footerRedesign');
   footerRedesignSelector = await keyToCss('footerRedesign');
+  postActivityWrapperSelector = await keyToCss('postActivityWrapper');
   pageModifications.register(footerRedesignSelector, removeFooterRedesign);
   document.head.append(styleElement);
 };
@@ -49,4 +59,5 @@ export const clean = async function () {
   $('[data-old-class-name]')
     .attr('class', function () { return this.dataset.oldClassName; })
     .removeAttr('data-old-class-name');
+  $(`.${removePaddingClass}`).removeClass(removePaddingClass);
 };

--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -1,33 +1,42 @@
-import { keyToClasses, keyToCss } from '../../util/css_map.js';
+import { keyToClasses, keyToCss, resolveExpressions } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
 
 let footerRedesignClasses;
 let footerRedesignSelector;
 
-const styleElement = buildStyle(`
-.xkit-control-button-container {
-  margin-left: 20px;
-}
+const keyToNot = async function (...keys) {
+  const classes = await keyToClasses(...keys);
+  return classes.map(className => `:not(.${className})`).join('');
+};
 
-[role="dialog"] #quick-reblog,
-[role="dialog"] #quick-tags {
-  top: 50% !important;
-  bottom: unset !important;
-  right: 100% !important;
-  transform: translate(-20px, -50%) !important;
-}
+const styleElement = buildStyle();
+resolveExpressions`
+  ${keyToCss('postActivityWrapper')}${keyToNot('postActivityWrapperOpen')} {
+    margin-top: 0;
+  }
+  .xkit-control-button-container {
+    margin-left: 20px;
+  }
 
-@media only screen and (max-width: 650px) {
-  #quick-reblog,
-  #quick-tags {
+  [role="dialog"] #quick-reblog,
+  [role="dialog"] #quick-tags {
     top: 50% !important;
     bottom: unset !important;
     right: 100% !important;
     transform: translate(-20px, -50%) !important;
   }
-}
-`);
+
+  @media only screen and (max-width: 650px) {
+    #quick-reblog,
+    #quick-tags {
+      top: 50% !important;
+      bottom: unset !important;
+      right: 100% !important;
+      transform: translate(-20px, -50%) !important;
+    }
+  }
+`.then(css => { styleElement.textContent = css; console.log(styleElement.textContent); });
 
 const removeFooterRedesign = elements => {
   elements.forEach(element => {


### PR DESCRIPTION
#### User-facing changes
- Fixes a 12px gap at the bottom of posts that was not there before the new notes UI.

#### Technical explanation
Two things contribute to the spacing at the bottom of posts: a 12px postActivityWrapper margin and a 12px footer padding. Opening the new notes view puts it between these.

Tumblr's code does this... I think:
> No redesign, closed (gap is too big; we only want one of these): 
> postActivityWrapper yes
> footer yes
> 
> No redesign, open (bottom of footer looks slightly weird, so we want no footer):  
> postActivityWrapper yes
> footer yes
> 
> Redesign, closed:
> postActivityWrapper yes
> footer yes
> 
> Redesign, open:
> postActivityWrapper no (overridden)
> footer no (overridden)

I am fairly certain that according to this, a) the correct fix for this behavior is "remove the footer padding when removing the redesign, but only if there's a postActivityWrapper" and b) I have lost a few months off my lifespan trying to decipher this chart. I think one of the assumptions the Tumblr code makes must be incorrect here, but I'm not convinced I know exactly what.

Actually, I'm not convinced anything is real, anymore. Is the world made out of conditional obfuscated CSS selectors? I think I see through the matrix.

#### Issues this closes
n/a