### PR TITLE
Implement dev-only global error notifications

### DIFF
--- a/src/background.js
+++ b/src/background.js
@@ -1,0 +1,5 @@
+const self = browser.management.getSelf();
+
+browser.runtime.onMessage.addListener(async (message, sender) => {
+  if (message === 'browser.management.getSelf') return self;
+});

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -2,7 +2,6 @@
 
 {
   const { getURL, sendMessage } = browser.runtime;
-  const extensionInfoPromise = sendMessage('browser.management.getSelf');
 
   const redpop = [...document.scripts].some(({ src }) => src.includes('/pop/'));
   const isReactLoaded = () => document.querySelector('[data-rh]') === null;
@@ -75,7 +74,7 @@
   };
 
   const runDevOnly = async () => {
-    const extensionInfo = await extensionInfoPromise;
+    const extensionInfo = await sendMessage('browser.management.getSelf');
     if (extensionInfo.installType === 'development') {
       console.log('XKit extension info:', extensionInfo);
 
@@ -88,7 +87,7 @@
   };
 
   const init = async function () {
-    await runDevOnly();
+    await runDevOnly().catch(console.log);
 
     browser.storage.onChanged.addListener(onStorageChanged);
 

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -76,18 +76,17 @@
   const runDevOnly = async () => {
     const extensionInfo = await sendMessage('browser.management.getSelf');
     if (extensionInfo.installType === 'development') {
-      console.log('XKit extension info:', extensionInfo);
+      console.log('XKit Rewritten is loaded in development mode. Extension info:', extensionInfo);
 
       const notificationsPath = getURL('/util/notifications.js');
       const { notify } = await import(notificationsPath);
-      window.addEventListener('error', (event) => { notify(`XKit error: ${event.message}`); });
-      window.addEventListener('unhandledrejection', (event) => { notify(`XKit error: ${event.reason}`); });
-      notify('XKit Rewritten developer error messaging enabled!');
+      window.addEventListener('error', (event) => { notify(`XKit Rewritten error: ${event.message}`); });
+      window.addEventListener('unhandledrejection', (event) => { notify(`XKit Rewritten error: ${event.reason}`); });
     }
   };
 
   const init = async function () {
-    await runDevOnly().catch(console.log);
+    await runDevOnly().catch(console.error);
 
     browser.storage.onChanged.addListener(onStorageChanged);
 

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -81,7 +81,8 @@
 
       const notificationsPath = getURL('/util/notifications.js');
       const { notify } = await import(notificationsPath);
-      window.onunhandledrejection = (event) => { notify(`XKit error: ${event.reason}`); };
+      window.addEventListener('error', (event) => { notify(`XKit error: ${event.message}`); });
+      window.addEventListener('unhandledrejection', (event) => { notify(`XKit error: ${event.reason}`); });
       notify('XKit Rewritten developer error messaging enabled!');
     }
   };

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -66,6 +66,14 @@
     }
   ],
 
+  "background": {
+    "scripts": [
+      "lib/browser-polyfill.min.js",
+      "background.js"
+    ],
+    "persistent": false
+  },
+
   "minimum_chrome_version": "88",
   "browser_specific_settings": {
     "gecko": {


### PR DESCRIPTION
#### User-facing changes
- n/a

#### Technical explanation
This implements a background script that checks whether the extension has been loaded in development mode, and if so, it adds `error` and `unhandledrejection` listeners to the `window` object in the extension context which will use the XKit notification system to notify the developer if they have an unhandled error or rejection. (This, of course, only catches errors in injected functions if the inject error handler works correctly, and won't work if the main script or notify utility contain errors, but it's still pretty convenient sometimes.)

Mostly a proof of concept to see if I could get dev mode detection to work. I don't actually know if it does; of course I tested that both Chromium and Firefox dev modes are detected as dev, but I can't say for sure if it false positives in non-dev mode.

#### Issues this closes
n/a