### PR TITLE
Notifications utility: Add persistent option

### DIFF
--- a/src/content_scripts/notifications.css
+++ b/src/content_scripts/notifications.css
@@ -10,10 +10,11 @@
   display: none;
 }
 
-#xkit-toasts div {
+#xkit-toasts > div {
   padding: 10px;
   border-top: 1px solid rgba(var(--white-on-dark), .13);
 
+  display: flex;
   background-color: rgb(var(--navy));
   background-image: linear-gradient(rgba(var(--white-on-dark), .07), rgba(var(--white-on-dark), .07));
   color: rgb(var(--white-on-dark));
@@ -25,7 +26,20 @@
   transition: opacity 1s;
 }
 
-#xkit-toasts div.visible {
+#xkit-toasts svg {
+  width: 1.5rem;
+  height: 1.5rem;
+
+  vertical-align: middle;
+
+  fill: rgb(var(--white-on-dark));
+}
+
+#xkit-toasts > div > div:first-child {
+  flex-grow: 1;
+}
+
+#xkit-toasts > div.visible {
   opacity: 1;
 }
 
@@ -34,13 +48,13 @@
   margin-bottom: 1ch;
 }
 
-#xkit-toasts[data-in-sidebar="true"] div {
+#xkit-toasts[data-in-sidebar="true"] > div {
   border-top: none;
 
   text-align: left;
 }
 
-#xkit-toasts[data-in-sidebar="true"] div:not(:last-child) {
+#xkit-toasts[data-in-sidebar="true"] > div:not(:last-child) {
   border-bottom: 1px solid rgba(var(--white-on-dark), .13);
 }
 

--- a/src/util/notifications.js
+++ b/src/util/notifications.js
@@ -1,4 +1,5 @@
 import { keyToCss } from './css_map.js';
+import { buildSvg } from './remixicon.js';
 
 const toastContainer = Object.assign(document.createElement('div'), { id: 'xkit-toasts' });
 
@@ -22,16 +23,33 @@ const addToastContainerToPage = async () => {
   }
 };
 
+const createDismissButton = () => {
+  const button = Object.assign(document.createElement('button'), {
+    onclick: ({ currentTarget }) => currentTarget.parentElement.remove()
+  });
+  const svg = buildSvg('ri-close-fill');
+  button.appendChild(svg);
+  return button;
+};
+
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 /**
  * @param {string} textContent - Text to display to the user as a notification
+ * @param {boolean} persistent - Whether to persist the notification until the user closes it
  */
-export const notify = async textContent => {
+export const notify = async (textContent, persistent = false) => {
   await addToastContainerToPage();
 
-  const toast = Object.assign(document.createElement('div'), { textContent, className: 'visible' });
+  const toast = Object.assign(document.createElement('div'), { className: 'visible' });
+  const text = Object.assign(document.createElement('div'), { textContent });
+  toast.append(text);
   toastContainer.append(toast);
+
+  if (persistent) {
+    toast.append(createDismissButton());
+    return;
+  }
 
   await sleep(4000);
   toast.classList.remove('visible');


### PR DESCRIPTION
Here's just an idea I had to allow notifications to optionally be persistent until the user manually closes them, in cases where the notification question is less an immediate response to a user action and more of an indicator of a background event that may have happened when the user was not looking at the tab. (I have wished XKit 7's update notifications were like this for years.) As I'm sure you could guess, I was primarily thinking about #451, but there may be other cases where this makes sense.

Annoyingly, this requires some kind of special handling for when the toast container target moves or a reversion of #422, which is not yet implemented here.

Anyway, before I think about how that would best be solved... any thoughts on this feature?

