### PR TITLE
Scroll to Bottom: Scroll Peepr if open

### DIFF
--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -3,20 +3,24 @@ import { translate } from '../util/language_data.js';
 import { pageModifications } from '../util/mutations.js';
 
 let knightRiderLoaderSelector;
+let peeprSelector;
+let timelineSelector;
 let scrollToBottomButton;
 let scrollToBottomIcon;
 let active = false;
+let scrollElement;
 
 const scrollToBottom = () => {
-  window.scrollTo({ top: document.documentElement.scrollHeight });
-  if (document.querySelector(knightRiderLoaderSelector) === null) {
+  scrollElement.scrollTo({ top: scrollElement.scrollHeight });
+  if (scrollElement.querySelector(knightRiderLoaderSelector) === null) {
     stopScrolling();
   }
 };
 const observer = new ResizeObserver(scrollToBottom);
 
 const startScrolling = () => {
-  observer.observe(document.documentElement);
+  scrollElement = document.querySelector(peeprSelector) || document.documentElement;
+  observer.observe(scrollElement.querySelector(timelineSelector));
   active = true;
   scrollToBottomIcon.style.fill = 'rgb(var(--yellow))';
   scrollToBottom();
@@ -61,7 +65,14 @@ const addButtonToPage = async function ([scrollToTopButton]) {
 };
 
 export const main = async function () {
-  knightRiderLoaderSelector = await resolveExpressions`main ${keyToCss('loader')} ${keyToCss('knightRiderLoader')}`;
+  knightRiderLoaderSelector = await resolveExpressions`
+    ${keyToCss('timeline')} ${keyToCss('loader')} ${keyToCss('knightRiderLoader')}
+  `;
+  peeprSelector = await resolveExpressions`
+    ${keyToCss('peepr')},
+    ${keyToCss('drawerContent')} > ${keyToCss('scrollContainer')}
+  `;
+  timelineSelector = await keyToCss('timeline');
 
   const scrollToTopLabel = await translate('Scroll to top');
   pageModifications.register(`button[aria-label="${scrollToTopLabel}"]`, addButtonToPage);

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -76,6 +76,7 @@ export const main = async function () {
 
   const scrollToTopLabel = await translate('Scroll to top');
   pageModifications.register(`button[aria-label="${scrollToTopLabel}"]`, addButtonToPage);
+  pageModifications.register(peeprSelector, stopScrolling);
 };
 
 export const clean = async function () {


### PR DESCRIPTION
#### User-facing changes
- Scroll to Bottom's button, which is displayed when Peepr is open, will scroll the Peepr container in the foreground when clicked instead of scrolling the background. This feels quite nice and works as I think one would expect with the new Peepr UI preview.

Current rough edges with this:
 - Tumblr still displays the scroll to top button when new Peepr is open, and it still scrolls the page in the background. I would view this as a Tumblr bug (I guess I'll go report it). If Staff fixes this bug in a way that breaks Scroll to Bottom, I will be sad.
 - I added a quick oneliner to stop scrolling if you open Peepr while it's active (although... why), but closing Peepr while it's active isn't totally elegant (scrolling stops, but the UI state is wrong until you click the button again). This could be fixed via simply stopping on any mouse click anywhere, or... idk, another way? Any ideas?

#### Technical explanation

I had to run the ResizeObserver on the timeline element instead of the actual element that gets scrolled... not sure why, actually. I attached a ResizeObserver to every relevant element to test and only `timeline` and `body` (and `main` and `layout` in new Peepr) trigger it on infinite scroll pagination.

Staff in their infinite wisdom decided to (at least currently) reuse the "scrollContainer" name from a component in blog carousels for the relevant element in new Peepr.

I have no idea how to elegantly indent resolveExpressions statements.

We could probably save like 4ms per load by storing the timeline element along with the scroll element and simplifying knightRiderLoaderSelector, but, eh.

#### Issues this closes
n/a