### PR TITLE
AccessKit: Fix XKit 7 disable gifs incompatibility

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -1,4 +1,4 @@
-.xkit-gif-label {
+.xkit-paused-gif-label {
   position: absolute;
   top: 1ch;
   right: 1ch;
@@ -13,7 +13,7 @@
   line-height: 1em;
 }
 
-.xkit-gif-label::before {
+.xkit-paused-gif-label::before {
   content: "GIF";
 }
 
@@ -22,7 +22,7 @@
 }
 
 figure:hover .xkit-paused-gif,
-figure:hover .xkit-gif-label {
+figure:hover .xkit-paused-gif-label {
   display: none;
 }
 

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -15,7 +15,7 @@ const pauseGif = function (gifElement) {
     canvas.getContext('2d').drawImage(image, 0, 0);
 
     const gifLabel = document.createElement('p');
-    gifLabel.className = 'xkit-gif-label';
+    gifLabel.className = 'xkit-paused-gif-label';
 
     gifElement.parentNode.append(canvas, gifLabel);
   };
@@ -25,7 +25,7 @@ const processGifs = function (gifElements) {
   gifElements.forEach(gifElement => {
     const pausedGifElements = [
       ...gifElement.parentNode.querySelectorAll('.xkit-paused-gif'),
-      ...gifElement.parentNode.querySelectorAll('.xkit-gif-label')
+      ...gifElement.parentNode.querySelectorAll('.xkit-paused-gif-label')
     ];
     if (pausedGifElements.length) {
       gifElement.after(...pausedGifElements);
@@ -49,6 +49,6 @@ export const clean = async function () {
   pageModifications.unregister(processGifs);
   document.body.classList.remove(className);
 
-  $('.xkit-paused-gif, .xkit-gif-label').remove();
+  $('.xkit-paused-gif, .xkit-paused-gif-label').remove();
   $('.xkit-accesskit-disabled-gif').removeClass('xkit-accesskit-disabled-gif');
 };


### PR DESCRIPTION
#### User-facing changes
- XKit 7's disable gifs and XKit Rewritten's disable gifs no longer cause styling issues when both enabled.

#### Technical explanation
n/a

#### Issues this closes
resolves #550