### PR TITLE
Add show all tags tweak

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -24,6 +24,11 @@
       "label": "Highlight contributed content on reblogs",
       "default": false
     },
+    "show_all_tags": {
+      "type": "checkbox",
+      "label": "Show every line of tags by default",
+      "default": false
+    },
     "caught_up_line": {
       "type": "checkbox",
       "label": "Turn \"You're caught up\" into a separating line",

--- a/src/scripts/tweaks/show_all_tags.js
+++ b/src/scripts/tweaks/show_all_tags.js
@@ -1,0 +1,20 @@
+import { keyToCss, resolveExpressions } from '../../util/css_map.js';
+import { buildStyle } from '../../util/interface.js';
+
+const styleElement = buildStyle();
+resolveExpressions`
+${keyToCss('tags')}${keyToCss('collapsed')} {
+  max-height: inherit;
+}
+${keyToCss('seeAll')} {
+  display: none;
+}
+`.then(css => { styleElement.textContent = css; });
+
+export const main = async function () {
+  document.head.append(styleElement);
+};
+
+export const clean = async function () {
+  styleElement.remove();
+};

--- a/src/scripts/tweaks/show_all_tags.js
+++ b/src/scripts/tweaks/show_all_tags.js
@@ -4,7 +4,7 @@ import { buildStyle } from '../../util/interface.js';
 const styleElement = buildStyle();
 resolveExpressions`
 ${keyToCss('tags')}${keyToCss('collapsed')} {
-  max-height: inherit;
+  max-height: none;
 }
 ${keyToCss('seeAll')} {
   display: none;


### PR DESCRIPTION
Feel free to close this; it was already kind of rejected with a batch of XK7 tweaks, IIRC, but I don't think I actually put it in the list for some reason.

#### User-facing changes
- Adds a tweaks option to show all post tags instead of requiring you to click a button.

#### Technical explanation
n/a

#### Issues this closes
n/a