### PR TITLE
AccessKit: Unpause all gifs on imageblock hover

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -26,7 +26,9 @@
 }
 
 *:hover > .xkit-paused-gif,
-*:hover > .xkit-paused-gif-label {
+*:hover > .xkit-gif-label,
+.xkit-paused-gif-container:hover .xkit-paused-gif,
+.xkit-paused-gif-container:hover .xkit-gif-label {
   display: none;
 }
 

--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -26,9 +26,9 @@
 }
 
 *:hover > .xkit-paused-gif,
-*:hover > .xkit-gif-label,
+*:hover > .xkit-paused-gif-label,
 .xkit-paused-gif-container:hover .xkit-paused-gif,
-.xkit-paused-gif-container:hover .xkit-gif-label {
+.xkit-paused-gif-container:hover .xkit-paused-gif-label {
   display: none;
 }
 

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -1,6 +1,7 @@
 import { pageModifications } from '../../util/mutations.js';
 import { keyToCss } from '../../util/css_map.js';
 import { dom } from '../../util/dom.js';
+import { postSelector } from '../../util/interface.js';
 
 const className = 'accesskit-disable-gifs';
 
@@ -85,7 +86,7 @@ export const main = async function () {
   `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 
-  pageModifications.register(await keyToCss('rows'), processRows);
+  pageModifications.register(`${postSelector} ${keyToCss('rows')}`, processRows);
 };
 
 export const clean = async function () {

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -1,5 +1,6 @@
 import { pageModifications } from '../../util/mutations.js';
 import { keyToCss, resolveExpressions } from '../../util/css_map.js';
+import { dom } from '../../util/dom.js';
 
 const className = 'accesskit-disable-gifs';
 
@@ -56,6 +57,22 @@ const processBackgroundGifs = function (gifBackgroundElements) {
   });
 };
 
+const processRows = function (rowsElements) {
+  rowsElements.forEach(rowsElement => {
+    [...rowsElement.children].forEach(row => {
+      if (!row.querySelector('figure')) return;
+
+      if (row.previousElementSibling?.classList?.contains('xkit-paused-gif-container')) {
+        row.previousElementSibling.append(row);
+      } else {
+        const wrapper = dom('div', { class: 'xkit-paused-gif-container' });
+        row.replaceWith(wrapper);
+        wrapper.append(row);
+      }
+    });
+  });
+};
+
 export const main = async function () {
   document.body.classList.add(className);
   const gifImage = await resolveExpressions`
@@ -67,12 +84,19 @@ export const main = async function () {
     ${keyToCss('communityHeaderImage', 'bannerImage')}[style*=".gif"]
   `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
+
+  pageModifications.register(await keyToCss('rows'), processRows);
 };
 
 export const clean = async function () {
   pageModifications.unregister(processGifs);
   pageModifications.unregister(processBackgroundGifs);
+  pageModifications.unregister(processRows);
   document.body.classList.remove(className);
+
+  [...document.querySelectorAll('.xkit-paused-gif-container')].forEach(wrapper =>
+    wrapper.replaceWith(...wrapper.children)
+  );
 
   $('.xkit-paused-gif, .xkit-paused-gif-label').remove();
   $('.xkit-accesskit-disabled-gif').removeClass('xkit-accesskit-disabled-gif');


### PR DESCRIPTION
I am kind of surprised React is okay with this. Anyway, I wanted to see if it worked and if the resulting functionality felt enjoyable and natural.

#### User-facing changes
- Hovering over any paused gif in an imageblock unpauses the entire image block

#### Technical explanation
~~Branch based off of #552; presumably I'll force push rebase this when it gets merged and if this is something we want to pursue.~~

This adds a wrapper div element around entire photosets and hides the paused gif overlay if the wrapper is hovered.

Not yet implemented: only performing this manipulation on gifs (cannot be synchronous; would have to be in processGifs checking for `.closest('.xkit-paused-gif-container')`), ~~clean function (`wrapper.replaceWith(...wrapper.children)`)~~

Edit: That I can think of, it's somewhat convoluted to only do this on photosets with a gif in them. Also, there's no way to make this behavior optional with AccessKit's preferences, and I don't know if most users would think this way makes more sense, though I do personally.

#### Issues this closes
Discussion #561