### PR TITLE
Popup: Add additional searchable text to scripts

### DIFF
--- a/src/browser_action/popup.js
+++ b/src/browser_action/popup.js
@@ -19,7 +19,10 @@ document.getElementById('search').addEventListener('input', event => {
 
   [...document.querySelectorAll('details.script')]
     .forEach(detailsElement => {
-      if (detailsElement.textContent.toLowerCase().includes(query)) {
+      if (
+        detailsElement.textContent.toLowerCase().includes(query) ||
+        detailsElement.dataset.relatedTerms.toLowerCase().includes(query)
+      ) {
         detailsElement.classList.remove('search-hidden');
       } else {
         detailsElement.classList.add('search-hidden');

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -132,7 +132,7 @@ const renderScripts = async function () {
   for (const scriptName of [...orderedEnabledScripts, ...disabledScripts]) {
     const url = getURL(`/scripts/${scriptName}.json`);
     const file = await fetch(url);
-    const { title = scriptName, description = '', icon = {}, help = '', relatedTerms = [], preferences = {}, } = await file.json();
+    const { title = scriptName, description = '', icon = {}, help = '', relatedTerms = [], preferences = {} } = await file.json();
 
     const scriptTemplateClone = document.getElementById('script').content.cloneNode(true);
 

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -132,12 +132,15 @@ const renderScripts = async function () {
   for (const scriptName of [...orderedEnabledScripts, ...disabledScripts]) {
     const url = getURL(`/scripts/${scriptName}.json`);
     const file = await fetch(url);
-    const { title = scriptName, description = '', icon = {}, help = '', preferences = {} } = await file.json();
+    const { title = scriptName, description = '', icon = {}, help = '', preferences = {}, relatedTerms = '' } = await file.json();
 
     const scriptTemplateClone = document.getElementById('script').content.cloneNode(true);
 
+    const detailsElement = scriptTemplateClone.querySelector('details.script');
+
+    detailsElement.dataset.relatedTerms = relatedTerms;
+
     if (enabledScripts.includes(scriptName) === false) {
-      const detailsElement = scriptTemplateClone.querySelector('details.script');
       detailsElement.classList.add('disabled');
     }
 

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -132,12 +132,11 @@ const renderScripts = async function () {
   for (const scriptName of [...orderedEnabledScripts, ...disabledScripts]) {
     const url = getURL(`/scripts/${scriptName}.json`);
     const file = await fetch(url);
-    const { title = scriptName, description = '', icon = {}, help = '', preferences = {}, relatedTerms = '' } = await file.json();
+    const { title = scriptName, description = '', icon = {}, help = '', relatedTerms = [], preferences = {}, } = await file.json();
 
     const scriptTemplateClone = document.getElementById('script').content.cloneNode(true);
 
     const detailsElement = scriptTemplateClone.querySelector('details.script');
-
     detailsElement.dataset.relatedTerms = relatedTerms;
 
     if (enabledScripts.includes(scriptName) === false) {

--- a/src/scripts/accesskit.json
+++ b/src/scripts/accesskit.json
@@ -1,13 +1,13 @@
 {
   "title": "AccessKit",
   "description": "Accessibility options for Tumblr",
-  "relatedTerms": [ "disable gifs" ],
   "icon": {
     "class_name": "ri-open-arm-line",
     "color": "white",
     "background_color": "#df46f6"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#accesskit",
+  "relatedTerms": [ "disable gifs" ],
   "preferences": {
     "disable_gifs": {
       "type": "checkbox",

--- a/src/scripts/accesskit.json
+++ b/src/scripts/accesskit.json
@@ -1,7 +1,7 @@
 {
   "title": "AccessKit",
   "description": "Accessibility options for Tumblr",
-  "relatedTerms": "disable gifs",
+  "relatedTerms": [ "disable gifs" ],
   "icon": {
     "class_name": "ri-open-arm-line",
     "color": "white",

--- a/src/scripts/accesskit.json
+++ b/src/scripts/accesskit.json
@@ -1,6 +1,7 @@
 {
   "title": "AccessKit",
   "description": "Accessibility options for Tumblr",
+  "relatedTerms": "disable gifs",
   "icon": {
     "class_name": "ri-open-arm-line",
     "color": "white",

--- a/src/scripts/accesskit.json
+++ b/src/scripts/accesskit.json
@@ -7,7 +7,7 @@
     "background_color": "#df46f6"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#accesskit",
-  "relatedTerms": [ "disable gifs" ],
+  "relatedTerms": [ "Disable GIFs" ],
   "preferences": {
     "disable_gifs": {
       "type": "checkbox",

--- a/src/scripts/anti_capitalism.json
+++ b/src/scripts/anti_capitalism.json
@@ -1,11 +1,11 @@
 {
   "title": "Anti-Capitalism",
   "description": "Hide advertisement containers",
-  "relatedTerms": [ "sponsored" ],
   "icon": {
     "class_name": "ri-creative-commons-nc-line",
     "color": "#ffd800",
     "background_color": "#cd0000"
   },
-  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#anti-capitalism"
+  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#anti-capitalism",
+  "relatedTerms": [ "sponsored" ]
 }

--- a/src/scripts/anti_capitalism.json
+++ b/src/scripts/anti_capitalism.json
@@ -1,7 +1,7 @@
 {
   "title": "Anti-Capitalism",
   "description": "Hide advertisement containers",
-  "relatedTerms": "sponsored",
+  "relatedTerms": [ "sponsored" ],
   "icon": {
     "class_name": "ri-creative-commons-nc-line",
     "color": "#ffd800",

--- a/src/scripts/anti_capitalism.json
+++ b/src/scripts/anti_capitalism.json
@@ -1,6 +1,7 @@
 {
   "title": "Anti-Capitalism",
   "description": "Hide advertisement containers",
+  "relatedTerms": "sponsored",
   "icon": {
     "class_name": "ri-creative-commons-nc-line",
     "color": "#ffd800",

--- a/src/scripts/cleanfeed.json
+++ b/src/scripts/cleanfeed.json
@@ -1,13 +1,13 @@
 {
   "title": "CleanFeed",
   "description": "Browse safely in public",
-  "relatedTerms": [ "nsfw" ],
   "icon": {
     "class_name": "ri-eye-off-line",
     "color": "white",
     "background_color": "#ff567e"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#cleanfeed",
+  "relatedTerms": [ "nsfw" ],
   "preferences": {
     "blockingMode": {
       "label": "Hide media from",

--- a/src/scripts/cleanfeed.json
+++ b/src/scripts/cleanfeed.json
@@ -1,7 +1,7 @@
 {
   "title": "CleanFeed",
   "description": "Browse safely in public",
-  "relatedTerms": "nsfw",
+  "relatedTerms": [ "nsfw" ],
   "icon": {
     "class_name": "ri-eye-off-line",
     "color": "white",

--- a/src/scripts/cleanfeed.json
+++ b/src/scripts/cleanfeed.json
@@ -1,6 +1,7 @@
 {
   "title": "CleanFeed",
   "description": "Browse safely in public",
+  "relatedTerms": "nsfw",
   "icon": {
     "class_name": "ri-eye-off-line",
     "color": "white",

--- a/src/scripts/collapsed_queue.json
+++ b/src/scripts/collapsed_queue.json
@@ -1,6 +1,7 @@
 {
   "title": "Collapsed Queue",
   "description": "Shorten posts in your queue",
+  "relatedTerms": "drafts plus, drafts+, enhanced queue",
   "icon": {
     "class_name": "ri-qr-scan-line",
     "color": "white",

--- a/src/scripts/collapsed_queue.json
+++ b/src/scripts/collapsed_queue.json
@@ -1,13 +1,13 @@
 {
   "title": "Collapsed Queue",
   "description": "Shorten posts in your queue",
-  "relatedTerms": [ "drafts plus", "drafts+", "enhanced queue" ],
   "icon": {
     "class_name": "ri-qr-scan-line",
     "color": "white",
     "background_color": "#F1615F"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#collapsed-queue",
+  "relatedTerms": [ "drafts plus", "drafts+", "enhanced queue" ],
   "preferences": {
     "runInQueue": {
       "type": "checkbox",

--- a/src/scripts/collapsed_queue.json
+++ b/src/scripts/collapsed_queue.json
@@ -1,7 +1,7 @@
 {
   "title": "Collapsed Queue",
   "description": "Shorten posts in your queue",
-  "relatedTerms": "drafts plus, drafts+, enhanced queue",
+  "relatedTerms": [ "drafts plus", "drafts+", "enhanced queue" ],
   "icon": {
     "class_name": "ri-qr-scan-line",
     "color": "white",

--- a/src/scripts/collapsed_queue.json
+++ b/src/scripts/collapsed_queue.json
@@ -7,7 +7,7 @@
     "background_color": "#F1615F"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#collapsed-queue",
-  "relatedTerms": [ "drafts plus", "drafts+", "enhanced queue" ],
+  "relatedTerms": [ "Drafts Plus", "Drafts+", "Enhanced Queue" ],
   "preferences": {
     "runInQueue": {
       "type": "checkbox",

--- a/src/scripts/mass_unliker.json
+++ b/src/scripts/mass_unliker.json
@@ -1,6 +1,7 @@
 {
   "title": "Mass Unliker",
   "description": "Clear your likes",
+  "relatedTerms": "delete likes",
   "icon": {
     "color": "white",
     "background_color": "#9d318b",

--- a/src/scripts/mass_unliker.json
+++ b/src/scripts/mass_unliker.json
@@ -1,11 +1,11 @@
 {
   "title": "Mass Unliker",
   "description": "Clear your likes",
-  "relatedTerms": [ "delete likes" ],
   "icon": {
     "color": "white",
     "background_color": "#9d318b",
     "class_name": "ri-thumb-down-line"
   },
-  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#mass-unliker"
+  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#mass-unliker",
+  "relatedTerms": [ "delete likes" ]
 }

--- a/src/scripts/mass_unliker.json
+++ b/src/scripts/mass_unliker.json
@@ -1,7 +1,7 @@
 {
   "title": "Mass Unliker",
   "description": "Clear your likes",
-  "relatedTerms": "delete likes",
+  "relatedTerms": [ "delete likes" ],
   "icon": {
     "color": "white",
     "background_color": "#9d318b",

--- a/src/scripts/notificationblock.json
+++ b/src/scripts/notificationblock.json
@@ -1,6 +1,7 @@
 {
   "title": "NotificationBlock",
   "description": "Block a post's notifications",
+  "relatedTerms": "activity",
   "icon": {
     "class_name": "ri-notification-off-line",
     "color": "white",

--- a/src/scripts/notificationblock.json
+++ b/src/scripts/notificationblock.json
@@ -1,11 +1,11 @@
 {
   "title": "NotificationBlock",
   "description": "Block a post's notifications",
-  "relatedTerms": [ "activity" ],
   "icon": {
     "class_name": "ri-notification-off-line",
     "color": "white",
     "background_color": "#f5223c"
   },
-  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#notificationblock"
+  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#notificationblock",
+  "relatedTerms": [ "activity" ]
 }

--- a/src/scripts/notificationblock.json
+++ b/src/scripts/notificationblock.json
@@ -1,7 +1,7 @@
 {
   "title": "NotificationBlock",
   "description": "Block a post's notifications",
-  "relatedTerms": "activity",
+  "relatedTerms": [ "activity" ],
   "icon": {
     "class_name": "ri-notification-off-line",
     "color": "white",

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -6,7 +6,7 @@
     "background_color": "#acd53a"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#quick-reblog",
-  "relatedTerms": "one-click postage, one click postage, auto tagger, autotagger",
+  "relatedTerms": [ "one-click postage", "one click postage", "auto tagger", "autotagger" ],
   "preferences": {
     "popupPosition": {
       "type": "select",

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -6,6 +6,7 @@
     "background_color": "#acd53a"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#quick-reblog",
+  "relatedTerms": "one-click postage, one click postage, auto tagger, autotagger",
   "preferences": {
     "popupPosition": {
       "type": "select",

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -6,7 +6,7 @@
     "background_color": "#acd53a"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#quick-reblog",
-  "relatedTerms": [ "one-click postage", "one click postage", "auto tagger", "autotagger" ],
+  "relatedTerms": [ "One-Click Postage", "One Click Postage", "Auto Tagger", "Autotagger" ],
   "preferences": {
     "popupPosition": {
       "type": "select",

--- a/src/scripts/quick_tags.json
+++ b/src/scripts/quick_tags.json
@@ -7,6 +7,7 @@
     "background_color": "#eeb92b"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#quick-tags",
+  "relatedTerms": [ "Auto Tagger", "AutoTagger", "XInbox" ],
   "preferences": {
     "originalPostTag": {
       "type": "text",

--- a/src/scripts/seen_posts.json
+++ b/src/scripts/seen_posts.json
@@ -7,7 +7,7 @@
     "background_color": "#849baf"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#seen-posts",
-  "relatedTerms": [ "read posts" ],
+  "relatedTerms": [ "Read Posts" ],
   "preferences": {
     "onlyDimAvatars": {
       "type": "checkbox",

--- a/src/scripts/seen_posts.json
+++ b/src/scripts/seen_posts.json
@@ -1,6 +1,7 @@
 {
   "title": "Seen Posts",
   "description": "Dim the posts you've seen already",
+  "relatedTerms": "read posts",
   "icon": {
     "class_name": "ri-eye-line",
     "color": "white",

--- a/src/scripts/seen_posts.json
+++ b/src/scripts/seen_posts.json
@@ -1,7 +1,7 @@
 {
   "title": "Seen Posts",
   "description": "Dim the posts you've seen already",
-  "relatedTerms": "read posts",
+  "relatedTerms": [ "read posts" ],
   "icon": {
     "class_name": "ri-eye-line",
     "color": "white",

--- a/src/scripts/seen_posts.json
+++ b/src/scripts/seen_posts.json
@@ -1,13 +1,13 @@
 {
   "title": "Seen Posts",
   "description": "Dim the posts you've seen already",
-  "relatedTerms": [ "read posts" ],
   "icon": {
     "class_name": "ri-eye-line",
     "color": "white",
     "background_color": "#849baf"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#seen-posts",
+  "relatedTerms": [ "read posts" ],
   "preferences": {
     "onlyDimAvatars": {
       "type": "checkbox",

--- a/src/scripts/trim_reblogs.json
+++ b/src/scripts/trim_reblogs.json
@@ -7,5 +7,5 @@
     "background_color": "#56bc8a"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#trim-reblogs",
-  "relatedTerms": [ "editable reblogs" ]
+  "relatedTerms": [ "Editable Reblogs" ]
 }

--- a/src/scripts/trim_reblogs.json
+++ b/src/scripts/trim_reblogs.json
@@ -1,6 +1,7 @@
 {
   "title": "Trim Reblogs",
   "description": "Cut long threads down to size",
+  "relatedTerms": "editable reblogs",
   "icon": {
     "class_name": "ri-scissors-cut-line",
     "color": "white",

--- a/src/scripts/trim_reblogs.json
+++ b/src/scripts/trim_reblogs.json
@@ -1,11 +1,11 @@
 {
   "title": "Trim Reblogs",
   "description": "Cut long threads down to size",
-  "relatedTerms": [ "editable reblogs" ],
   "icon": {
     "class_name": "ri-scissors-cut-line",
     "color": "white",
     "background_color": "#56bc8a"
   },
-  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#trim-reblogs"
+  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#trim-reblogs",
+  "relatedTerms": [ "editable reblogs" ]
 }

--- a/src/scripts/trim_reblogs.json
+++ b/src/scripts/trim_reblogs.json
@@ -1,7 +1,7 @@
 {
   "title": "Trim Reblogs",
   "description": "Cut long threads down to size",
-  "relatedTerms": "editable reblogs",
+  "relatedTerms": [ "editable reblogs" ],
   "icon": {
     "class_name": "ri-scissors-cut-line",
     "color": "white",

--- a/src/scripts/trim_reblogs.json
+++ b/src/scripts/trim_reblogs.json
@@ -7,5 +7,5 @@
     "background_color": "#56bc8a"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#trim-reblogs",
-  "relatedTerms": [ "Editable Reblogs" ]
+  "relatedTerms": [ "Condensed Reblogs", "Editable Reblogs" ]
 }

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -1,6 +1,7 @@
 {
   "title": "Tweaks",
   "description": "Miscellaneous dashboard options",
+  "relatedTerms": "blacklist",
   "icon": {
     "class_name": "ri-settings-5-line",
     "color": "white",

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -1,13 +1,13 @@
 {
   "title": "Tweaks",
   "description": "Miscellaneous dashboard options",
-  "relatedTerms": [ "blacklist" ],
   "icon": {
     "class_name": "ri-settings-5-line",
     "color": "white",
     "background_color": "#ecc84b"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#tweaks",
+  "relatedTerms": [ "blacklist" ],
   "preferences": {
     "footer_unredesign": {
       "type": "checkbox",

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -7,7 +7,7 @@
     "background_color": "#ecc84b"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#tweaks",
-  "relatedTerms": [ "Blacklist" ],
+  "relatedTerms": [ "Blacklist", "Separator" ],
   "preferences": {
     "footer_unredesign": {
       "type": "checkbox",

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -1,7 +1,7 @@
 {
   "title": "Tweaks",
   "description": "Miscellaneous dashboard options",
-  "relatedTerms": "blacklist",
+  "relatedTerms": [ "blacklist" ],
   "icon": {
     "class_name": "ri-settings-5-line",
     "color": "white",

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -7,7 +7,7 @@
     "background_color": "#ecc84b"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#tweaks",
-  "relatedTerms": [ "blacklist" ],
+  "relatedTerms": [ "Blacklist" ],
   "preferences": {
     "footer_unredesign": {
       "type": "checkbox",

--- a/src/scripts/vanilla_audio.json
+++ b/src/scripts/vanilla_audio.json
@@ -7,7 +7,7 @@
     "background_color": "#7c5cff"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#vanilla-audio",
-  "relatedTerms": [ "audio downloader", "audio plus", "audio+" ],
+  "relatedTerms": [ "Audio Downloader", "Audio Plus", "Audio+" ],
   "preferences": {
     "defaultVolume": {
       "type": "select",

--- a/src/scripts/vanilla_audio.json
+++ b/src/scripts/vanilla_audio.json
@@ -1,7 +1,7 @@
 {
   "title": "Vanilla Audio",
   "description": "Use the browser's controls for audio posts",
-  "relatedTerms": "audio downloader, audio plus, audio+",
+  "relatedTerms": [ "audio downloader", "audio plus", "audio+" ],
   "icon": {
     "class_name": "ri-file-music-line",
     "color": "white",

--- a/src/scripts/vanilla_audio.json
+++ b/src/scripts/vanilla_audio.json
@@ -1,13 +1,13 @@
 {
   "title": "Vanilla Audio",
   "description": "Use the browser's controls for audio posts",
-  "relatedTerms": [ "audio downloader", "audio plus", "audio+" ],
   "icon": {
     "class_name": "ri-file-music-line",
     "color": "white",
     "background_color": "#7c5cff"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#vanilla-audio",
+  "relatedTerms": [ "audio downloader", "audio plus", "audio+" ],
   "preferences": {
     "defaultVolume": {
       "type": "select",

--- a/src/scripts/vanilla_audio.json
+++ b/src/scripts/vanilla_audio.json
@@ -1,6 +1,7 @@
 {
   "title": "Vanilla Audio",
   "description": "Use the browser's controls for audio posts",
+  "relatedTerms": "audio downloader, audio plus, audio+",
   "icon": {
     "class_name": "ri-file-music-line",
     "color": "white",

--- a/src/scripts/vanilla_video.json
+++ b/src/scripts/vanilla_video.json
@@ -7,7 +7,7 @@
     "background_color": "#ff62ce"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#vanilla-video",
-  "relatedTerms": [ "video downloader", "autoplay" ],
+  "relatedTerms": [ "Video Downloader", "autoplay" ],
   "preferences": {
     "defaultVolume": {
       "type": "select",

--- a/src/scripts/vanilla_video.json
+++ b/src/scripts/vanilla_video.json
@@ -1,7 +1,7 @@
 {
   "title": "Vanilla Video",
   "description": "Use the browser's controls for video posts",
-  "relatedTerms": "video downloader",
+  "relatedTerms": "video downloader, autoplay",
   "icon": {
     "class_name": "ri-movie-line",
     "color": "white",

--- a/src/scripts/vanilla_video.json
+++ b/src/scripts/vanilla_video.json
@@ -1,7 +1,7 @@
 {
   "title": "Vanilla Video",
   "description": "Use the browser's controls for video posts",
-  "relatedTerms": "video downloader, autoplay",
+  "relatedTerms": [ "video downloader", "autoplay" ],
   "icon": {
     "class_name": "ri-movie-line",
     "color": "white",

--- a/src/scripts/vanilla_video.json
+++ b/src/scripts/vanilla_video.json
@@ -1,6 +1,7 @@
 {
   "title": "Vanilla Video",
   "description": "Use the browser's controls for video posts",
+  "relatedTerms": "video downloader",
   "icon": {
     "class_name": "ri-movie-line",
     "color": "white",

--- a/src/scripts/vanilla_video.json
+++ b/src/scripts/vanilla_video.json
@@ -1,13 +1,13 @@
 {
   "title": "Vanilla Video",
   "description": "Use the browser's controls for video posts",
-  "relatedTerms": [ "video downloader", "autoplay" ],
   "icon": {
     "class_name": "ri-movie-line",
     "color": "white",
     "background_color": "#ff62ce"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#vanilla-video",
+  "relatedTerms": [ "video downloader", "autoplay" ],
   "preferences": {
     "defaultVolume": {
       "type": "select",


### PR DESCRIPTION
#### User-facing changes
- Searching the popup for terms related to a script like the name of its XKit 7 equivalent will still find the script.

Probably should have proposed this a year ago when more people might have been switching from XKit 7. Then again, someday it will stop working, so maybe there will be another wave then.

#### Technical explanation
Uses a data attribute on the script element.

Would require an update to the manifest documentation.

#### Issues this closes
Discussion #113