### PR TITLE
Classic Search: remove closure from clean()

### DIFF
--- a/src/scripts/classic_search.js
+++ b/src/scripts/classic_search.js
@@ -3,14 +3,22 @@ import { pageModifications } from '../util/mutations.js';
 
 const excludeClass = 'xkit-classic-search-done';
 const cloneClass = 'classic-search';
-const placeholderInputId = 'classic-search-placeholder';
 
 let newTab;
 
-const replaceSearchForm = function ([searchFormElement]) {
-  searchFormElement.classList.add(`${excludeClass}`);
+const swapNodes = (first, second) => {
+  const temporary = document.createElement('div');
+  first.replaceWith(temporary);
+  second.replaceWith(first);
+  temporary.replaceWith(second);
+};
 
+const replaceSearchForm = function ([searchFormElement]) {
   const searchFormElementClone = searchFormElement.cloneNode(true);
+
+  searchFormElement.classList.add(excludeClass);
+  searchFormElementClone.classList.add(cloneClass);
+
   searchFormElementClone.addEventListener('submit', event => {
     event.preventDefault();
 
@@ -23,14 +31,10 @@ const replaceSearchForm = function ([searchFormElement]) {
       location.assign(address);
     }
   });
-  searchFormElementClone.classList.add(cloneClass);
 
-  const realInputElement = searchFormElement.querySelector('input');
+  const inputElement = searchFormElement.querySelector('input');
   const cloneInputElement = searchFormElementClone.querySelector('input');
-  const placeholderElement = Object.assign(document.createElement('div'), { id: placeholderInputId });
-
-  realInputElement.replaceWith(placeholderElement);
-  cloneInputElement.replaceWith(realInputElement);
+  swapNodes(inputElement, cloneInputElement);
 
   searchFormElement.parentNode.prepend(searchFormElementClone);
 };
@@ -44,11 +48,14 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(replaceSearchForm);
 
+  const searchFormElement = document.querySelector(`.${excludeClass}`);
   const searchFormElementClone = document.querySelector(`.${cloneClass}`);
-  const realInputElement = searchFormElementClone?.querySelector('input');
-  const placeholderElement = document.getElementById(placeholderInputId);
 
-  placeholderElement?.replaceWith(realInputElement);
+  if (searchFormElement && searchFormElementClone) {
+    const inputElement = searchFormElement.querySelector('input');
+    const cloneInputElement = searchFormElementClone.querySelector('input');
+    swapNodes(inputElement, cloneInputElement);
+  }
 
   searchFormElementClone?.remove();
   $(`.${excludeClass}`).removeClass(excludeClass);

--- a/src/scripts/classic_search.js
+++ b/src/scripts/classic_search.js
@@ -1,16 +1,14 @@
 import { getPreferences } from '../util/preferences.js';
 import { pageModifications } from '../util/mutations.js';
 
+const excludeClass = 'xkit-classic-search-done';
+const cloneClass = 'classic-search';
+const placeholderInputId = 'classic-search-placeholder';
+
 let newTab;
 
-let searchInputElement;
-let searchInputParent;
-
 const replaceSearchForm = function ([searchFormElement]) {
-  searchFormElement.classList.add('xkit-classic-search-done');
-
-  searchInputElement = searchFormElement.querySelector('input');
-  searchInputParent = searchInputElement.parentNode;
+  searchFormElement.classList.add(`${excludeClass}`);
 
   const searchFormElementClone = searchFormElement.cloneNode(true);
   searchFormElementClone.addEventListener('submit', event => {
@@ -25,23 +23,35 @@ const replaceSearchForm = function ([searchFormElement]) {
       location.assign(address);
     }
   });
-  searchFormElementClone.classList.add('classic-search');
-  searchFormElementClone.querySelector('input').replaceWith(searchInputElement);
+  searchFormElementClone.classList.add(cloneClass);
+
+  const realInputElement = searchFormElement.querySelector('input');
+  const cloneInputElement = searchFormElementClone.querySelector('input');
+  const placeholderElement = Object.assign(document.createElement('div'), { id: placeholderInputId });
+
+  realInputElement.replaceWith(placeholderElement);
+  cloneInputElement.replaceWith(realInputElement);
+
   searchFormElement.parentNode.prepend(searchFormElementClone);
 };
 
 export const main = async function () {
   ({ newTab } = await getPreferences('classic_search'));
 
-  pageModifications.register('form[role="search"][action="/search"]:not(.classic-search):not(.xkit-classic-search-done)', replaceSearchForm);
+  pageModifications.register(`form[role="search"][action="/search"]:not(.${cloneClass}):not(.${excludeClass})`, replaceSearchForm);
 };
 
 export const clean = async function () {
   pageModifications.unregister(replaceSearchForm);
 
-  searchInputParent.appendChild(searchInputElement);
-  $('.classic-search').remove();
-  $('.xkit-classic-search-done').removeClass('xkit-classic-search-done');
+  const searchFormElementClone = document.querySelector(`.${cloneClass}`);
+  const realInputElement = searchFormElementClone?.querySelector('input');
+  const placeholderElement = document.getElementById(placeholderInputId);
+
+  placeholderElement?.replaceWith(realInputElement);
+
+  searchFormElementClone?.remove();
+  $(`.${excludeClass}`).removeClass(excludeClass);
 };
 
 export const stylesheet = true;


### PR DESCRIPTION
~~I think I have to sleep on this one; there has to be a better way to do this.~~ Okay, I didn't spend any sleep time on it... but there was indeed a better way to do it!

#### User-facing changes
- Progress towards Classic Search not breaking if XKit Rewritten is initialized twice (by an update or developer refresh in Firefox.)

#### Technical explanation
This removes the reference to `searchInputElement` in Classic Search's `clean` function so it can be run without the extension being initialized, as discussed in #451.

In order to create the desired behavior ("Classic Search displays a copy of the form element containing the real input element, and clean() puts back the real form element containing the real input element"), the real and cloned input elements are left in the DOM along with the real and cloned form elements; they're just swapped. This way, the transformation can be reversed using the same swapping function based only on the DOM positions.

(This doesn't actually fix the double initialization by itself, of course)

#### Issues this closes
n/a