### PR TITLE
AccessKit: Make alt text user-selectable

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -58,4 +58,7 @@ figure.accesskit-visible-alt-text figcaption {
   line-height: 1.5;
   text-align: center;
   overflow-wrap: break-word;
+
+  user-select: text;
+  cursor: initial;
 }

--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -29,6 +29,7 @@ const processImages = function (imageElements) {
     if (!shouldShowCaption) continue;
 
     const caption = Object.assign(document.createElement('figcaption'), { textContent: alt });
+    caption.addEventListener('click', event => event.stopPropagation());
     imageBlock.append(caption);
   }
 };


### PR DESCRIPTION
#### User-facing changes
- AccessKit's alt text captions no longer act like part of the button that opens the lightbox, but instead act like regular text boxes that can be selected and copied.

Not tested on mobile.

#### Technical explanation
I was surprised at how easy this was, though it does feel a little weird. But I guess the state of "being inside a button element" confers a set of attributes that are ultimately all manipulatable.

#### Issues this closes
Discussion #519