### PR TITLE
Mutual Checker: Minor refactor of reprocessing

### DIFF
--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -25,8 +25,7 @@ const needsReprocessing = postElement =>
 
 const addIcons = function (postElements) {
   filterPostElements(postElements, { includeFiltered: true }).forEach(async postElement => {
-    if (postElement.classList.contains(excludeClass) && !needsReprocessing(postElement)) return;
-    postElement.classList.add(excludeClass);
+    if (needsReprocessing(postElement) === false) return;
 
     const postAttribution = postElement.querySelector(postAttributionSelector);
     if (postAttribution === null) { return; }

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -19,13 +19,13 @@ let primaryBlogName;
 let postAttributionSelector;
 let icon;
 
-const needsReprocessing = postElement =>
+const alreadyProcessed = postElement =>
   postElement.classList.contains(mutualsClass) &&
-  postElement.querySelector(`.${mutualIconClass}`) === null;
+  postElement.querySelector(`.${mutualIconClass}`);
 
 const addIcons = function (postElements) {
   filterPostElements(postElements, { includeFiltered: true }).forEach(async postElement => {
-    if (needsReprocessing(postElement) === false) return;
+    if (alreadyProcessed(postElement)) return;
 
     const postAttribution = postElement.querySelector(postAttributionSelector);
     if (postAttribution === null) { return; }

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -1,4 +1,4 @@
-import { postSelector, filterPostElements } from '../util/interface.js';
+import { filterPostElements } from '../util/interface.js';
 import { timelineObjectMemoized } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { getPrimaryBlogName } from '../util/user_blogs.js';
@@ -19,12 +19,15 @@ let primaryBlogName;
 let postAttributionSelector;
 let icon;
 
-const addIcons = function (postElements) {
-  [...document.querySelectorAll(`${postSelector}.${mutualsClass}`)]
-    .filter(postElement => postElement.querySelector(`.${mutualIconClass}`) === null)
-    .forEach(postElement => postElement.classList.remove(excludeClass));
+const needsReprocessing = postElement =>
+  postElement.classList.contains(mutualsClass) &&
+  postElement.querySelector(`.${mutualIconClass}`) === null;
 
-  filterPostElements(postElements, { excludeClass, includeFiltered: true }).forEach(async postElement => {
+const addIcons = function (postElements) {
+  filterPostElements(postElements, { includeFiltered: true }).forEach(async postElement => {
+    if (postElement.classList.contains(excludeClass) && !needsReprocessing(postElement)) return;
+    postElement.classList.add(excludeClass);
+
     const postAttribution = postElement.querySelector(postAttributionSelector);
     if (postAttribution === null) { return; }
 

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -5,7 +5,6 @@ import { getPrimaryBlogName } from '../util/user_blogs.js';
 import { keyToCss } from '../util/css_map.js';
 import { onNewPosts } from '../util/mutations.js';
 
-const excludeClass = 'xkit-mutual-checker-done';
 const mutualIconClass = 'xkit-mutual-icon';
 const mutualsClass = 'from-mutual';
 
@@ -86,8 +85,7 @@ export const main = async function () {
 export const clean = async function () {
   onNewPosts.removeListener(addIcons);
 
-  $(`.${excludeClass}`)
-    .removeClass(excludeClass)
+  $(`.${mutualsClass}`)
     .removeClass(mutualsClass);
   $(`.${mutualIconClass}`).remove();
 };

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -85,8 +85,7 @@ export const main = async function () {
 export const clean = async function () {
   onNewPosts.removeListener(addIcons);
 
-  $(`.${mutualsClass}`)
-    .removeClass(mutualsClass);
+  $(`.${mutualsClass}`).removeClass(mutualsClass);
   $(`.${mutualIconClass}`).remove();
 };
 


### PR DESCRIPTION
#### User-facing changes
- n/a

#### Technical explanation
This is a minor refactor of the reprocessing logic in mutual checker which ensures that when you click to unfilter a post, it is processed again. Rather than querying the entire page for these posts, this just checks the new posts.

I initially kept the "remove excludeClass if necessary" logic:

```js
filterPostElements(postElements, { includeFiltered: true }).forEach(postElement => {
  if (postElement.classList.contains(mutualsClass) && postElement.querySelector(`.${mutualIconClass}`) === null) {
    postElement.classList.remove(excludeClass);
  }
});
```

which works just as well as the committed code, which replaces the built-in exposeTimelines logic with one with an exception.

This PR is entirely a matter of which you think is more clear. The performance benefit is not significant and the current code is fine.

#### Issues this closes
n/a