### PR TITLE
Convert user utilities to synchronous

### DIFF
--- a/src/scripts/anti_capitalism.js
+++ b/src/scripts/anti_capitalism.js
@@ -25,7 +25,8 @@ const showPremiumPlea = async () => {
   const { [storageKey]: hasShownPlea } = await browser.storage.local.get(storageKey);
   if (hasShownPlea) return;
 
-  const { response: { user: { hasTumblrPremium, usedToHaveTumblrPremium } } } = await userInfo;
+  if (userInfo === undefined) return;
+  const { hasTumblrPremium, usedToHaveTumblrPremium } = userInfo;
   if (hasTumblrPremium || usedToHaveTumblrPremium) {
     browser.storage.local.set({ [storageKey]: true });
     return;

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -1,7 +1,7 @@
 import { filterPostElements } from '../util/interface.js';
 import { timelineObject } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
-import { getPrimaryBlogName } from '../util/user.js';
+import { primaryBlogName } from '../util/user.js';
 import { keyToCss } from '../util/css_map.js';
 import { onNewPosts } from '../util/mutations.js';
 import { dom } from '../util/dom.js';
@@ -17,7 +17,6 @@ const aprilFoolsPath = 'M858 352q-6-14-8-35-2-12-4-38-3-38-6-54-7-28-22-43t-43-2
 const following = {};
 const mutuals = {};
 
-let primaryBlogName;
 let postAttributionSelector;
 let showOnlyMutuals;
 let icon;
@@ -68,8 +67,9 @@ const addIcons = function (postElements) {
 };
 
 export const main = async function () {
+  if (primaryBlogName === undefined) return;
+
   ({ showOnlyMutuals } = await getPreferences('mutual_checker'));
-  primaryBlogName = await getPrimaryBlogName();
   following[primaryBlogName] = Promise.resolve(false);
 
   postAttributionSelector = await keyToCss('postAttribution');

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -2,7 +2,7 @@ import { sha256 } from '../util/crypto.js';
 import { timelineObject } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { postSelector, filterPostElements, postType } from '../util/interface.js';
-import { getUserBlogs } from '../util/user.js';
+import { userBlogs } from '../util/user.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
 import { notify } from '../util/notifications.js';
@@ -278,7 +278,6 @@ export const main = async function () {
 
   popupElement.className = popupPosition;
 
-  const userBlogs = await getUserBlogs();
   blogSelector.replaceChildren(
     ...userBlogs.map(({ name, uuid }) => Object.assign(document.createElement('option'), { value: uuid, textContent: name }))
   );

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -4,7 +4,7 @@ import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
 import { keyToCss } from '../util/css_map.js';
 import { translate } from '../util/language_data.js';
-import { getPrimaryBlogName, getUserBlogs } from '../util/user.js';
+import { primaryBlogName, userBlogs } from '../util/user.js';
 
 const hiddenClass = 'xkit-show-originals-hidden';
 const lengthenedClass = 'xkit-show-originals-lengthened';
@@ -15,7 +15,6 @@ const includeFiltered = true;
 
 let showOwnReblogs;
 let showReblogsWithContributedContent;
-let primaryBlogName;
 let whitelist;
 let disabledBlogs;
 
@@ -125,11 +124,10 @@ export const main = async function () {
   } = await getPreferences('show_originals'));
 
   whitelist = whitelistedUsernames.split(',').map(username => username.trim());
-  const nonGroupUserBlogs = (await getUserBlogs().catch(() => []))
+  const nonGroupUserBlogs = userBlogs
     .filter(blog => !blog.isGroupChannel)
     .map(blog => blog.name);
   disabledBlogs = [...whitelist, ...showOwnReblogs ? nonGroupUserBlogs : []];
-  primaryBlogName = await getPrimaryBlogName().catch(() => undefined);
 
   onNewPosts.addListener(processPosts);
 };

--- a/src/scripts/tag_replacer.js
+++ b/src/scripts/tag_replacer.js
@@ -3,7 +3,7 @@ import { megaEdit } from '../util/mega_editor.js';
 import { showModal, modalCancelButton, modalCompleteButton } from '../util/modals.js';
 import { addSidebarItem, removeSidebarItem } from '../util/sidebar.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
-import { getUserBlogs } from '../util/user.js';
+import { userBlogs } from '../util/user.js';
 
 const getPostsFormId = 'xkit-tag-replacer-get-posts';
 
@@ -13,8 +13,6 @@ const createBlogSpan = name => dom('span', { class: 'tag-replacer-blog' }, null,
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const showInitialPrompt = async () => {
-  const userBlogs = await getUserBlogs();
-
   const initialForm = dom('form', { id: getPostsFormId }, { submit: confirmReplaceTag }, [
     dom('label', null, null, [
       'Replace tags on:',

--- a/src/scripts/tweaks/hide_liked_posts.js
+++ b/src/scripts/tweaks/hide_liked_posts.js
@@ -1,4 +1,4 @@
-import { getPrimaryBlogName } from '../../util/user.js';
+import { primaryBlogName } from '../../util/user.js';
 import { onNewPosts } from '../../util/mutations.js';
 import { buildStyle, filterPostElements } from '../../util/interface.js';
 import { timelineObject } from '../../util/react_props.js';
@@ -9,7 +9,6 @@ const timeline = /\/v2\/timeline\/dashboard/;
 const hiddenClass = 'xkit-tweaks-hide-liked-posts-hidden';
 const styleElement = buildStyle(`.${hiddenClass} article { display: none; }`);
 
-let primaryBlogName;
 let likedSelector;
 
 const processPosts = async function (postElements) {
@@ -24,7 +23,6 @@ const processPosts = async function (postElements) {
 };
 
 export const main = async function () {
-  primaryBlogName = await getPrimaryBlogName();
   likedSelector = await resolveExpressions`footer ${keyToCss('liked')}`;
 
   onNewPosts.addListener(processPosts);

--- a/src/scripts/tweaks/hide_my_posts.js
+++ b/src/scripts/tweaks/hide_my_posts.js
@@ -1,4 +1,4 @@
-import { getPrimaryBlogName } from '../../util/user.js';
+import { primaryBlogName } from '../../util/user.js';
 import { onNewPosts } from '../../util/mutations.js';
 import { buildStyle, filterPostElements } from '../../util/interface.js';
 import { timelineObject } from '../../util/react_props.js';
@@ -8,8 +8,6 @@ const timeline = /\/v2\/timeline\/dashboard/;
 
 const hiddenClass = 'xkit-tweaks-hide-my-posts-hidden';
 const styleElement = buildStyle(`.${hiddenClass} article { display: none; }`);
-
-let primaryBlogName;
 
 const processPosts = async function (postElements) {
   filterPostElements(postElements, { excludeClass, timeline }).forEach(async postElement => {
@@ -22,8 +20,6 @@ const processPosts = async function (postElements) {
 };
 
 export const main = async function () {
-  primaryBlogName = await getPrimaryBlogName();
-
   onNewPosts.addListener(processPosts);
   document.head.append(styleElement);
 };

--- a/src/util/user.js
+++ b/src/util/user.js
@@ -1,35 +1,28 @@
 import { apiFetch } from './tumblr_helpers.js';
 
-export const userInfo = apiFetch('/v2/user/info');
+const fetchedUserInfo = await apiFetch('/v2/user/info').catch(() => ({ response: {} }));
 
 /**
- * @returns {Promise<object[]>} - An array of blog objects the current user has post access to
+ * {object?} userInfo - The contents of the /v2/user/info API endpoint
  */
-export const getUserBlogs = async function () {
-  const { response: { user: { blogs } } } = await userInfo;
-  return blogs;
-};
+export const userInfo = fetchedUserInfo.response.user;
 
 /**
- * @returns {Promise<string[]>} - An array of blog names the current user has post access to
+ * {object[]} userBlogs - An array of blog objects the current user has post access to
  */
-export const getUserBlogNames = async function () {
-  const blogs = await getUserBlogs();
-  return blogs.map(blog => blog.name);
-};
+export const userBlogs = userInfo?.blogs ?? [];
 
 /**
- * @returns {Promise<object>} - The primary ("main") blog for the user
+ * {string[]} userBlogNames - An array of blog names the current user has post access to
  */
-export const getPrimaryBlog = async function () {
-  const blogs = await getUserBlogs();
-  return blogs.find(blog => blog.primary === true);
-};
+export const userBlogNames = userBlogs.map(blog => blog.name);
 
 /**
- * @returns {Promise<string>} - The name of the user's primary blog
+ * {object?} primaryBlog - The primary ("main") blog for the user
  */
-export const getPrimaryBlogName = async function () {
-  const primaryBlog = await getPrimaryBlog();
-  return primaryBlog.name;
-};
+export const primaryBlog = userBlogs.find(blog => blog.primary === true);
+
+/**
+ * {string?} primaryBlogName - The name of the user's primary blog
+ */
+export const primaryBlogName = primaryBlog?.name;


### PR DESCRIPTION
Okay, question: do you think it makes more sense to make the `user.js` utility exports constants, or functions?

The major difference I can see is in what happens when the API query fails (generally when the user is logged out). I assume - I just realized while writing this that I didn't test it - that if there were no error handling in a top level await, the dynamic `import()` in `main.js` would crash, and while this is handled, it seems to me like that's not ideal. Thus it makes sense to handle errors gracefully. If `user.js` exports a constant `primaryBlogName`, it has to be set to something if the API fetch fails (in this case, `undefined`), while keeping the `getPrimaryBlogName` function export could have that function throw. Before this PR, generally speaking, `user.js` throwing would crash the main function on any script that required it, nicely ensuring that scripts which expect a user do not run when there is none.

Of course, scripts should be responsible for not having buggy behavior unless `main.js` checked if you were logged in and just stopped the extension entirely if not, though some scripts do work when logged out. Even in that case, though, API queries aren't guaranteed to work, and the `.undefined` css map situation was a good reminder that graceful failure modes are nice.

---

#### User-facing changes
- n/a

#### Technical explanation


#### Issues this closes
n/a