### PR TITLE
Fix CSS map removed key behavior

### DIFF
--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -6,7 +6,7 @@ import { getCssMap } from './tumblr_helpers.js';
  */
 export const keyToClasses = async function (...keys) {
   const cssMap = await getCssMap;
-  return keys.flatMap(key => cssMap[key]);
+  return keys.flatMap(key => cssMap[key]).filter(Boolean);
 };
 
 /**


### PR DESCRIPTION
#### User-facing changes
- Fixes script misbehavior when Tumblr removes CSS keys

#### Technical explanation
If `keyToCss` is called with an invalid/no-longer-valid key name, it now outputs `:is()`, which doesn't appear to match anything. Previously, it cast `undefined` to `'undefined'`, and thus output `:is(.undefined)`, which actually did match a `postAttribution` element briefly rendered inside asks as they load that had the css class `undefined`.

#### Issues this closes
Addresses the core issue in #602