### PR TITLE
AccessKit: Make alt text user-selectable in the radar

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -62,7 +62,3 @@ figure.accesskit-visible-alt-text figcaption {
   user-select: text;
   cursor: initial;
 }
-
-:any-link figure.accesskit-visible-alt-text figcaption {
-  cursor: inherit;
-}

--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -29,7 +29,10 @@ const processImages = function (imageElements) {
     if (!shouldShowCaption) continue;
 
     const caption = Object.assign(document.createElement('figcaption'), { textContent: alt });
-    caption.addEventListener('click', event => event.stopPropagation());
+    caption.addEventListener('click', event => {
+      event.preventDefault();
+      event.stopPropagation();
+    });
     imageBlock.append(caption);
   }
 };


### PR DESCRIPTION
#### User-facing changes
- AccessKit's alt text captions can now be selected in the radar in the same way that they can be in posts in other locations.

#### Technical explanation
I had actually originally assumed `preventDefault()` would be necessary in #520, but it worked without it, so I committed it that way, thinking, "wow, button elements are weird." Well... turns out that it is necessary!

#### Issues this closes
n/a