### PR TITLE
Fix z-index thrashing with native shorten posts

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -2,7 +2,6 @@
   position: absolute;
   top: 1ch;
   right: 1ch;
-  z-index: 1;
 
   height: 1em;
   padding: 5px;
@@ -20,7 +19,6 @@
 
 .xkit-paused-gif {
   position: absolute;
-  z-index: 1;
 }
 
 figure:hover .xkit-paused-gif,

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -17,13 +17,18 @@ const pauseGif = function (gifElement) {
     const gifLabel = document.createElement('p');
     gifLabel.className = 'xkit-gif-label';
 
-    gifElement.parentNode.prepend(canvas, gifLabel);
+    gifElement.parentNode.append(canvas, gifLabel);
   };
 };
 
 const processGifs = function (gifElements) {
   gifElements.forEach(gifElement => {
-    if (gifElement.parentNode.querySelector('.xkit-paused-gif') !== null) {
+    const pausedGifElements = [
+      ...gifElement.parentNode.querySelectorAll('.xkit-paused-gif'),
+      ...gifElement.parentNode.querySelectorAll('.xkit-gif-label')
+    ];
+    if (pausedGifElements.length) {
+      gifElement.after(...pausedGifElements);
       return;
     }
 

--- a/src/scripts/cleanfeed.css
+++ b/src/scripts/cleanfeed.css
@@ -8,7 +8,6 @@
   position: absolute;
   top: 0;
   left: 0;
-  z-index: 1;
 
   display: flex;
   justify-content: center;


### PR DESCRIPTION
...by not using z-indexes at all. Certainly not the only way to solve this.

#### User-facing changes
- AccessKit paused gifs and CleanFeed hidden images no longer appear over Tumblr's native shorten post control element and flicker when hovered.

#### Technical explanation
Rather than adding a z-index to the Tumblr native shorten post control element, this removes the z-indexes from the Disable Gifs elements and the CleanFeed element and uses DOM ordering to ensure that they appear on top of the images they are supposed to replace.

Cleanfeed's element is an `::after` element, so I don't think it's possible for it to be out of order(?) and its z-index seems unnecessary.

Disable Gifs, as you pointed out in the relevant GitHub issue, needs to handle gifs being removed from the DOM and reattached as the last child of their containers, since React does not know about our placeholders. Rather than just exiting when this occurs, this moves the existing placeholders after the image before exiting.

I think `pausedGifElements` is an unclear variable name, but I didn't have any better ideas.

#### Issues this closes
#536