### PR TITLE
Experiment: Coalesce timelineObject calls

### DIFF
--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -1,6 +1,6 @@
 import { buildStyle, filterPostElements } from '../../util/interface.js';
 import { onNewPosts } from '../../util/mutations.js';
-import { exposeTimelines, timelineObject } from '../../util/react_props.js';
+import { exposeTimelines, timelineObjectImmediate } from '../../util/react_props.js';
 
 const excludeClass = 'xkit-no-recommended-posts-done';
 const hiddenClass = 'xkit-no-recommended-posts-hidden';
@@ -13,7 +13,7 @@ const processPosts = async function (postElements) {
   await exposeTimelines();
 
   filterPostElements(postElements, { excludeClass, timeline, includeFiltered }).forEach(async postElement => {
-    const { recommendationReason } = await timelineObject(postElement.dataset.id);
+    const { recommendationReason } = await timelineObjectImmediate(postElement.dataset.id);
     if (!recommendationReason) return;
 
     const { loggingReason } = recommendationReason;

--- a/src/scripts/painter.js
+++ b/src/scripts/painter.js
@@ -1,5 +1,5 @@
 import { filterPostElements } from '../util/interface.js';
-import { timelineObject } from '../util/react_props.js';
+import { timelineObjectImmediate } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
@@ -17,7 +17,7 @@ let tagArray;
 const excludeClass = 'xkit-painter-done';
 
 const paint = postElements => filterPostElements(postElements, { excludeClass }).forEach(async postElement => {
-  const { canDelete, liked, rebloggedFromId, rebloggedRootId, rebloggedRootUuid, tags } = await timelineObject(postElement.dataset.id);
+  const { canDelete, liked, rebloggedFromId, rebloggedRootId, rebloggedRootUuid, tags } = await timelineObjectImmediate(postElement.dataset.id);
 
   const coloursToApply = [];
 

--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -3,7 +3,7 @@ import { pageModifications } from '../util/mutations.js';
 import { notify } from '../util/notifications.js';
 import { registerPostOption, unregisterPostOption } from '../util/post_actions.js';
 import { getPreferences } from '../util/preferences.js';
-import { timelineObjectMemoized, timelineObject, editPostFormTags } from '../util/react_props.js';
+import { timelineObjectMemoized, timelineObjectImmediate, editPostFormTags } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 
 const symbolId = 'ri-price-tag-3-line';
@@ -68,7 +68,7 @@ const processPostForm = async function ([selectedTagsElement]) {
       response = {},
       state = response.state,
       askingName = response.askingName
-    } = await (postIsOnScreen ? timelineObject(postId) : apiFetch(`/v2/blog/${blogName}/posts/${postId}`));
+    } = await (postIsOnScreen ? timelineObjectImmediate(postId) : apiFetch(`/v2/blog/${blogName}/posts/${postId}`));
 
     if (state === 'submission') {
       const tagsToAdd = [];

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -4,7 +4,7 @@ import { filterPostElements } from '../util/interface.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 import { onNewPosts } from '../util/mutations.js';
 import { notify } from '../util/notifications.js';
-import { timelineObject, timelineObjectMemoized } from '../util/react_props.js';
+import { timelineObjectImmediate, timelineObjectMemoized } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 
 const symbolId = 'ri-scissors-cut-line';
@@ -107,7 +107,7 @@ const processPosts = postElements => filterPostElements(postElements, { excludeC
   const editButton = postElement.querySelector('footer a[href*="/edit/"]');
   if (!editButton) { return; }
 
-  const { trail = [] } = await timelineObject(postElement.dataset.id);
+  const { trail = [] } = await timelineObjectImmediate(postElement.dataset.id);
   if (trail.length < 2) { return; }
 
   const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: onButtonClicked });


### PR DESCRIPTION
#### User-facing changes
- bit faster if you have certain scripts enabled

#### Technical explanation
This fixes the inefficiency in which a) multiple extensions calling the unmemoized version of timelineObject in the same callback all do separate injections, and b) even if you only have one, it'll do an unnecessary extra call if it's after a timelineObjectMemoized, which is dependent upon what order you enable the scripts in.

This is done by adding a second cache, which in some sense "immediately" invalidates itself. Thus, unmemoized timelineObject requests are still guaranteed to be up to date; if anything, they can resolve a bit faster than before, since all concurrent invocations resolve on what would have been the first call.



<details>

<summary>This is a bit tunable:</summary>

```js
resultPromise.then(() => { delete immediateCache[postID]; }); 
```
^ This combines all timelineObject calls that would have been fired while one is still pending. This is the most robust way to collect unnecessary function calls, but is vulnerable to a race condition in which a mutation that changes the intended result of timelineObject happens after the first call, before the second call, and before we receive the message from the first call. Maybe if you spam clicked the like button just as a post loaded you could desync the Painter UI?

```js
queueMicrotask(() => { delete immediateCache[postID]; }); 
```
^ This only combines timelineObject calls made within the current synchronous event loop (i.e. if you call timelineObject immediately in your onNewPosts callback, you're fine; if you await something first, you may not be.) It 100% guarantees no race condition, though. 

```js
Promise.race([
  resultPromise,
  new Promise(setTimeout(resolve, 0)),
  new Promise(resolve => requestAnimationFrame(resolve))
]).then(() => { delete immediateCache[postID]; }); 
```
```js
queueMicrotask(queueMicrotask(queueMicrotask(queueMicrotask(queueMicrotask(() => { delete immediateCache[postID]; })))));
```
If you really wanted the best of both worlds, you could reduce the possibility of a race condition while ensuring calls are coalesced or reduce the possibility of calls not being coalesced while ensuring there is no race condition, but this gets fairly silly.

</details>

#### Issues this closes
n/a