### PR TITLE
new tweak: Hide liked posts

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -65,6 +65,11 @@
       "label": "Hide my own posts on the dashboard",
       "default": false
     },
+    "hide_liked_posts": {
+      "type": "checkbox",
+      "label": "Hide posts that I've liked on the dashboard",
+      "default": false
+    },
     "hide_follower_counts": {
       "type": "checkbox",
       "label": "Hide my follower count where possible",

--- a/src/scripts/tweaks/hide_liked_posts.js
+++ b/src/scripts/tweaks/hide_liked_posts.js
@@ -4,7 +4,6 @@ import { buildStyle, filterPostElements } from '../../util/interface.js';
 import { timelineObject } from '../../util/react_props.js';
 import { keyToCss, resolveExpressions } from '../../util/css_map.js';
 
-const excludeClass = 'xkit-tweaks-hide-liked-posts-done';
 const timeline = /\/v2\/timeline\/dashboard/;
 
 const hiddenClass = 'xkit-tweaks-hide-liked-posts-hidden';
@@ -14,7 +13,7 @@ let primaryBlogName;
 let likedSelector;
 
 const processPosts = async function (postElements) {
-  filterPostElements(postElements, { excludeClass, timeline }).forEach(async postElement => {
+  filterPostElements(postElements, { timeline }).forEach(async postElement => {
     const { canEdit, isSubmission, postAuthor } = await timelineObject(postElement);
     const isMyPost = canEdit && (isSubmission || postAuthor === primaryBlogName || postAuthor === undefined);
 
@@ -36,6 +35,5 @@ export const clean = async function () {
   onNewPosts.removeListener(processPosts);
   styleElement.remove();
 
-  $(`.${excludeClass}`).removeClass(excludeClass);
   $(`.${hiddenClass}`).removeClass(hiddenClass);
 };

--- a/src/scripts/tweaks/hide_liked_posts.js
+++ b/src/scripts/tweaks/hide_liked_posts.js
@@ -1,0 +1,41 @@
+import { getPrimaryBlogName } from '../../util/user.js';
+import { onNewPosts } from '../../util/mutations.js';
+import { buildStyle, filterPostElements } from '../../util/interface.js';
+import { timelineObject } from '../../util/react_props.js';
+import { keyToCss, resolveExpressions } from '../../util/css_map.js';
+
+const excludeClass = 'xkit-tweaks-hide-liked-posts-done';
+const timeline = /\/v2\/timeline\/dashboard/;
+
+const hiddenClass = 'xkit-tweaks-hide-liked-posts-hidden';
+const styleElement = buildStyle(`.${hiddenClass} article { display: none; }`);
+
+let primaryBlogName;
+let likedSelector;
+
+const processPosts = async function (postElements) {
+  filterPostElements(postElements, { excludeClass, timeline }).forEach(async postElement => {
+    const { canEdit, isSubmission, postAuthor } = await timelineObject(postElement);
+    const isMyPost = canEdit && (isSubmission || postAuthor === primaryBlogName || postAuthor === undefined);
+
+    if (postElement.querySelector(likedSelector) && isMyPost === false) {
+      postElement.classList.add(hiddenClass);
+    }
+  });
+};
+
+export const main = async function () {
+  primaryBlogName = await getPrimaryBlogName();
+  likedSelector = await resolveExpressions`footer ${keyToCss('liked')}`;
+
+  onNewPosts.addListener(processPosts);
+  document.head.append(styleElement);
+};
+
+export const clean = async function () {
+  onNewPosts.removeListener(processPosts);
+  styleElement.remove();
+
+  $(`.${excludeClass}`).removeClass(excludeClass);
+  $(`.${hiddenClass}`).removeClass(hiddenClass);
+};


### PR DESCRIPTION
#### User-facing changes
Adds a tweak to hide liked posts on the dashboard.

Two functionality considerations:
- As per my comment in the linked issue, should this only check posts on load or should it immediately hide a post when you press the like button? (Currently implemented the former.)
- Should this exclude your own posts? Tweaks can't really have sub-preferences. I personally assume that, by default, no script hides my own posts besides the one whose function is specifically "hide my own posts," but I can definitely imagine disagreement on this.

#### Technical explanation
n/a

#### Issues this closes
resolves #594