### PR TITLE
Post footer redesign tweak: Further improve tip button position

### DIFF
--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -1,6 +1,5 @@
 import { keyToClasses, keyToCss, resolveExpressions } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
-import { translate } from '../../util/language_data.js';
 import { pageModifications } from '../../util/mutations.js';
 
 const removePaddingClass = 'xkit-footer-padding-fix';
@@ -16,8 +15,17 @@ resolveExpressions`
   padding-bottom: 0;
 }
 
-article footer button[aria-label="${translate('Tip')}"] {
-  margin-left: var(--post-padding);
+/*
+${keyToCss('noteCount')} {
+  align-items: flex-end;
+  flex-grow: 1;
+  padding-right: 0;
+}
+*/
+
+${keyToCss('noteCount')} {
+  align-items: flex-end;
+  gap: var(--post-padding);
 }
 
 .xkit-control-button-container {

--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -15,16 +15,8 @@ resolveExpressions`
   padding-bottom: 0;
 }
 
-/*
 ${keyToCss('noteCount')} {
-  align-items: flex-end;
-  flex-grow: 1;
-  padding-right: 0;
-}
-*/
-
-${keyToCss('noteCount')} {
-  align-items: flex-end;
+  align-items: center;
   gap: var(--post-padding);
 }
 


### PR DESCRIPTION
#### User-facing changes

Fixes a visual issue where the tip indicator was misplaced on posts without any notes. (Also fixes a minor vertical positioning oddity regardless of whether there are notes or not.)

CSS for two positioning option variants is supplied, one commented. I don't think I have a preference.

| Before |
| --- |
| <img width="597" src="https://user-images.githubusercontent.com/8336245/153539963-90d483eb-f7a8-4a6b-ab70-df33b077d544.png"> |

| After (left align) |
| --- |
| <img width="597" src="https://user-images.githubusercontent.com/8336245/153539955-889a17c6-f165-4a49-ab92-0e52217794f8.png"> |

| After (right align; code is commented) |
| --- |
| <img width="597" src="https://user-images.githubusercontent.com/8336245/153539961-24730b6c-c632-4563-aeed-391c8d332a47.png"> |

#### Technical explanation
Something something flexbox. I have basically no idea - I just poked it until it looked right. https://caniuse.com/flexbox-gap seemed within our supported browsers even though I've never heard of it before.

#### Issues this closes
n/a; I didn't bother making another issue
