### PR TITLE
Seen Posts: Fix dimming blazed posts

### DIFF
--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -1,4 +1,4 @@
-body:not(.xkit-seen-posts-only-dim-avatar) .xkit-seen-posts-seen:not(:hover) article,
+body:not(.xkit-seen-posts-only-dim-avatar) .xkit-seen-posts-seen:not(:hover),
 body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article > :first-child img {
   opacity: 0.5;
 }


### PR DESCRIPTION
~~I think this works. Ran out of posts to test on at the moment.~~

#### User-facing changes
- Seen posts consistently dims blazed posts.

#### Technical explanation
Sets the opacity on the entire listTimelineObject instead of just the article element. I can't think of a place where this would be a problem, but I could be wrong?

#### Issues this closes
Resolves #559.