### PR TITLE
Post footer redesign tweak: Improve overflow behavior

### DIFF
--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -20,6 +20,10 @@ ${keyToCss('noteCount')} {
   gap: var(--post-padding);
 }
 
+${keyToCss('controls')} {
+  margin-left: auto;
+}
+
 .xkit-control-button-container {
   margin-left: 20px;
 }

--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -15,12 +15,12 @@ resolveExpressions`
   padding-bottom: 0;
 }
 
-${keyToCss('noteCount')} {
+article footer > ${keyToCss('noteCount')} {
   align-items: center;
   gap: var(--post-padding);
 }
 
-${keyToCss('controls')} {
+article footer > ${keyToCss('controls')} {
   margin-left: auto;
 }
 


### PR DESCRIPTION
#### User-facing changes

Improves the behavior of the post footer redesign tweak if there are a large number of icons.

| Before |
| --- |
| <img width="668" src="https://user-images.githubusercontent.com/8336245/153604000-e45200fa-bc20-487a-9d91-45fd2d5fff9b.png"> |

| After |
| --- |
| <img width="668" src="https://user-images.githubusercontent.com/8336245/153603996-064dd4c8-0c8b-4bdb-9700-44e5cf2ce30b.png"> |

#### Technical explanation

I was hoping there would be some magic keyword like `justify-self` for this, but I guess it doesn't work in flexbox (kinda reasonable).

#### Issues this closes
Resolves #435.