### PR TITLE
AccessKit: Disable more gifs

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -21,8 +21,8 @@
   position: absolute;
 }
 
-figure:hover .xkit-paused-gif,
-figure:hover .xkit-gif-label {
+*:hover > .xkit-paused-gif,
+*:hover > .xkit-gif-label {
   display: none;
 }
 

--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -26,6 +26,14 @@
   display: none;
 }
 
+.xkit-paused-background-gif:not(:hover) {
+  background-image: none !important;
+  background-color: rgb(var(--secondary-accent));
+}
+
+.xkit-paused-background-gif:not(:hover) > div {
+  color: rgb(var(--black));
+}
 
 body.accesskit-blue-links article a[target="_blank"][href^="https://t.umblr.com/redirect"],
 body.accesskit-blue-links article a[target="_blank"][href^="https://href.li/"] {

--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -9,6 +9,7 @@
 
   background-color: rgb(var(--black));
   color: rgb(var(--white));
+  font-size: 1rem;
   font-weight: bold;
   line-height: 1em;
 }

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -71,6 +71,7 @@ export const main = async function () {
 
 export const clean = async function () {
   pageModifications.unregister(processGifs);
+  pageModifications.unregister(processBackgroundGifs);
   document.body.classList.remove(className);
 
   $('.xkit-paused-gif, .xkit-gif-label').remove();

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -1,5 +1,5 @@
 import { pageModifications } from '../../util/mutations.js';
-import { keyToCss } from '../../util/css_map.js';
+import { keyToCss, resolveExpressions } from '../../util/css_map.js';
 
 const className = 'accesskit-disable-gifs';
 
@@ -58,11 +58,14 @@ const processBackgroundGifs = function (gifBackgroundElements) {
 
 export const main = async function () {
   document.body.classList.add(className);
-  const gifImageContainer = `:is(figure, ${await keyToCss('tagImage')})`;
-  const gifImage = `${gifImageContainer} img[srcset*=".gif"]`;
+  const gifImage = await resolveExpressions`
+    :is(figure, ${keyToCss('tagImage')}) img[srcset*=".gif"]
+  `;
   pageModifications.register(gifImage, processGifs);
 
-  const gifBackgroundImage = `[style*=".gif"]${await keyToCss('communityHeaderImage')}`;
+  const gifBackgroundImage = await resolveExpressions`
+    ${keyToCss('communityHeaderImage')}[style*=".gif"]
+  `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 };
 

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -64,7 +64,7 @@ export const main = async function () {
   pageModifications.register(gifImage, processGifs);
 
   const gifBackgroundImage = await resolveExpressions`
-    ${keyToCss('communityHeaderImage')}[style*=".gif"]
+    ${keyToCss('communityHeaderImage', 'bannerImage')}[style*=".gif"]
   `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 };

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -59,7 +59,7 @@ const processBackgroundGifs = function (gifBackgroundElements) {
 export const main = async function () {
   document.body.classList.add(className);
   const gifImage = await resolveExpressions`
-    :is(figure, ${keyToCss('tagImage')}) img[srcset*=".gif"]
+    :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img[srcset*=".gif"]
   `;
   pageModifications.register(gifImage, processGifs);
 

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -41,11 +41,29 @@ const processGifs = function (gifElements) {
   });
 };
 
+const processBackgroundGifs = function (gifBackgroundElements) {
+  gifBackgroundElements.forEach(gifBackgroundElement => {
+    gifBackgroundElement.classList.add('xkit-paused-background-gif');
+    const pausedGifElements = [
+      ...gifBackgroundElement.querySelectorAll('.xkit-gif-label')
+    ];
+    if (pausedGifElements.length) {
+      return;
+    }
+    const gifLabel = document.createElement('p');
+    gifLabel.className = 'xkit-gif-label';
+    gifBackgroundElement.append(gifLabel);
+  });
+};
+
 export const main = async function () {
   document.body.classList.add(className);
   const gifImageContainer = `:is(figure, ${await keyToCss('tagImage')})`;
   const gifImage = `${gifImageContainer} img[srcset*=".gif"]`;
   pageModifications.register(gifImage, processGifs);
+
+  const gifBackgroundImage = `[style*=".gif"]${await keyToCss('communityHeaderImage')}`;
+  pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 };
 
 export const clean = async function () {
@@ -54,4 +72,5 @@ export const clean = async function () {
 
   $('.xkit-paused-gif, .xkit-gif-label').remove();
   $('.xkit-accesskit-disabled-gif').removeClass('xkit-accesskit-disabled-gif');
+  $('.xkit-paused-background-gif').removeClass('xkit-paused-background-gif');
 };

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -1,4 +1,5 @@
 import { pageModifications } from '../../util/mutations.js';
+import { keyToCss } from '../../util/css_map.js';
 
 const className = 'accesskit-disable-gifs';
 
@@ -42,7 +43,9 @@ const processGifs = function (gifElements) {
 
 export const main = async function () {
   document.body.classList.add(className);
-  pageModifications.register('figure img[srcset*=".gif"]', processGifs);
+  const gifImageContainer = `:is(figure, ${await keyToCss('tagImage')})`;
+  const gifImage = `${gifImageContainer} img[srcset*=".gif"]`;
+  pageModifications.register(gifImage, processGifs);
 };
 
 export const clean = async function () {

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -45,13 +45,13 @@ const processBackgroundGifs = function (gifBackgroundElements) {
   gifBackgroundElements.forEach(gifBackgroundElement => {
     gifBackgroundElement.classList.add('xkit-paused-background-gif');
     const pausedGifElements = [
-      ...gifBackgroundElement.querySelectorAll('.xkit-gif-label')
+      ...gifBackgroundElement.querySelectorAll('.xkit-paused-gif-label')
     ];
     if (pausedGifElements.length) {
       return;
     }
     const gifLabel = document.createElement('p');
-    gifLabel.className = 'xkit-gif-label';
+    gifLabel.className = 'xkit-paused-gif-label';
     gifBackgroundElement.append(gifLabel);
   });
 };


### PR DESCRIPTION
#### User-facing changes
- Disables GIFs in more places: the related tags previews and the banners above the timeline.

![image](https://user-images.githubusercontent.com/8336245/163130226-0983da0b-1233-4d2e-bab6-4d1428da1dbb.png)

![image](https://user-images.githubusercontent.com/8336245/163606006-a4f01314-9de2-449a-b85c-fc6b6a999a94.png)


#### Technical explanation
The `tagImage` element is quite similar to an image in a post, just smaller and without a `figure` element surrounding it. Of course, the gif labels are rather intrusive in this case - maybe they could be smaller? - but I assume a user who wants this script would prefer this to these elements being animated (well, I do, anyway). The `takeoverBanner` element is also very similar.

The communityHeaderImage element is harder: it has a gif set as its background image and the text overlay is contained within it. Rather than doing some really complicated DOM manipulation to pause it, I just used the method from the boring tag chiclets script to remove its background. Not ideal, but it works.

#### Issues this closes
n/a

---

~~WIP: I intended this to be about animated `takeoverBanner` elements, but I forgot to save the HTML of the one I was looking at and I don't have it anymore on either of my accounts, so in the meantime, here's some other paused stuff.~~

~~(If you think one function or the other is worth implementing and the other is not, I can do that too, of course.)~~

