### PR TITLE
AccessKit: : Disable visible alt text in Gutenberg editor

### DIFF
--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -17,7 +17,7 @@ const processImages = function (imageElements) {
   imageElements.forEach(imageElement => {
     const { alt } = imageElement;
     const imageBlock = imageElement.closest(imageBlockSelector);
-    if (imageBlock !== null) imageBlocks.set(imageBlock, alt);
+    imageBlocks.set(imageBlock, alt);
   });
 
   for (const [imageBlock, alt] of imageBlocks) {
@@ -60,7 +60,7 @@ export const main = async function () {
   styleElement.textContent = `${imageBlockLinkSelector}, ${imageBlockButtonInnerSelector} { height: 100%; }`;
   document.head.append(styleElement);
 
-  pageModifications.register('img[alt]', processImages);
+  pageModifications.register(`article ${imageBlockSelector} img[alt]`, processImages);
 
   browser.storage.onChanged.addListener(onStorageChanged);
 };

--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -8,6 +8,7 @@ let mode;
 
 let imageBlockSelector;
 let imageString;
+let blockEditorContainerSelector;
 
 const styleElement = buildStyle();
 const processedClass = 'accesskit-visible-alt-text';
@@ -15,6 +16,8 @@ const processedClass = 'accesskit-visible-alt-text';
 const processImages = function (imageElements) {
   const imageBlocks = new Map();
   imageElements.forEach(imageElement => {
+    if (imageElement.closest(blockEditorContainerSelector)) return;
+
     const { alt } = imageElement;
     const imageBlock = imageElement.closest(imageBlockSelector);
     if (imageBlock !== null) imageBlocks.set(imageBlock, alt);
@@ -53,6 +56,7 @@ export const main = async function () {
   ({ visible_alt_text_mode: mode } = await getPreferences('accesskit'));
   imageBlockSelector = await keyToCss('imageBlock');
   imageString = await translate('Image');
+  blockEditorContainerSelector = await keyToCss('blockEditorContainer');
 
   const imageBlockLinkSelector = await keyToCss('imageBlockLink');
   const imageBlockButtonInnerSelector = await resolveExpressions`${keyToCss('imageBlockButton')} ${keyToCss('buttonInner')}`;

--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -8,7 +8,6 @@ let mode;
 
 let imageBlockSelector;
 let imageString;
-let blockEditorContainerSelector;
 
 const styleElement = buildStyle();
 const processedClass = 'accesskit-visible-alt-text';
@@ -16,8 +15,6 @@ const processedClass = 'accesskit-visible-alt-text';
 const processImages = function (imageElements) {
   const imageBlocks = new Map();
   imageElements.forEach(imageElement => {
-    if (imageElement.closest(blockEditorContainerSelector)) return;
-
     const { alt } = imageElement;
     const imageBlock = imageElement.closest(imageBlockSelector);
     if (imageBlock !== null) imageBlocks.set(imageBlock, alt);
@@ -56,7 +53,6 @@ export const main = async function () {
   ({ visible_alt_text_mode: mode } = await getPreferences('accesskit'));
   imageBlockSelector = await keyToCss('imageBlock');
   imageString = await translate('Image');
-  blockEditorContainerSelector = await keyToCss('blockEditorContainer');
 
   const imageBlockLinkSelector = await keyToCss('imageBlockLink');
   const imageBlockButtonInnerSelector = await resolveExpressions`${keyToCss('imageBlockButton')} ${keyToCss('buttonInner')}`;


### PR DESCRIPTION
This is one way of solving #557. Perhaps not the best way; it would be convenient to be able to preview the alt text that you have written for an image while composing it. Getting the styling correct seems nontrivial without a better understanding of the Gutenberg code than I currently have, however.

#### User-facing changes
- There is no visible alt text in the post compose form, but at least it isn't buggy and doesn't change formatting suddenly without user interaction.

#### Technical explanation
n/a

#### Issues this closes
#557