### PR TITLE
Show Originals: Fix UI desync in blog view

### DIFF
--- a/src/scripts/show_originals.css
+++ b/src/scripts/show_originals.css
@@ -1,4 +1,4 @@
-[data-show-originals="on"] .xkit-show-originals-hidden article {
+[data-show-originals="on"] ~ .xkit-show-originals-hidden article {
   display: none;
 }
 
@@ -30,8 +30,8 @@
   opacity: 0.65;
 }
 
-[data-show-originals="on"] .xkit-show-originals-controls > a[data-mode="on"],
-[data-show-originals="off"] .xkit-show-originals-controls > a[data-mode="off"],
+[data-show-originals="on"].xkit-show-originals-controls > a[data-mode="on"],
+[data-show-originals="off"].xkit-show-originals-controls > a[data-mode="off"],
 .xkit-show-originals-controls > a[data-mode="disabled"] {
   box-shadow: inset 0 -3px 0 var(--blog-link-color, rgb(var(--accent)));
   color: var(--blog-link-color, rgb(var(--accent)));

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -34,15 +34,15 @@ const createButton = (textContent, onclick, mode) => {
 };
 
 const addControls = async (timelineElement, location, disabled) => {
+  const controls = Object.assign(document.createElement('div'), { className: controlsClass });
+
   const handleClick = async ({ currentTarget: { dataset: { mode } } }) => {
-    timelineElement.dataset.showOriginals = mode;
+    controls.dataset.showOriginals = mode;
 
     const { [storageKey]: savedModes = {} } = await browser.storage.local.get(storageKey);
     savedModes[location] = mode;
     browser.storage.local.set({ [storageKey]: savedModes });
   };
-
-  const controls = Object.assign(document.createElement('div'), { className: controlsClass });
 
   const onButton = createButton(await translate('Original Posts'), handleClick, 'on');
   const offButton = createButton(await translate('All posts'), handleClick, 'off');
@@ -55,6 +55,7 @@ const addControls = async (timelineElement, location, disabled) => {
   } else {
     timelineElement.querySelector(postSelector)?.parentElement?.prepend(controls);
   }
+  return controls;
 };
 
 const processTimelines = async () => {
@@ -75,13 +76,13 @@ const processTimelines = async () => {
       const isDisabledPeeprBlog = disabledPeeprBlogs.some(name => timeline.startsWith(`/v2/blog/${name}/posts`));
 
       if (location && timelineElement.querySelector(`.${controlsClass}`) === null) {
-        addControls(timelineElement, location, isDisabledPeeprBlog);
+        const controls = await addControls(timelineElement, location, isDisabledPeeprBlog);
         if (isDisabledPeeprBlog) return;
 
         lengthenTimeline(timelineElement);
         const { [storageKey]: savedModes = {} } = await browser.storage.local.get(storageKey);
         const mode = savedModes[location] ?? 'on';
-        timelineElement.dataset.showOriginals = mode;
+        controls.dataset.showOriginals = mode;
       }
     });
 };

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -33,8 +33,14 @@ const createButton = (textContent, onclick, mode) => {
   return button;
 };
 
-const addControls = async (timelineElement, location, disabled) => {
+const addControls = async (timelineElement, location) => {
   const controls = Object.assign(document.createElement('div'), { className: controlsClass });
+  controls.dataset.location = location;
+
+  const firstPost = timelineElement.querySelector(postSelector);
+  location === 'blogSubscriptions'
+    ? firstPost?.before(controls)
+    : firstPost?.parentElement?.prepend(controls);
 
   const handleClick = async ({ currentTarget: { dataset: { mode } } }) => {
     controls.dataset.showOriginals = mode;
@@ -48,43 +54,48 @@ const addControls = async (timelineElement, location, disabled) => {
   const offButton = createButton(await translate('All posts'), handleClick, 'off');
   const disabledButton = createButton(await translate('All posts'), null, 'disabled');
 
-  controls.append(...disabled ? [disabledButton] : [onButton, offButton]);
-
-  if (location === 'blogSubscriptions') {
-    timelineElement.querySelector(postSelector)?.before(controls);
+  if (location === 'disabled') {
+    controls.append(disabledButton);
   } else {
-    timelineElement.querySelector(postSelector)?.parentElement?.prepend(controls);
+    controls.append(onButton, offButton);
+
+    lengthenTimeline(timelineElement);
+    const { [storageKey]: savedModes = {} } = await browser.storage.local.get(storageKey);
+    const mode = savedModes[location] ?? 'on';
+    controls.dataset.showOriginals = mode;
   }
-  return controls;
+};
+
+const getLocation = timelineElement => {
+  const { timeline, which } = timelineElement.dataset;
+
+  const isInPeepr = getComputedStyle(timelineElement).getPropertyValue('--blog-title-color') !== '';
+  const isSinglePostPeepr = timeline.includes('permalink');
+
+  const on = {
+    dashboard: timeline === '/v2/timeline/dashboard',
+    peepr: isInPeepr && !isSinglePostPeepr,
+    blogSubscriptions: timeline === '/v2/timeline' && which === 'blog_subscriptions'
+  };
+  const location = Object.keys(on).find(location => on[location]);
+  const isDisabledPeeprBlog = disabledPeeprBlogs.some(name => timeline.startsWith(`/v2/blog/${name}/posts`));
+
+  if (!location || isSinglePostPeepr) return undefined;
+  if (isDisabledPeeprBlog) return 'disabled';
+  return location;
 };
 
 const processTimelines = async () => {
   await exposeTimelines();
-  [...document.querySelectorAll('[data-timeline]')]
-    .forEach(async timelineElement => {
-      const { timeline, which } = timelineElement.dataset;
+  [...document.querySelectorAll('[data-timeline]')].forEach(async timelineElement => {
+    const location = getLocation(timelineElement);
 
-      const isInPeepr = getComputedStyle(timelineElement).getPropertyValue('--blog-title-color') !== '';
-      const isSinglePostPeepr = timeline.includes('permalink');
-
-      const on = {
-        dashboard: timeline === '/v2/timeline/dashboard',
-        peepr: isInPeepr && !isSinglePostPeepr,
-        blogSubscriptions: timeline === '/v2/timeline' && which === 'blog_subscriptions'
-      };
-      const location = Object.keys(on).find(location => on[location]);
-      const isDisabledPeeprBlog = disabledPeeprBlogs.some(name => timeline.startsWith(`/v2/blog/${name}/posts`));
-
-      if (location && timelineElement.querySelector(`.${controlsClass}`) === null) {
-        const controls = await addControls(timelineElement, location, isDisabledPeeprBlog);
-        if (isDisabledPeeprBlog) return;
-
-        lengthenTimeline(timelineElement);
-        const { [storageKey]: savedModes = {} } = await browser.storage.local.get(storageKey);
-        const mode = savedModes[location] ?? 'on';
-        controls.dataset.showOriginals = mode;
-      }
-    });
+    const currentControls = timelineElement.querySelector(`.${controlsClass}`);
+    if (currentControls?.dataset?.location !== location) {
+      currentControls?.remove();
+      if (location) addControls(timelineElement, location);
+    }
+  });
 };
 
 const processPosts = async function (postElements) {


### PR DESCRIPTION
Because navigating within the blog view to another blog (whether it is to a single post or to that blog's timeline) does not unmount the timeline element, the Show Originals controls are not removed or changed to reflect the new location. Using the existence of the controls element as part of a state machine, which I previously did, was evidently a bad idea.

#### User-facing changes

Fixes UI desync bugs in the Show Originals UI when soft navigating within the blog view modal:

- navigating from a whitelisted blog to a non-whitelisted blog does not switch from whitelist to non-whitelist and vice versa
- navigating from a timeline where reblogs are hidden to a single post which is a reblog hides the single post

#### Technical explanation

This state machine was getting pretty complicated and unwieldy, and I want to minimize complication in a script that is supposed to do a relatively simple thing (heh, immediate failure there). Instead of trying to think of and handle every kind of state transition, here is the most straightforward, declarative logic I could think of:

- Running `getLocation` on a timeline returns  `undefined` to display no UI or a location string to display the Show Originals controls in that mode.
- The controls element has a `location` data attribute set to this value. Whether reblogs are hidden is entirely controlled by the controls element.
- `processTimelines` checks every timeline with `getLocation` and replaces any controls element with the incorrect `location` attribute with a new one.

(...Yes, you can tell I code React; the controls element is effectively a component with a prop.)

#### Issues this closes
n/a