### PR TITLE
new tweak: Hide footer tooltips

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -55,6 +55,11 @@
       "label": "Hide the note type badges in post footers",
       "default": false
     },
+    "hide_footer_tooltips": {
+      "type": "checkbox",
+      "label": "Hide the tooltips for the post footer control buttons",
+      "default": false
+    },
     "hide_filtered_posts": {
       "type": "checkbox",
       "label": "Hide filtered posts entirely",

--- a/src/scripts/tweaks/hide_footer_tooltips.js
+++ b/src/scripts/tweaks/hide_footer_tooltips.js
@@ -1,0 +1,18 @@
+import { keyToCss, resolveExpressions } from '../../util/css_map.js';
+import { buildStyle } from '../../util/interface.js';
+
+const styleElement = buildStyle();
+
+export const main = async function () {
+  styleElement.textContent = await resolveExpressions`
+    article footer ${keyToCss('controlIcon')} ${keyToCss('tooltip')},
+    article footer ${keyToCss('controlIcon')} ${keyToCss('tooltip')} ~ * {
+      display: none;
+    }
+  `;
+  document.head.append(styleElement);
+};
+
+export const clean = async function () {
+  styleElement.remove();
+};


### PR DESCRIPTION
No idea if this works with the newest footer redesign, as I don't have it.

#### User-facing changes
- Adds a tweak to hide the tooltips for the post footer control buttons.

#### Technical explanation
This could also target `article footer ${keyToCss('controlIcon')} ${keyToCss('popoverHolder')}`; not sure which is more robust against changes. `popoverHolder` is used for footer popovers that we don't want to target (the "oldest first" / "newest first" selector), so care must be taken here.

#### Issues this closes
resolves #595, #575