### PR TITLE
Fix disable gifs "poster" incompatibility

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -19,6 +19,7 @@
 
 .xkit-paused-gif {
   position: absolute;
+  visibility: visible;
 }
 
 figure:hover .xkit-paused-gif,

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -1,4 +1,5 @@
 import { pageModifications } from '../../util/mutations.js';
+import { keyToCss } from '../../util/css_map.js';
 
 const className = 'accesskit-disable-gifs';
 
@@ -42,7 +43,7 @@ const processGifs = function (gifElements) {
 
 export const main = async function () {
   document.body.classList.add(className);
-  pageModifications.register('figure img[srcset*=".gif"]', processGifs);
+  pageModifications.register(`figure img[srcset*=".gif"]:not(${await keyToCss('poster')})`, processGifs);
 };
 
 export const clean = async function () {


### PR DESCRIPTION
Well, this is kind of a mess (a least temporarily?)

It appears that Tumblr now places a "poster" static image element over GIFs, with CSS that defaults both the "poster" and actual animated image element to `visibility: hidden`, and moves a class that sets `visibility: visible` from the poster to the animated element once the gif loads.

If this is fully rolled out, usable everywhere, and we want to rely on it, this makes the feature extremely easy to implement, as we can just reuse the "poster" element instead of using canvases. I lack the forbidden knowledge to know if this is currently true.

In the meantime (?), as a quick and dirty fix, this PR stops a second canvas element from being created by the "poster" element and ensures that whether or not the `visible` class gets copied, the canvas element is set to `visibility: visible`.

Not sure what happens to offscreen gifs that get scrolled back onscreen at the moment.

#### User-facing changes
- Fixes disable gifs with new Tumblr gif code

#### Technical explanation
see above

#### Issues this closes
Discussion #612