### PR TITLE
AccessKit: Remove blaze fire animation with disable animations feature

### DIFF
--- a/src/scripts/accesskit/disable_animations.js
+++ b/src/scripts/accesskit/disable_animations.js
@@ -17,6 +17,10 @@ ${playPauseSelector} {
 ${keyToCss('postLikeHeartAnimation')} {
   display: none;
 }
+
+canvas#fire-everywhere {
+  display: none;
+}
 `.then(css => { styleElement.textContent = css; });
 
 export const main = async () => document.head.append(styleElement);


### PR DESCRIPTION
#### User-facing changes
- Removes the animated fire behind the Blaze menu when AccessKit's Disable Animations option is on.

I suppose one could possibly freeze this instead of removing it if there's a way to copy the contents of a canvas?

#### Technical explanation
n/a

#### Issues this closes
n/a