### PR TITLE
Popup: Fix iframe options sometimes capturing scroll

### DIFF
--- a/src/browser_action/resize_frames.js
+++ b/src/browser_action/resize_frames.js
@@ -1,4 +1,4 @@
-const callback = () => { window.frameElement.height = document.documentElement.scrollHeight + 1; };
+const callback = () => { window.frameElement.height = document.documentElement.scrollHeight; };
 const observer = new ResizeObserver(callback);
 
 callback();

--- a/src/browser_action/resize_frames.js
+++ b/src/browser_action/resize_frames.js
@@ -1,4 +1,4 @@
-const callback = () => { window.frameElement.height = document.documentElement.scrollHeight; };
+const callback = () => { window.frameElement.height = document.documentElement.scrollHeight + 1; };
 const observer = new ResizeObserver(callback);
 
 callback();

--- a/src/scripts/postblock/options/index.css
+++ b/src/scripts/postblock/options/index.css
@@ -18,6 +18,7 @@ html {
   font-size: 14px;
   scrollbar-color: rgb(var(--grey)) transparent;
   scrollbar-width: thin;
+  overflow-y: hidden;
 }
 
 body {

--- a/src/scripts/quick_tags/options/index.css
+++ b/src/scripts/quick_tags/options/index.css
@@ -18,6 +18,7 @@ html {
   font-size: 14px;
   scrollbar-color: rgb(var(--dark-grey)) transparent;
   scrollbar-width: thin;
+  overflow-y: hidden;
 }
 
 body {


### PR DESCRIPTION
#### User-facing changes
- iframe preferences no longer sometimes capture user scroll

#### Technical explanation
~~I thiiiiink this is the correct fix. Probably. Maybe? Well, it seems to work.~~

~~This adds one to the height set on iframe preference elements by the resize frames script, ensuring that even if the actual height of the document is fractional and `document.documentElement.scrollHeight` rounds down, all of the content will still fit in the iframe without a scroll bar appearing.~~

~~Not sure if this is better than changing the overflow css property, assuming that that also works.~~

This changes the overflow CSS property, which does work! It must be changed on the iframe contents, though, not the iframe itself.

#### Issues this closes
Resolves #509