### PR TITLE
Implementing option to only show posts from mutuals requested in #588

### DIFF
--- a/src/scripts/mutual_checker.css
+++ b/src/scripts/mutual_checker.css
@@ -7,6 +7,6 @@ svg.xkit-mutual-icon {
 	margin-right: 0.5ch;
 }
 
-.no-mutual {
+.xkit-mutual-checker-hidden article {
   display: none;
 }

--- a/src/scripts/mutual_checker.css
+++ b/src/scripts/mutual_checker.css
@@ -7,6 +7,6 @@ svg.xkit-mutual-icon {
 	margin-right: 0.5ch;
 }
 
-.xkit-mutual-checker-hidden article {
+[data-timeline="/v2/timeline/dashboard"] .xkit-mutual-checker-hidden article {
   display: none;
 }

--- a/src/scripts/mutual_checker.css
+++ b/src/scripts/mutual_checker.css
@@ -6,3 +6,7 @@ svg.xkit-mutual-icon {
   margin-left: 0;
 	margin-right: 0.5ch;
 }
+
+.no-mutual {
+  display: none;
+}

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -60,7 +60,7 @@ const addIcons = function (postElements) {
     if (isMutual) {
       postElement.classList.add(mutualsClass);
       postAttribution.prepend(icon.cloneNode(true));
-    } else if(showOnlyMutuals) {
+    } else if (showOnlyMutuals) {
       postElement.classList.add('no-mutual');
     } else if (!showOnlyMutuals) {
       postElement.classList.remove('no-mutual');

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -60,9 +60,9 @@ const addIcons = function (postElements) {
     if (isMutual) {
       postElement.classList.add(mutualsClass);
       postAttribution.prepend(icon.cloneNode(true));
-    } else  if(showOnlyMutuals){
+    } else if(showOnlyMutuals) {
       postElement.classList.add('no-mutual');
-    } else if(!showOnlyMutuals){
+    } else if (!showOnlyMutuals) {
       postElement.classList.remove('no-mutual');
     }
   });

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -8,6 +8,7 @@ import { dom } from '../util/dom.js';
 import { getPreferences } from '../util/preferences.js';
 
 const mutualIconClass = 'xkit-mutual-icon';
+const hiddenClass = 'xkit-mutual-checker-hidden';
 const mutualsClass = 'from-mutual';
 
 const regularPath = 'M593 500q0-45-22.5-64.5T500 416t-66.5 19-18.5 65 18.5 64.5T500 583t70.5-19 22.5-64zm-90 167q-44 0-83.5 18.5t-63 51T333 808v25h334v-25q0-39-22-71.5t-59.5-51T503 667zM166 168l14-90h558l12-78H180q-8 0-51 63l-42 63v209q-19 3-52 3t-33-3q-1 1 0 27 3 53 0 53l32-2q35-1 53 2v258H2l-3 40q-2 41 3 41 42 0 64-1 7-1 21 1v246h756q25 0 42-13 14-10 22-27 5-13 8-28l1-13V275q0-47-3-63-5-24-22.5-34T832 168H166zm667 752H167V754q17 0 38.5-6.5T241 730q16-12 16-26 0-21-33-28-19-4-57-4-3 0-1-51 2-37 1-36V421q88 0 90-48 1-20-33-30-24-6-57-6-4 0-2-44l2-43h635q14 0 22.5 11t8.5 26v543q0 5 4 26 5 30 5 42 1 22-9 22z';
@@ -61,9 +62,9 @@ const addIcons = function (postElements) {
       postElement.classList.add(mutualsClass);
       postAttribution.prepend(icon.cloneNode(true));
     } else if (showOnlyMutuals) {
-      postElement.classList.add('no-mutual');
+      postElement.classList.add(hiddenClass);
     } else if (!showOnlyMutuals) {
-      postElement.classList.remove('no-mutual');
+      postElement.classList.remove(hiddenClass);
     }
   });
 };

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -5,6 +5,7 @@ import { getPrimaryBlogName } from '../util/user.js';
 import { keyToCss } from '../util/css_map.js';
 import { onNewPosts } from '../util/mutations.js';
 import { dom } from '../util/dom.js';
+import { getPreferences } from '../util/preferences.js';
 
 const mutualIconClass = 'xkit-mutual-icon';
 const mutualsClass = 'from-mutual';
@@ -17,6 +18,7 @@ const mutuals = {};
 
 let primaryBlogName;
 let postAttributionSelector;
+let showOnlyMutuals;
 let icon;
 
 const alreadyProcessed = postElement =>
@@ -58,11 +60,16 @@ const addIcons = function (postElements) {
     if (isMutual) {
       postElement.classList.add(mutualsClass);
       postAttribution.prepend(icon.cloneNode(true));
+    } else  if(showOnlyMutuals){
+      postElement.classList.add('no-mutual');
+    } else if(!showOnlyMutuals){
+      postElement.classList.remove('no-mutual');
     }
   });
 };
 
 export const main = async function () {
+  ({ showOnlyMutuals } = await getPreferences('mutual_checker'));
   primaryBlogName = await getPrimaryBlogName();
   following[primaryBlogName] = Promise.resolve(false);
 

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -64,9 +64,6 @@ const addIcons = function (postElements) {
     } else if (showOnlyMutuals) {
       postElement.classList.add(hiddenClass);
     }
-    // else if (!showOnlyMutuals) {
-    //  postElement.classList.remove(hiddenClass);
-    //}
   });
 };
 

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -63,9 +63,10 @@ const addIcons = function (postElements) {
       postAttribution.prepend(icon.cloneNode(true));
     } else if (showOnlyMutuals) {
       postElement.classList.add(hiddenClass);
-    } else if (!showOnlyMutuals) {
-      postElement.classList.remove(hiddenClass);
     }
+    // else if (!showOnlyMutuals) {
+    //  postElement.classList.remove(hiddenClass);
+    //}
   });
 };
 
@@ -95,6 +96,7 @@ export const clean = async function () {
   onNewPosts.removeListener(addIcons);
 
   $(`.${mutualsClass}`).removeClass(mutualsClass);
+  $(`.${hiddenClass}`).removeClass(hiddenClass);
   $(`.${mutualIconClass}`).remove();
 };
 

--- a/src/scripts/mutual_checker.json
+++ b/src/scripts/mutual_checker.json
@@ -10,7 +10,7 @@
   "preferences": {
     "showOnlyMutuals": {
       "type": "checkbox",
-      "label": "Only show mutuals on dashboard",
+      "label": "Only show posts from mutuals on dashboard",
       "default": false
     }
   }

--- a/src/scripts/mutual_checker.json
+++ b/src/scripts/mutual_checker.json
@@ -6,5 +6,12 @@
     "color": "white",
     "background_color": "#777777"
   },
-  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#mutual-checker"
+  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#mutual-checker",
+  "preferences": {
+    "showOnlyMutuals": {
+      "type": "checkbox",
+      "label": "Only show mutuals on dashboard",
+      "default": false
+    }
+  }
 }

--- a/src/scripts/mutual_checker.json
+++ b/src/scripts/mutual_checker.json
@@ -10,7 +10,7 @@
   "preferences": {
     "showOnlyMutuals": {
       "type": "checkbox",
-      "label": "Only show posts from mutuals on dashboard",
+      "label": "Only show posts from mutuals on the dashboard",
       "default": false
     }
   }


### PR DESCRIPTION
#### User-facing changes
- Added option to Mutual Checker script to only show posts by mutuals on dashboard.

#### Technical explanation
- Hides via CSS all the posts made by non-mutual blogs.

#### Issues this closes
Issue #588 