### PR TITLE
TimelineObject utility: Process elements directly

### DIFF
--- a/src/scripts/cleanfeed.js
+++ b/src/scripts/cleanfeed.js
@@ -2,7 +2,7 @@ import { onNewPosts } from '../util/mutations.js';
 import { keyToCss } from '../util/css_map.js';
 import { buildStyle, filterPostElements } from '../util/interface.js';
 import { translate } from '../util/language_data.js';
-import { timelineObjectMemoized } from '../util/react_props.js';
+import { timelineObject } from '../util/react_props.js';
 import { getPreferences } from '../util/preferences.js';
 
 const hiddenClass = 'xkit-cleanfeed-filtered';
@@ -21,7 +21,7 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
     return;
   }
 
-  const { blog: { name, isAdult }, trail } = await timelineObjectMemoized(postElement.dataset.id);
+  const { blog: { name, isAdult }, trail } = await timelineObject(postElement);
 
   if (isAdult || localFlaggedBlogs.includes(name)) {
     postElement.classList.add(hiddenClass);

--- a/src/scripts/mirror_posts.js
+++ b/src/scripts/mirror_posts.js
@@ -1,7 +1,7 @@
 import { postSelector } from '../util/interface.js';
 import { registerMeatballItem, unregisterMeatballItem } from '../util/meatballs.js';
 import { showModal, modalCancelButton } from '../util/modals.js';
-import { timelineObjectMemoized } from '../util/react_props.js';
+import { timelineObject } from '../util/react_props.js';
 
 const meatballButtonId = 'mirror_posts';
 const meatballButtonLabel = 'Mirror this post';
@@ -26,9 +26,8 @@ archiveDotOrgForm.append(archiveDotOrgInput, archiveDotOrgButton);
 
 const onButtonClicked = async function ({ currentTarget }) {
   const postElement = currentTarget.closest(postSelector);
-  const postID = postElement.dataset.id;
 
-  const { postUrl } = await timelineObjectMemoized(postID);
+  const { postUrl } = await timelineObject(postElement);
   const ampUrl = `${postUrl}/amp`;
 
   const archiveTodayButton = Object.assign(document.createElement('button'), {

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -1,5 +1,5 @@
 import { postSelector, filterPostElements } from '../util/interface.js';
-import { timelineObjectMemoized } from '../util/react_props.js';
+import { timelineObject } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { getPrimaryBlogName } from '../util/user_blogs.js';
 import { keyToCss } from '../util/css_map.js';
@@ -33,7 +33,7 @@ const addIcons = function (postElements) {
     if (!blogName) return;
 
     if (following[blogName] === undefined) {
-      const { blog } = await timelineObjectMemoized(postElement.dataset.id);
+      const { blog } = await timelineObject(postElement);
       if (blogName === blog.name) {
         following[blogName] = Promise.resolve(blog.followed && !blog.isMember);
       } else {

--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -13,7 +13,7 @@ const processPosts = async function (postElements) {
   await exposeTimelines();
 
   filterPostElements(postElements, { excludeClass, timeline, includeFiltered }).forEach(async postElement => {
-    const { recommendationReason } = await timelineObject(postElement.dataset.id);
+    const { recommendationReason } = await timelineObject(postElement);
     if (!recommendationReason) return;
 
     const { loggingReason } = recommendationReason;

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -4,7 +4,7 @@ import { pageModifications } from '../util/mutations.js';
 import { inject } from '../util/inject.js';
 import { keyToCss } from '../util/css_map.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
-import { timelineObjectMemoized } from '../util/react_props.js';
+import { timelineObject } from '../util/react_props.js';
 
 const storageKey = 'notificationblock.blockedPostTargetIDs';
 const meatballButtonBlockId = 'notificationblock-block';
@@ -45,7 +45,7 @@ const onButtonClicked = async function ({ currentTarget }) {
   const postElement = currentTarget.closest(postSelector);
   const { id } = postElement.dataset;
 
-  const { rebloggedRootId } = await timelineObjectMemoized(id);
+  const { rebloggedRootId } = await timelineObject(postElement);
   const rootId = rebloggedRootId || id;
   const shouldBlockNotifications = blockedPostTargetIDs.includes(rootId) === false;
 
@@ -81,14 +81,16 @@ const onButtonClicked = async function ({ currentTarget }) {
   });
 };
 
-const blockPostFilter = async ({ dataset: { id } }) => {
-  const { canEdit, rebloggedRootId } = await timelineObjectMemoized(id);
+const blockPostFilter = async (postElement) => {
+  const { id } = postElement.dataset;
+  const { canEdit, rebloggedRootId } = await timelineObject(postElement);
   const rootId = rebloggedRootId || id;
   return canEdit && blockedPostTargetIDs.includes(rootId) === false;
 };
 
-const unblockPostFilter = async ({ dataset: { id } }) => {
-  const { rebloggedRootId } = await timelineObjectMemoized(id);
+const unblockPostFilter = async (postElement) => {
+  const { id } = postElement.dataset;
+  const { rebloggedRootId } = await timelineObject(postElement);
   const rootId = rebloggedRootId || id;
   return blockedPostTargetIDs.includes(rootId);
 };

--- a/src/scripts/painter.js
+++ b/src/scripts/painter.js
@@ -17,7 +17,7 @@ let tagArray;
 const excludeClass = 'xkit-painter-done';
 
 const paint = postElements => filterPostElements(postElements, { excludeClass }).forEach(async postElement => {
-  const { canDelete, liked, rebloggedFromId, rebloggedRootId, rebloggedRootUuid, tags } = await timelineObject(postElement.dataset.id);
+  const { canDelete, liked, rebloggedFromId, rebloggedRootId, rebloggedRootUuid, tags } = await timelineObject(postElement);
 
   const coloursToApply = [];
 

--- a/src/scripts/postblock.js
+++ b/src/scripts/postblock.js
@@ -1,7 +1,7 @@
 import { filterPostElements, postSelector } from '../util/interface.js';
 import { registerMeatballItem, unregisterMeatballItem } from '../util/meatballs.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
-import { timelineObjectMemoized } from '../util/react_props.js';
+import { timelineObject } from '../util/react_props.js';
 import { onNewPosts, pageModifications } from '../util/mutations.js';
 
 const meatballButtonId = 'postblock';
@@ -14,7 +14,7 @@ const processPosts = async function (postElements) {
 
   filterPostElements(postElements, { includeFiltered: true }).forEach(async postElement => {
     const postID = postElement.dataset.id;
-    const { rebloggedRootId } = await timelineObjectMemoized(postID);
+    const { rebloggedRootId } = await timelineObject(postElement);
 
     const rootID = rebloggedRootId || postID;
 
@@ -30,7 +30,7 @@ const onButtonClicked = async function ({ currentTarget }) {
   const postElement = currentTarget.closest(postSelector);
   const postID = postElement.dataset.id;
 
-  const { rebloggedRootId } = await timelineObjectMemoized(postID);
+  const { rebloggedRootId } = await timelineObject(postElement);
   const rootID = rebloggedRootId || postID;
 
   showModal({

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -1,5 +1,5 @@
 import { sha256 } from '../util/crypto.js';
-import { timelineObjectMemoized } from '../util/react_props.js';
+import { timelineObject } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { postSelector, filterPostElements, postType } from '../util/interface.js';
 import { getUserBlogs } from '../util/user_blogs.js';
@@ -100,7 +100,8 @@ const showPopupOnHover = ({ currentTarget }) => {
   currentTarget.closest('div').appendChild(popupElement);
   popupElement.parentNode.addEventListener('mouseleave', removePopupOnLeave);
 
-  const thisPostID = currentTarget.closest(postSelector).dataset.id;
+  const thisPost = currentTarget.closest(postSelector);
+  const thisPostID = thisPost.dataset.id;
   if (thisPostID !== lastPostID) {
     if (!rememberLastBlog) {
       blogSelector.value = blogSelector.options[0].value;
@@ -108,7 +109,7 @@ const showPopupOnHover = ({ currentTarget }) => {
     commentInput.value = '';
     [...quickTagsList.children].forEach(({ dataset }) => delete dataset.checked);
     tagsInput.value = '';
-    timelineObjectMemoized(thisPostID).then(({ tags, trail, content, layout, blogName, rebloggedRootName }) => {
+    timelineObject(thisPost).then(({ tags, trail, content, layout, blogName, rebloggedRootName }) => {
       suggestableTags = tags;
       if (blogName) suggestableTags.push(blogName);
       if (rebloggedRootName) suggestableTags.push(rebloggedRootName);
@@ -141,7 +142,8 @@ const reblogPost = async function ({ currentTarget }) {
   actionButtons.disabled = true;
   lastPostID = null;
 
-  const postID = currentTarget.closest(postSelector).dataset.id;
+  const postElement = currentTarget.closest(postSelector);
+  const postID = postElement.dataset.id;
   const { state } = currentTarget.dataset;
 
   const blog = blogSelector.value;
@@ -150,7 +152,7 @@ const reblogPost = async function ({ currentTarget }) {
     ...reblogTag ? [reblogTag] : [],
     ...(state === 'queue' && queueTag) ? [queueTag] : []
   ].join(',');
-  const { blog: { uuid: parentTumblelogUUID }, reblogKey, rebloggedRootId } = await timelineObjectMemoized(postID);
+  const { blog: { uuid: parentTumblelogUUID }, reblogKey, rebloggedRootId } = await timelineObject(postElement);
 
   const requestPath = `/v2/blog/${blog}/posts`;
 
@@ -200,7 +202,7 @@ const processPosts = async function (postElements) {
   const { [alreadyRebloggedStorageKey]: alreadyRebloggedList = [] } = await browser.storage.local.get(alreadyRebloggedStorageKey);
   filterPostElements(postElements).forEach(async postElement => {
     const { id } = postElement.dataset;
-    const { rebloggedRootId } = await timelineObjectMemoized(id);
+    const { rebloggedRootId } = await timelineObject(postElement);
 
     const rootID = rebloggedRootId || id;
 

--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -4,7 +4,7 @@ import { pageModifications } from '../util/mutations.js';
 import { notify } from '../util/notifications.js';
 import { registerPostOption, unregisterPostOption } from '../util/post_actions.js';
 import { getPreferences } from '../util/preferences.js';
-import { timelineObjectMemoized, timelineObject, editPostFormTags } from '../util/react_props.js';
+import { timelineObject, editPostFormTags } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 
 const symbolId = 'ri-price-tag-3-line';
@@ -71,13 +71,13 @@ const processPostForm = async function ([selectedTagsElement]) {
     });
   } else if ((answerTag || autoTagAsker) && location.pathname.startsWith('/edit')) {
     const [blogName, postId] = location.pathname.split('/').slice(2);
-    const postIsOnScreen = document.querySelector(`[tabindex="-1"][data-id="${postId}"]`) !== null;
+    const postOnScreen = document.querySelector(`[tabindex="-1"][data-id="${postId}"]`);
 
     const {
       response = {},
       state = response.state,
       askingName = response.askingName
-    } = await (postIsOnScreen ? timelineObject(postId) : apiFetch(`/v2/blog/${blogName}/posts/${postId}`));
+    } = await (postOnScreen ? timelineObject(postOnScreen) : apiFetch(`/v2/blog/${blogName}/posts/${postId}`));
 
     if (state === 'submission') {
       const tagsToAdd = [];
@@ -117,7 +117,7 @@ const togglePostOptionPopupDisplay = async function ({ target, currentTarget }) 
 
 const addTagsToPost = async function ({ postElement, inputTags = [] }) {
   const postId = postElement.dataset.id;
-  const { blog: { uuid } } = await timelineObjectMemoized(postId);
+  const { blog: { uuid } } = await timelineObject(postElement);
 
   const {
     response: {

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -1,5 +1,5 @@
 import { filterPostElements } from '../util/interface.js';
-import { timelineObjectMemoized, exposeTimelines } from '../util/react_props.js';
+import { timelineObject, exposeTimelines } from '../util/react_props.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
 import { keyToCss } from '../util/css_map.js';
@@ -58,7 +58,7 @@ const processPosts = async function (postElements) {
   filterPostElements(postElements, { includeFiltered })
     .filter(postElement => postElement.matches(`[data-timeline].${activeTimelineClass} div`))
     .forEach(async postElement => {
-      const { rebloggedRootId, canEdit, content, blogName } = await timelineObjectMemoized(postElement.dataset.id);
+      const { rebloggedRootId, canEdit, content, blogName } = await timelineObject(postElement);
 
       if (!rebloggedRootId) { return; }
       if (showOwnReblogs && canEdit) { return; }

--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -1,6 +1,6 @@
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { filterPostElements } from '../util/interface.js';
-import { exposeTimelines, timelineObjectMemoized } from '../util/react_props.js';
+import { exposeTimelines, timelineObject } from '../util/react_props.js';
 import { keyToCss } from '../util/css_map.js';
 import { onNewPosts, pageModifications } from '../util/mutations.js';
 import { translate } from '../util/language_data.js';
@@ -30,7 +30,7 @@ const processPosts = async function (postElements) {
   await exposeTimelines();
 
   for (const postElement of filterPostElements(postElements, { excludeClass, timeline, includeFiltered })) {
-    const { timestamp } = await timelineObjectMemoized(postElement.dataset.id);
+    const { timestamp } = await timelineObject(postElement);
     const savedTimestamp = timestamps[currentTag] || 0;
 
     if (timestamp > savedTimestamp) {

--- a/src/scripts/timestamps.js
+++ b/src/scripts/timestamps.js
@@ -1,5 +1,5 @@
 import { getPostElements } from '../util/interface.js';
-import { timelineObjectMemoized } from '../util/react_props.js';
+import { timelineObject } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { onNewPosts } from '../util/mutations.js';
 import { getPreferences } from '../util/preferences.js';
@@ -110,7 +110,7 @@ const addPostTimestamps = async function () {
   getPostElements({ excludeClass: 'xkit-timestamps-done' }).forEach(async postElement => {
     const { id } = postElement.dataset;
 
-    const { timestamp, postUrl } = await timelineObjectMemoized(id);
+    const { timestamp, postUrl } = await timelineObject(postElement);
     cache[id] = Promise.resolve(timestamp);
 
     const noteCountElement = postElement.querySelector(noteCountSelector);
@@ -144,7 +144,7 @@ const removePostTimestamps = function () {
 
 const addReblogTimestamps = async function () {
   getPostElements({ excludeClass: 'xkit-reblog-timestamps-done' }).forEach(async postElement => {
-    let { trail } = await timelineObjectMemoized(postElement.dataset.id);
+    let { trail } = await timelineObject(postElement);
     if (!trail.length) {
       return;
     }

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -4,7 +4,7 @@ import { filterPostElements, postSelector } from '../util/interface.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 import { onNewPosts } from '../util/mutations.js';
 import { notify } from '../util/notifications.js';
-import { timelineObject, timelineObjectMemoized } from '../util/react_props.js';
+import { timelineObject } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 
 const symbolId = 'ri-scissors-cut-line';
@@ -23,7 +23,7 @@ const onButtonClicked = async function ({ currentTarget }) {
     blog: { uuid },
     rebloggedRootUuid,
     rebloggedRootId
-  } = await timelineObjectMemoized(postId);
+  } = await timelineObject(postElement);
 
   if (rebloggedRootUuid && rebloggedRootId) {
     const { response: { shouldOpenInLegacy } } = await apiFetch(`/v2/blog/${rebloggedRootUuid}/posts/${rebloggedRootId}`);
@@ -107,7 +107,7 @@ const processPosts = postElements => filterPostElements(postElements, { excludeC
   const editButton = postElement.querySelector('footer a[href*="/edit/"]');
   if (!editButton) { return; }
 
-  const { trail = [] } = await timelineObject(postElement.dataset.id);
+  const { trail = [] } = await timelineObject(postElement);
   if (trail.length < 2) { return; }
 
   const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: onButtonClicked });

--- a/src/scripts/tweaks/hide_my_posts.js
+++ b/src/scripts/tweaks/hide_my_posts.js
@@ -1,7 +1,7 @@
 import { getPrimaryBlogName } from '../../util/user_blogs.js';
 import { onNewPosts } from '../../util/mutations.js';
 import { buildStyle, filterPostElements } from '../../util/interface.js';
-import { exposeTimelines, timelineObjectMemoized } from '../../util/react_props.js';
+import { exposeTimelines, timelineObject } from '../../util/react_props.js';
 
 const excludeClass = 'xkit-tweaks-hide-my-posts-done';
 const timeline = /\/v2\/timeline\/dashboard/;
@@ -14,7 +14,7 @@ let primaryBlogName;
 const processPosts = async function (postElements) {
   await exposeTimelines();
   filterPostElements(postElements, { excludeClass, timeline }).forEach(async postElement => {
-    const { canEdit, isSubmission, postAuthor } = await timelineObjectMemoized(postElement.dataset.id);
+    const { canEdit, isSubmission, postAuthor } = await timelineObject(postElement);
 
     if (canEdit && (isSubmission || postAuthor === primaryBlogName || postAuthor === undefined)) {
       postElement.classList.add(hiddenClass);

--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -3,7 +3,7 @@ const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 
 /**
  * @param {Function} func - Function to run in the page context (can be async)
- * @param {Array} args - Array of arguments to pass to the function via spread
+ * @param {Array} [args] - Array of arguments to pass to the function via spread
  * @param {Element} [target] - Element to append script to; will be accessible as
  *                             document.currentScript.parentElement in the injected function.
  * @returns {Promise<any>} The return value of the function, or the caught exception

--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -4,7 +4,8 @@ const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 /**
  * @param {Function} func - Function to run in the page context (can be async)
  * @param {Array} args - Array of arguments to pass to the function via spread
- * @param {Element} target
+ * @param {Element} [target] - Element to append script to; will be accessible as
+ *                             document.currentScript.parentElement in the injected function.
  * @returns {Promise<any>} The return value of the function, or the caught exception
  */
 export const inject = async (func, args = [], target = document.documentElement) => {

--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -4,9 +4,10 @@ const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
 /**
  * @param {Function} func - Function to run in the page context (can be async)
  * @param {Array} args - Array of arguments to pass to the function via spread
+ * @param {Element} target
  * @returns {Promise<any>} The return value of the function, or the caught exception
  */
-export const inject = async (func, args = []) => {
+export const inject = async (func, args = [], target = document.documentElement) => {
   const script = document.createElement('script');
   const name = `xkit$${func.name || 'injected'}`;
   const async = func instanceof AsyncFunction;
@@ -46,11 +47,11 @@ export const inject = async (func, args = []) => {
         attributes: true,
         attributeFilter: ['data-result', 'data-exception']
       });
-      document.documentElement.append(script);
+      target.append(script);
       script.remove();
     });
   } else {
-    document.documentElement.appendChild(script);
+    target.append(script);
     script.remove();
     return JSON.parse(script.dataset.result);
   }

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -26,7 +26,7 @@ export const timelineObject = async function (postElement) {
   if (!timelineObjectCache.has(postElement)) {
     timelineObjectCache.set(postElement, inject(unburyTimelineObject, [], postElement));
   }
-  return cache.get(postElement);
+  return timelineObjectCache.get(postElement);
 };
 
 const unburyGivenPaths = selector => {

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -1,7 +1,7 @@
 import { inject } from './inject.js';
 import { keyToCss } from './css_map.js';
 
-const cache = new WeakMap();
+const timelineObjectCache = new WeakMap();
 
 const unburyTimelineObject = () => {
   const postElement = document.currentScript.parentElement;
@@ -23,8 +23,8 @@ const unburyTimelineObject = () => {
  * @returns {Promise<object>} - The post's buried timelineObject property
  */
 export const timelineObject = async function (postElement) {
-  if (!cache.has(postElement)) {
-    cache.set(postElement, inject(unburyTimelineObject, [], postElement));
+  if (!timelineObjectCache.has(postElement)) {
+    timelineObjectCache.set(postElement, inject(unburyTimelineObject, [], postElement));
   }
   return cache.get(postElement);
 };

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -1,10 +1,10 @@
 import { inject } from './inject.js';
 import { keyToCss } from './css_map.js';
 
-const cache = {};
+const cache = new WeakMap();
 
-const unburyTimelineObject = async id => {
-  const postElement = document.querySelector(`[tabindex="-1"][data-id="${id}"]`);
+const unburyTimelineObject = () => {
+  const postElement = document.currentScript.parentElement;
   const reactKey = Object.keys(postElement).find(key => key.startsWith('__reactFiber'));
   let fiber = postElement[reactKey];
 
@@ -19,19 +19,14 @@ const unburyTimelineObject = async id => {
 };
 
 /**
- * @param {string} postID - The post ID of an on-screen post
- * @returns {Promise<object>} - The post's buried timelineObject property (cached; use
- *  timelineObject if you need up-to-date properties that may have changed)
- */
-export const timelineObjectMemoized = async postID => cache[postID] || timelineObject(postID);
-
-/**
- * @param {string} postID - The post ID of an on-screen post
+ * @param {Element} postElement - An on-screen post
  * @returns {Promise<object>} - The post's buried timelineObject property
  */
-export const timelineObject = async function (postID) {
-  cache[postID] = inject(unburyTimelineObject, [postID]);
-  return cache[postID];
+export const timelineObject = async function (postElement) {
+  if (!cache.has(postElement)) {
+    cache.set(postElement, inject(unburyTimelineObject, [], postElement));
+  }
+  return cache.get(postElement);
 };
 
 const unburyGivenPaths = selector => {


### PR DESCRIPTION
#### User-facing changes
- Slightly increased performance when loading new posts

#### Technical explanation
As we discussed in #416, it should be possible to skip using querySelector in some (all, I think, but at the expense of too much complexity in some cases) injected functions by injecting script elements into relevant DOM containers. I got worried it wouldn't work, so I tried it, and it seems to! 

This implements a parameter in `inject()` specifying which DOM element the script will be injected into. Because the script can find its location via `document.currentScript`, this removes the need for injected functions to communicate which element they are supposed to query or affect via serializable data and thus the need to use querySelector/querySelectorAll in the page context to find an element when the extension context already knows which one it is, which is the most expensive part of this whole process by far.

This takes advantage of this technique in `timelineObject`, converting its data id parameter into an element parameter and using a WeakMap to store its cache with elements as keys (yay, finally a use for WeakMap!). This means the cache gets invalidated more often than before, but it's really fast now, so who cares, really.

Finally, it removes the distinction between memoized and unmemoized `timelineObject`, relying on the fact that the resulting invalidation behavior should be up to date enough for any current use.

#### Issues this closes
n/a

---

~~Committing in case it saves time/sparks useful discussion. Feel free to ignore, peruse, cherry pick, etc, or I could convert this into a real PR with a real issue template description and a rebase off of master if you'd like. Sometimes it's fun to see the different ways we think to implement concepts when we try them independently, though - I'm curious if you were imagining something somewhat different than I was!~~
