### PR TITLE
Hide scroll to bottom with Peepr open

### DIFF
--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -1,11 +1,21 @@
 import { keyToClasses, keyToCss, resolveExpressions } from '../util/css_map.js';
 import { translate } from '../util/language_data.js';
 import { pageModifications } from '../util/mutations.js';
+import { buildStyle } from '../util/interface.js';
+
+const scrollToBottomButtonId = 'xkit-scroll-to-bottom-button';
 
 let knightRiderLoaderSelector;
 let scrollToBottomButton;
 let scrollToBottomIcon;
 let active = false;
+
+const styleElement = buildStyle();
+resolveExpressions`
+  ${keyToCss('isPeeprShowing')} #${scrollToBottomButtonId} {
+    display: none;
+  }
+`.then(css => { styleElement.textContent = css; });
 
 const scrollToBottom = () => {
   window.scrollTo({ top: document.documentElement.scrollHeight });
@@ -49,6 +59,7 @@ const addButtonToPage = async function ([scrollToTopButton]) {
     scrollToBottomButton.style.marginTop = '0.5ch';
     scrollToBottomButton.style.transform = 'rotate(180deg)';
     scrollToBottomButton.addEventListener('click', onClick);
+    scrollToBottomButton.id = scrollToBottomButtonId;
 
     scrollToBottomIcon = scrollToBottomButton.querySelector('svg');
     scrollToBottomIcon.style.fill = active ? 'rgb(var(--yellow))' : '';
@@ -65,6 +76,7 @@ export const main = async function () {
 
   const scrollToTopLabel = await translate('Scroll to top');
   pageModifications.register(`button[aria-label="${scrollToTopLabel}"]`, addButtonToPage);
+  document.head.append(styleElement);
 };
 
 export const clean = async function () {
@@ -72,4 +84,5 @@ export const clean = async function () {
   pageModifications.unregister(checkForButtonRemoved);
   stopScrolling();
   scrollToBottomButton?.remove();
+  styleElement.remove();
 };


### PR DESCRIPTION
#### User-facing changes
- Hides the scroll to bottom with Peepr open. It scrolls the background container, so it doesn't make sense to show it if something is on top of what it would affect.

#### Technical explanation
`isPeeprShowing` is used by both the beta and old peepr containers.

#### Issues this closes
n/a