### PR TITLE
Tweaks: Add blaze button hiding 

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -50,6 +50,11 @@
       "label": "Hide the note type badges in post footers",
       "default": false
     },
+    "hide_blaze": {
+      "type": "checkbox",
+      "label": "Hide the blaze button in post footers",
+      "default": false
+    },
     "hide_filtered_posts": {
       "type": "checkbox",
       "label": "Hide filtered posts entirely",

--- a/src/scripts/tweaks/hide_blaze.js
+++ b/src/scripts/tweaks/hide_blaze.js
@@ -1,0 +1,30 @@
+import { keyToCss } from '../../util/css_map.js';
+import { buildStyle, filterPostElements } from '../../util/interface.js';
+import { translate } from '../../util/language_data.js';
+import { onNewPosts } from '../../util/mutations.js';
+
+const hiddenClass = 'xkit-blaze-hidden';
+let controlIconSelector;
+let blazeIconSelector;
+
+const styleElement = buildStyle(`.${hiddenClass} { display: none; }`);
+
+const processPosts = postElements => filterPostElements(postElements).forEach(postElement => {
+  const blazeIcon = postElement.querySelector(blazeIconSelector);
+  blazeIcon?.closest(controlIconSelector)?.classList.add(hiddenClass);
+});
+
+export const main = async function () {
+  document.head.append(styleElement);
+  controlIconSelector = await keyToCss('controlIcon');
+  const blazeLabel = await translate('Reblog');
+  blazeIconSelector = `${controlIconSelector} [aria-label="${blazeLabel}"]`;
+
+  onNewPosts.addListener(processPosts);
+};
+
+export const clean = async function () {
+  onNewPosts.removeListener(processPosts);
+  styleElement.remove();
+  $(`.${hiddenClass}`).removeClass(hiddenClass);
+};

--- a/src/scripts/tweaks/hide_blaze.js
+++ b/src/scripts/tweaks/hide_blaze.js
@@ -17,7 +17,7 @@ const processPosts = postElements => filterPostElements(postElements).forEach(po
 export const main = async function () {
   document.head.append(styleElement);
   controlIconSelector = await keyToCss('controlIcon');
-  const blazeLabel = await translate('Reblog');
+  const blazeLabel = await translate('Blaze');
   blazeIconSelector = `${controlIconSelector} [aria-label="${blazeLabel}"]`;
 
   onNewPosts.addListener(processPosts);


### PR DESCRIPTION
I don't know if this button will be togglable in Tumblr's settings, but in case it never is, here's a way to hide it.

The one thing I don't know is whether the button appears on other people's blazed posts as an indicator that that is the reason for them appearing on your dash. If that is the case, I guess this should be changed to exclude selected icons or to an onNewPosts-based script filtering for... oh, filterPostElements doesn't have an option for editable, does it. Interesting. Anyway, I need to get a blazed post to check on that. **Edit:** Looks like they do not have blaze buttons.

#### User-facing changes
- Adds a Tweaks option to hide the blaze button.

#### Technical explanation
`${keyToCss('controlIcon')} ${keyToCss('igniteButton')}` works too, though I assume it's less robust; the other control buttons don't have their own CSS classes.

#### Issues this closes
n/a