### PR TITLE
Visible Alt Text Tweak: Improve wrapping on tiny images

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -51,8 +51,9 @@ figure.accesskit-visible-alt-text {
 }
 
 figure.accesskit-visible-alt-text figcaption {
+  box-sizing: border-box;
   height: 100%;
-  min-width: min-content;
+  min-width: calc((min(540px, 100vw) / 3) - (4px * 2));
   padding: var(--post-header-vertical-padding) var(--post-padding);
   overflow: hidden;
 

--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -52,6 +52,7 @@ figure.accesskit-visible-alt-text {
 
 figure.accesskit-visible-alt-text figcaption {
   height: 100%;
+  min-width: min-content;
   padding: var(--post-header-vertical-padding) var(--post-padding);
   overflow: hidden;
 


### PR DESCRIPTION
#### User-facing changes

Improves alt text captions wrapping on very small images.

Before:

<img width="595" src="https://user-images.githubusercontent.com/8336245/153731992-cebbaadb-73d1-4998-b183-adf833bbd699.png">

After:
<img width="595" src="https://user-images.githubusercontent.com/8336245/153731950-81e2cb25-3ee0-4e55-9e9c-0b03170a843a.png">

<img width="599" src="https://user-images.githubusercontent.com/8336245/153732000-a97a34db-3aec-48e2-8ccf-2de247872c03.png">

#### Technical explanation

`min-content` sets the minimum width to the width of the longest word. This is not perfect:

<img width="599" src="https://user-images.githubusercontent.com/8336245/153732024-e7a9afb7-ec97-4c1b-bbe9-ec5884d975c0.png">

If you know of a way to improve this, that would be awesome. Perhaps just setting the minimum width to a reasonable quantity is better? But that doesn't adapt nicely to single word captions, so I dunno.

Edit: Oh, yeah, and I have no idea what the idiomatic css rule order is supposed to be.

#### Issues this closes
n/a