### PR TITLE
Expose Timelines Utility: Fix "show all posts" peepr button

### DIFF
--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -11,10 +11,10 @@ const dimClass = 'xkit-seen-posts-seen';
 const onlyDimAvatarsClass = 'xkit-seen-posts-only-dim-avatar';
 
 const dimPosts = async function (postElements) {
+  await exposeTimelines();
+
   const storageKey = 'seen_posts.seenPosts';
   const { [storageKey]: seenPosts = [] } = await browser.storage.local.get(storageKey);
-
-  await exposeTimelines();
 
   for (const postElement of filterPostElements(postElements, { excludeClass, timeline, includeFiltered })) {
     const { id } = postElement.dataset;

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -61,14 +61,22 @@ const unburyGivenPaths = async (selector) => {
   });
 };
 
-const timelineSelector = keyToCss('timeline');
+let exposedPromise;
 
 /**
  * Adds data-timeline attributes to all timeline elements on the page, set to the buried endpointApiRequest.givenPath property
  *
  * @returns {Promise<void>} Resolves when finished
  */
-export const exposeTimelines = async () => inject(unburyGivenPaths, [await timelineSelector]);
+export const exposeTimelines = async () => {
+  const timelineSelector = await keyToCss('timeline');
+
+  if (!exposedPromise) {
+    exposedPromise = inject(unburyGivenPaths, [timelineSelector]);
+    queueMicrotask(() => { exposedPromise = null; });
+  }
+  return exposedPromise;
+};
 
 const controlTagsInput = async ({ add, remove }) => {
   add = add.map(tag => tag.trim()).filter((tag, index, array) => array.indexOf(tag) === index);

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -1,5 +1,5 @@
 import { inject } from './inject.js';
-import { keyToCss, resolveExpressions } from './css_map.js';
+import { keyToCss } from './css_map.js';
 
 const cache = {};
 
@@ -61,16 +61,21 @@ const unburyGivenPaths = async (selector) => {
   });
 };
 
+let exposedPromise;
+
 /**
  * Adds data-timeline attributes to all timeline elements on the page, set to the buried endpointApiRequest.givenPath property
  *
  * @returns {Promise<void>} Resolves when finished
  */
 export const exposeTimelines = async () => {
-  const timelineSelector = await resolveExpressions`${keyToCss('timeline')}:not([data-timeline])`;
-  if (document.querySelector(timelineSelector) !== null) {
-    return inject(unburyGivenPaths, [timelineSelector]);
+  const timelineSelector = await keyToCss('timeline');
+
+  if (!exposedPromise) {
+    exposedPromise = inject(unburyGivenPaths, [timelineSelector]);
+    queueMicrotask(() => { exposedPromise = null; });
   }
+  return exposedPromise;
 };
 
 const controlTagsInput = async ({ add, remove }) => {

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -68,7 +68,7 @@ const timelineSelector = keyToCss('timeline');
  *
  * @returns {Promise<void>} Resolves when finished
  */
-export const exposeTimelines = async () => inject(unburyGivenPaths, [await timelineSelector]);
+export const exposeTimelines = async () => inject(unburyGivenPaths, [await timelineSelector], { returnsVoid: true });
 
 const controlTagsInput = async ({ add, remove }) => {
   add = add.map(tag => tag.trim()).filter((tag, index, array) => array.indexOf(tag) === index);

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -61,22 +61,14 @@ const unburyGivenPaths = async (selector) => {
   });
 };
 
-let exposedPromise;
+const timelineSelector = keyToCss('timeline');
 
 /**
  * Adds data-timeline attributes to all timeline elements on the page, set to the buried endpointApiRequest.givenPath property
  *
  * @returns {Promise<void>} Resolves when finished
  */
-export const exposeTimelines = async () => {
-  const timelineSelector = await keyToCss('timeline');
-
-  if (!exposedPromise) {
-    exposedPromise = inject(unburyGivenPaths, [timelineSelector]);
-    queueMicrotask(() => { exposedPromise = null; });
-  }
-  return exposedPromise;
-};
+export const exposeTimelines = async () => inject(unburyGivenPaths, [await timelineSelector]);
 
 const controlTagsInput = async ({ add, remove }) => {
   add = add.map(tag => tag.trim()).filter((tag, index, array) => array.indexOf(tag) === index);

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -68,7 +68,7 @@ const timelineSelector = keyToCss('timeline');
  *
  * @returns {Promise<void>} Resolves when finished
  */
-export const exposeTimelines = async () => inject(unburyGivenPaths, [await timelineSelector], { returnsVoid: true });
+export const exposeTimelines = async () => inject(unburyGivenPaths, [await timelineSelector]);
 
 const controlTagsInput = async ({ add, remove }) => {
   add = add.map(tag => tag.trim()).filter((tag, index, array) => array.indexOf(tag) === index);


### PR DESCRIPTION
#### User-facing changes
- None directly; needed to fix Show Originals

#### Technical explanation

This unconditionally processes every timeline each time exposeTimelines is run, rather than checking an exclude class to only process unprocessed timelines.

This solves the problem described in #467 in which Tumblr changes a timeline's givenPath attribute without rerendering it.

Because the querySelectorAll used to check if anything needed to be processed was just as expensive as the querySelectorAll in the processing itself, this in itself is not a significant performance degradation. This is only true if the inject call resolves within the same event loop (i.e. within the animation frame before a repaint), however, which ~~is why #454 is valuable for this PR and why it uses the returnsVoid flag added there.~~ is now true because of 454b268bba7ed92fe008c8e83a4c5ffda6bb9529.

This also implements a small throttle effect as a performance optimization, in which multiple calls to exposeTimelines at the "same time" will only perform the injection once, and all calls will return the same Promise. The "same time" is fairly strict (the calls must be in the same microtask loop, so placing an await statement before one call but not another will break this, but there's no downside in that case, it just means you saved a few less CPU cycles than you could have.)

#### Issues this closes
Resoves #467.