### PR TITLE
Footer redesign revert tweak: New implementation

### DIFF
--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -1,12 +1,7 @@
-import { keyToClasses, keyToCss, resolveExpressions } from '../../util/css_map.js';
+import { keyToCss, resolveExpressions } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
-import { pageModifications } from '../../util/mutations.js';
 
 const removePaddingClass = 'xkit-footer-padding-fix';
-
-let footerRedesignClasses;
-let footerRedesignSelector;
-let postActivityWrapperSelector;
 
 const styleElement = buildStyle();
 
@@ -47,29 +42,11 @@ article footer > ${keyToCss('controls')} {
 }
 `.then(css => { styleElement.textContent = css; });
 
-const removeFooterRedesign = elements => {
-  elements.forEach(element => {
-    element.dataset.oldClassName = element.className;
-    element.classList.remove(...footerRedesignClasses);
-    if (element.querySelector(postActivityWrapperSelector)) {
-      element.classList.add(removePaddingClass);
-    }
-  });
-};
-
 export const main = async function () {
-  footerRedesignClasses = await keyToClasses('footerRedesign');
-  footerRedesignSelector = await keyToCss('footerRedesign');
-  postActivityWrapperSelector = await keyToCss('postActivityWrapper');
-  pageModifications.register(footerRedesignSelector, removeFooterRedesign);
   document.head.append(styleElement);
 };
 
 export const clean = async function () {
   styleElement.remove();
-  pageModifications.unregister(removeFooterRedesign);
-  $('[data-old-class-name]')
-    .attr('class', function () { return this.dataset.oldClassName; })
-    .removeAttr('data-old-class-name');
   $(`.${removePaddingClass}`).removeClass(removePaddingClass);
 };

--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -1,21 +1,33 @@
 import { keyToCss, resolveExpressions } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
-const removePaddingClass = 'xkit-footer-padding-fix';
-
 const styleElement = buildStyle();
 
 resolveExpressions`
-.${removePaddingClass} {
-  padding-bottom: 0;
+article footer ${keyToCss('footerRow')} {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-bottom: 12px;
+}
+article footer ${keyToCss('controls')} {
+  justify-content: flex-end;
+  padding: 0;
+  padding-right: var(--post-padding);
+  border: none;
+  margin: 0;
+}
+article footer ${keyToCss('controlIcon')} {
+  margin-left: 20px;
 }
 
-article footer > ${keyToCss('noteCount')} {
+article footer ${keyToCss('noteCount')} {
   align-items: center;
   gap: var(--post-padding);
 }
 
-article footer > ${keyToCss('controls')} {
+article footer ${keyToCss('controls')} {
   margin-left: auto;
 }
 
@@ -48,5 +60,4 @@ export const main = async function () {
 
 export const clean = async function () {
   styleElement.remove();
-  $(`.${removePaddingClass}`).removeClass(removePaddingClass);
 };

--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -13,22 +13,16 @@ article footer ${keyToCss('footerRow')} {
 }
 article footer ${keyToCss('controls')} {
   justify-content: flex-end;
-  padding: 0;
-  padding-right: var(--post-padding);
+  padding: 0 var(--post-padding) 0 0;
+  margin: 0 0 0 auto;
   border: none;
-  margin: 0;
 }
 article footer ${keyToCss('controlIcon')} {
   margin-left: 20px;
 }
-
 article footer ${keyToCss('noteCount')} {
   align-items: center;
   gap: var(--post-padding);
-}
-
-article footer ${keyToCss('controls')} {
-  margin-left: auto;
 }
 
 .xkit-control-button-container {

--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -17,16 +17,12 @@ article footer ${keyToCss('controls')} {
   margin: 0 0 0 auto;
   border: none;
 }
-article footer ${keyToCss('controlIcon')} {
+article footer ${keyToCss('controlIcon')}, .xkit-control-button-container {
   margin-left: 20px;
 }
 article footer ${keyToCss('noteCount')} {
   align-items: center;
   gap: var(--post-padding);
-}
-
-.xkit-control-button-container {
-  margin-left: 20px;
 }
 
 [role="dialog"] #quick-reblog,
@@ -48,10 +44,5 @@ article footer ${keyToCss('noteCount')} {
 }
 `.then(css => { styleElement.textContent = css; });
 
-export const main = async function () {
-  document.head.append(styleElement);
-};
-
-export const clean = async function () {
-  styleElement.remove();
-};
+export const main = async () => document.head.append(styleElement);
+export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/footer_unredesign.js
+++ b/src/scripts/tweaks/footer_unredesign.js
@@ -9,7 +9,7 @@ article footer ${keyToCss('footerRow')} {
   justify-content: space-between;
   align-items: center;
   flex-wrap: wrap;
-  margin-bottom: 12px;
+  padding-bottom: 12px;
 }
 article footer ${keyToCss('controls')} {
   justify-content: flex-end;


### PR DESCRIPTION
I haven't done what I think of as a  "self-review" of this yet, per se. Seems to work though.

#### User-facing changes
- Fixes the footer redesign revert tweak not working after Staff removed the old footer CSS.

#### Technical explanation
Primarily based on the comment in #413. This removes the manipulation of the `footerRedesign` class, which no longer exists, implementing the old footer css explicitly.

Staff added a `footerRow` element in between the footer element and its children, necessitating a few tweaks.

The functionality on #459 is done how I personally think is the most clear: always putting a bottom ~~margin~~ *padding* on the footer; never putting a top margin on the `postActivityWrapper`.

#### Issues this closes
#553