### PR TITLE
Enable import/no-cycle lint rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "sourceType": "module"
   },
   "rules": {
+    "import/no-cycle": "error"
   },
   "ignorePatterns": [
     "lib/"


### PR DESCRIPTION
#### User-facing changes
- n/a

#### Technical explanation
I don't think this is particularly important, but fun fact: the eslint `plugin:import/recommended` preset doesn't include `import/no-cycle` and so circular dependencies currently aren't linted. I don't really expect this extension to run into this, but it could plausibly happen between util files.

#### Issues this closes
n/a