### PR TITLE
Scroll to Bottom: remove closure from clean()

### DIFF
--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -83,6 +83,6 @@ export const clean = async function () {
   pageModifications.unregister(addButtonToPage);
   pageModifications.unregister(checkForButtonRemoved);
   stopScrolling();
-  scrollToBottomButton?.remove();
+  $(`#${scrollToBottomButtonId}`).remove();
   styleElement.remove();
 };

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -83,6 +83,6 @@ export const clean = async function () {
   pageModifications.unregister(addButtonToPage);
   pageModifications.unregister(checkForButtonRemoved);
   stopScrolling();
-  $(`#${scrollToBottomButtonId}`).remove();
+  $(`[id="${scrollToBottomButtonId}"]`).remove();
   styleElement.remove();
 };


### PR DESCRIPTION
#### User-facing changes
- n/a

#### Technical explanation
This uses a CSS selector in Scroll to Bottom's clean function instead of a variable reference. This ensures that clean removes buttons added by a stale version of XKit that has been invalidated by an update or developer refresh in Firefox.

#### Issues this closes
n/a