### PR TITLE
Quick Tags/Quick Reblog: Validate tag length

### DIFF
--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -91,8 +91,20 @@ const doSmartQuotes = ({ currentTarget }) => {
     .replace(/"/g, '\u201D');
 };
 
+const checkLength = ({ currentTarget }) => {
+  const { value } = currentTarget;
+  const tags = value.split(',').map(tag => tag.trim());
+  if (tags.some(tag => tag.length > 140)) {
+    tagsInput.setCustomValidity('Tag is longer than 140 characters!');
+    tagsInput.reportValidity();
+  } else {
+    tagsInput.setCustomValidity('');
+  }
+};
+
 tagsInput.addEventListener('input', updateTagSuggestions);
 tagsInput.addEventListener('input', doSmartQuotes);
+tagsInput.addEventListener('input', checkLength);
 
 const showPopupOnHover = ({ currentTarget }) => {
   clearTimeout(timeoutID);

--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -37,6 +37,17 @@ const doSmartQuotes = ({ currentTarget }) => {
     .replace(/"/g, '\u201D');
 };
 popupInput.addEventListener('input', doSmartQuotes);
+const checkLength = ({ currentTarget }) => {
+  const { value } = currentTarget;
+  const tags = value.split(',').map(tag => tag.trim());
+  if (tags.some(tag => tag.length > 140)) {
+    popupInput.setCustomValidity('Tag is longer than 140 characters!');
+    popupInput.reportValidity();
+  } else {
+    popupInput.setCustomValidity('');
+  }
+};
+popupInput.addEventListener('input', checkLength);
 popupForm.appendChild(popupInput);
 
 const postOptionPopupElement = Object.assign(document.createElement('div'), { id: 'quick-tags-post-option' });


### PR DESCRIPTION
#### User-facing changes
- Typing a >140 character tag into the quick tags popup text box displays an error message and prevents submission.

#### Technical explanation
Non-regex version. The regex version (setting a `pattern` attribute on the input element) requires designing some CSS to indicate the invalid state, and I didn't come up with anything that didn't look terrible. It's much fewer LOC though.

#### Issues this closes
resolves #584