### PR TITLE
Hide post element contents instead of articles

### DIFF
--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -7,7 +7,7 @@ const hiddenClass = 'xkit-no-recommended-posts-hidden';
 const timeline = /\/v2\/timeline\/dashboard/;
 const includeFiltered = true;
 
-const styleElement = buildStyle(`.${hiddenClass} article { display: none; }`);
+const styleElement = buildStyle(`.${hiddenClass} > * { display: none; }`);
 
 const processPosts = async function (postElements) {
   filterPostElements(postElements, { excludeClass, timeline, includeFiltered }).forEach(async postElement => {

--- a/src/scripts/postblock.css
+++ b/src/scripts/postblock.css
@@ -1,3 +1,3 @@
-.xkit-postblock-hidden article {
+.xkit-postblock-hidden > * {
   display: none;
 }

--- a/src/scripts/show_originals.css
+++ b/src/scripts/show_originals.css
@@ -1,4 +1,4 @@
-[data-show-originals="on"] ~ .xkit-show-originals-hidden article {
+[data-show-originals="on"] ~ .xkit-show-originals-hidden > * {
   display: none;
 }
 

--- a/src/scripts/tweaks/hide_filtered_posts.js
+++ b/src/scripts/tweaks/hide_filtered_posts.js
@@ -1,13 +1,13 @@
 import { pageModifications } from '../../util/mutations.js';
 import { keyToCss, resolveExpressions } from '../../util/css_map.js';
-import { buildStyle } from '../../util/interface.js';
+import { buildStyle, postSelector } from '../../util/interface.js';
 
 const hiddenClass = 'xkit-tweaks-hide-filtered-posts-hidden';
-const styleElement = buildStyle(`.${hiddenClass} { display: none; }`);
+const styleElement = buildStyle(`.${hiddenClass} > * { display: none; }`);
 
 const hideFilteredPosts = filteredScreens => filteredScreens
-  .map(filteredScreen => filteredScreen.closest('article'))
-  .forEach(article => article.classList.add(hiddenClass));
+  .map(filteredScreen => filteredScreen.closest(postSelector))
+  .forEach(postElement => postElement.classList.add(hiddenClass));
 
 export const main = async function () {
   const filteredScreenSelector = await resolveExpressions`article ${keyToCss('filteredScreen')}`;

--- a/src/scripts/tweaks/hide_my_posts.js
+++ b/src/scripts/tweaks/hide_my_posts.js
@@ -7,7 +7,7 @@ const excludeClass = 'xkit-tweaks-hide-my-posts-done';
 const timeline = /\/v2\/timeline\/dashboard/;
 
 const hiddenClass = 'xkit-tweaks-hide-my-posts-hidden';
-const styleElement = buildStyle(`.${hiddenClass} article { display: none; }`);
+const styleElement = buildStyle(`.${hiddenClass} > * { display: none; }`);
 
 let primaryBlogName;
 


### PR DESCRIPTION
Presumably it would take knowledge of the Tumblr code that I do not have to know if this is a good or bad idea, but I will PR it for discussion.

#### User-facing changes
- n/a

#### Technical explanation
This changes the CSS in all five scripts/tweaks that hide posts to setting `display:none` on the sibling `hiddenObserver` and `hiddenObserverMiddlePoint` elements as well as the `article` elements in hidden posts.

For the most part, this does nothing, but I assume that it affects the data Tumblr collects, which could indirectly affect the user experience as mentioned in #592.

#### Issues this closes
n/a