### PR TITLE
Update "blog view" exclusion filtering

### DIFF
--- a/src/scripts/shorten_posts.js
+++ b/src/scripts/shorten_posts.js
@@ -10,7 +10,7 @@ let maxHeight;
 let tagsSelector;
 
 const excludeClass = 'xkit-shorten-posts-done';
-const noPeepr = true;
+const noBlogView = true;
 
 const shortenClass = 'xkit-shorten-posts-shortened';
 const tagsClass = 'xkit-shorten-posts-tags';
@@ -35,7 +35,7 @@ const unshortenOnClick = ({ currentTarget }) => {
   currentTarget.remove();
 };
 
-const shortenPosts = postElements => filterPostElements(postElements, { excludeClass, noPeepr }).forEach(postElement => {
+const shortenPosts = postElements => filterPostElements(postElements, { excludeClass, noBlogView }).forEach(postElement => {
   if (postElement.getBoundingClientRect().height > (window.innerHeight * maxHeight)) {
     postElement.classList.add(shortenClass);
 

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -1,4 +1,4 @@
-import { filterPostElements, postSelector } from '../util/interface.js';
+import { filterPostElements, postSelector, blogViewSelector } from '../util/interface.js';
 import { timelineObject } from '../util/react_props.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
@@ -69,7 +69,7 @@ const addControls = async (timelineElement, location) => {
 const getLocation = timelineElement => {
   const { timeline, which } = timelineElement.dataset;
 
-  const isInPeepr = getComputedStyle(timelineElement).getPropertyValue('--blog-title-color') !== '';
+  const isInPeepr = timelineElement.matches(blogViewSelector);
   const isSinglePostPeepr = timeline.includes('permalink');
 
   const on = {

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -17,7 +17,7 @@ let showOwnReblogs;
 let showReblogsWithContributedContent;
 let primaryBlogName;
 let whitelist;
-let disabledPeeprBlogs;
+let disabledBlogs;
 
 const lengthenTimeline = async (timeline) => {
   const paginatorSelector = await keyToCss('manualPaginatorButtons');
@@ -69,19 +69,19 @@ const addControls = async (timelineElement, location) => {
 const getLocation = timelineElement => {
   const { timeline, which } = timelineElement.dataset;
 
-  const isInPeepr = timelineElement.matches(blogViewSelector);
-  const isSinglePostPeepr = timeline.includes('permalink');
+  const isInBlogView = timelineElement.matches(blogViewSelector);
+  const isSinglePostBlogView = timeline.includes('permalink');
 
   const on = {
     dashboard: timeline === '/v2/timeline/dashboard',
-    peepr: isInPeepr && !isSinglePostPeepr,
+    peepr: isInBlogView && !isSinglePostBlogView,
     blogSubscriptions: timeline === '/v2/timeline' && which === 'blog_subscriptions'
   };
   const location = Object.keys(on).find(location => on[location]);
-  const isDisabledPeeprBlog = disabledPeeprBlogs.some(name => timeline.startsWith(`/v2/blog/${name}/posts`));
+  const isDisabledBlog = disabledBlogs.some(name => timeline.startsWith(`/v2/blog/${name}/posts`));
 
-  if (!location || isSinglePostPeepr) return undefined;
-  if (isDisabledPeeprBlog) return 'disabled';
+  if (!location || isSinglePostBlogView) return undefined;
+  if (isDisabledBlog) return 'disabled';
   return location;
 };
 
@@ -128,7 +128,7 @@ export const main = async function () {
   const nonGroupUserBlogs = (await getUserBlogs().catch(() => []))
     .filter(blog => !blog.isGroupChannel)
     .map(blog => blog.name);
-  disabledPeeprBlogs = [...whitelist, ...showOwnReblogs ? nonGroupUserBlogs : []];
+  disabledBlogs = [...whitelist, ...showOwnReblogs ? nonGroupUserBlogs : []];
   primaryBlogName = await getPrimaryBlogName().catch(() => undefined);
 
   onNewPosts.addListener(processPosts);

--- a/src/util/interface.js
+++ b/src/util/interface.js
@@ -7,7 +7,7 @@ export const blogViewSelector = '[style*="--blog-title-color"] *';
  * @typedef {object} PostFilterOptions
  * @property {string} [excludeClass] - Classname to exclude and add
  * @property {RegExp} [timeline] - Filter results to matching [data-timeline] children
- * @property {boolean} [noPeepr] - Whether to exclude posts in the blog view modal
+ * @property {boolean} [noBlogView] - Whether to exclude posts in the blog view modal
  * @property {boolean} [includeFiltered] - Whether to include filtered posts
  */
 
@@ -16,14 +16,14 @@ export const blogViewSelector = '[style*="--blog-title-color"] *';
  * @param {PostFilterOptions} [postFilterOptions] - Post filter options
  * @returns {HTMLDivElement[]} Matching post elements
  */
-export const filterPostElements = function (postElements, { excludeClass, timeline, noPeepr = false, includeFiltered = false } = {}) {
+export const filterPostElements = function (postElements, { excludeClass, timeline, noBlogView = false, includeFiltered = false } = {}) {
   postElements = postElements.map(element => element.closest(postSelector)).filter(Boolean);
 
   if (timeline instanceof RegExp) {
     postElements = postElements.filter(postElement => timeline.test(postElement.closest('[data-timeline]')?.dataset.timeline));
   }
 
-  if (noPeepr) {
+  if (noBlogView) {
     postElements = postElements.filter(postElement => postElement.matches(blogViewSelector) === false);
   }
 

--- a/src/util/interface.js
+++ b/src/util/interface.js
@@ -1,12 +1,13 @@
 import { dom } from './dom.js';
 
 export const postSelector = '[tabindex="-1"][data-id]';
+export const blogViewSelector = '[style*="--blog-title-color"] *';
 
 /**
  * @typedef {object} PostFilterOptions
  * @property {string} [excludeClass] - Classname to exclude and add
  * @property {RegExp} [timeline] - Filter results to matching [data-timeline] children
- * @property {boolean} [noPeepr] - Whether to exclude posts in [role="dialog"]
+ * @property {boolean} [noPeepr] - Whether to exclude posts in the blog view modal
  * @property {boolean} [includeFiltered] - Whether to include filtered posts
  */
 
@@ -23,7 +24,7 @@ export const filterPostElements = function (postElements, { excludeClass, timeli
   }
 
   if (noPeepr) {
-    postElements = postElements.filter(postElement => postElement.matches(`[role="dialog"] ${postSelector}`) === false);
+    postElements = postElements.filter(postElement => postElement.matches(blogViewSelector) === false);
   }
 
   if (!includeFiltered) {


### PR DESCRIPTION
Question: Do we want to rename this option flag to `noBlogView`? Edit: Done!

#### User-facing changes
- Shorten posts is consistently inactive in the blog view.

#### Technical explanation
The noPeepr flag now checks for the blog-theme-specific styles that are applied to the view formerly know as Peepr in both glass and non-glass modes.

Checking for a parent with a style attribute is a bit faster than calling `getComputedStyle`.

#### Issues this closes
Resolves #569