### PR TITLE
Quick Tags: replace quotes in tags input

### DIFF
--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -24,6 +24,14 @@ const popupInput = Object.assign(document.createElement('input'), {
   autocomplete: 'off',
   onkeydown: event => event.stopPropagation()
 });
+const doSmartQuotes = ({ currentTarget }) => {
+  const { value } = currentTarget;
+  currentTarget.value = value
+    .replace(/^"/, '\u201C')
+    .replace(/ "/g, ' \u201C')
+    .replace(/"/g, '\u201D');
+};
+popupInput.addEventListener('input', doSmartQuotes);
 popupForm.appendChild(popupInput);
 
 const postOptionPopupElement = Object.assign(document.createElement('div'), { id: 'quick-tags-post-option' });


### PR DESCRIPTION
Yep, it's just 66cb198 applied to quick reblog.

#### User-facing changes
- prevents unintentionally triggering Tumblr's weird handling of quotes in the tags field

I do wish there was a clean way to integrate this into the post form, but it obviously makes no sense to add a quick tags text input to a form that already has a text input for tags, and silently editing the tags would make sense as a standalone extension or tweak, maybe, but would be a weird side effect of quick tags itself.

If this were really common, it could be a separate fix-my-quotes-please post form button (perhaps one that only showed up if you had quote characters in your tags), but eh.

#### Technical explanation
n/a

#### Issues this closes
#489 again