### PR TITLE
docs: document related terms manifest key

### DIFF
--- a/docs/Chapter 4.0 - Feature framework.md
+++ b/docs/Chapter 4.0 - Feature framework.md
@@ -31,6 +31,7 @@ The stylesheet file is a normal CSS file which, assuming the module file correct
     "color": "#33ff00",
     "background_color": "#000000"
   },
+  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#example",
   "relatedTerms": [ "hello world", "demonstration" ],
   "preferences": {
     "log": {

--- a/docs/Chapter 4.0 - Feature framework.md
+++ b/docs/Chapter 4.0 - Feature framework.md
@@ -31,6 +31,7 @@ The stylesheet file is a normal CSS file which, assuming the module file correct
     "color": "#33ff00",
     "background_color": "#000000"
   },
+  "relatedTerms": [ "hello world", "demonstration" ],
   "preferences": {
     "log": {
       "type": "checkbox",

--- a/docs/Chapter 4.1 - Feature manifests.md
+++ b/docs/Chapter 4.1 - Feature manifests.md
@@ -46,6 +46,12 @@ The background colour of the feature icon. Defaults to pure white (`#ffffff`) if
 
 URL which points to a usage guide or extended description for the feature.
 
+### `"relatedTerms"`
+- Type: Array
+- Required: No
+
+An optional array of strings related to this script that a user might search for. Case insensitive.
+
 ### `"preferences"`
 - Type: Object
 - Required: No


### PR DESCRIPTION
I am not good at documentation prose :D

This adds documentation about the relatedTerms manifest key added in #506.

It also adds an example help link to the example script manifest (it's a dead link, but still. Seemed clearer than linking to the location of the document in question, or something).