### PR TITLE
Fix pageModifications processing unmounted elements

### DIFF
--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -62,7 +62,7 @@ const onBeforeRepaint = () => {
   const addedNodes = mutationsPool
     .splice(0)
     .flatMap(({ addedNodes }) => [...addedNodes])
-    .filter(addedNode => addedNode instanceof Element);
+    .filter(addedNode => addedNode instanceof Element && addedNode.isConnected);
 
   if (addedNodes.length === 0) return;
 


### PR DESCRIPTION
#### User-facing changes
- Fixes buggy behavior when clicking to navigate while posts are loading

#### Technical explanation
This filters elements out of pageModifications if they aren't mounted to the DOM, i.e. if they were added and then removed before onBeforeRepaint fires. This includes a bunch of <img> elements while scrolling, some loading indicators, a few random things, and notably the entire post list if you click to navigate twice in a row while Tumblr's javascript is still loading your first navigation action. This should remove some unnecessary processing done by extensions like AccessKit Visible Alt Text.

I looked through the list of listeners registered to pageModifications and I don't see anything this would obviously break.

#### Issues this closes
Discussion #479 (fixed in practice, though that should probably have another fallback just in case of another type of failure)