### PR TITLE
Fix mega edit utility with new inject() function

### DIFF
--- a/src/util/mega_editor.js
+++ b/src/util/mega_editor.js
@@ -44,7 +44,7 @@ export const megaEdit = async function (postIds, options) {
     delete requestBody.tags;
   }
 
-  return inject((resource, body) => fetch(resource, {
+  return inject(async (resource, body) => fetch(resource, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
     body


### PR DESCRIPTION
#### User-facing changes
- n/a

#### Technical explanation
This adds the async keyword to the mega-edit utility so that it uses the asynchronous return path in the new inject() function.

I... admittedly PR'd this without testing it since I didn't save my test code for the mega edit utility as far as I can tell. Whoops. Might get to it later, though.

#### Issues this closes
n/a