### PR TITLE
No Recommended: Fix GIFs in hidden carousels appearing

### DIFF
--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -7,6 +7,7 @@ const hiddenClass = 'xkit-no-recommended-blog-carousels-hidden';
 const styleElement = buildStyle(`
   .${hiddenClass} { position: relative; }
   .${hiddenClass} > div { visibility: hidden; position: absolute; max-width: 100%; }
+  .${hiddenClass} > div img { visibility: hidden; }
 `);
 
 let listTimelineObjectSelector;


### PR DESCRIPTION
#### User-facing changes
- Fixes GIFs from carousels sometimes appearing in the background between posts on accounts with Tumblr's latest changes to GIF loading.

#### Technical explanation
Tumblr's changes to GIF loading (detailed in #615) toggle the `visibility` css attribute on image elements to switch between static and an animated versions of GIFs.

This interferes with the changes in #282, as the Tumblr-set `visibility: visible` on GIFs within carousels overrides the `visibility: hidden` used to hide the carousels.

This ensures that these image elements have `visibility: hidden` set. This could instead be `.${hiddenClass} > div * { visibility: hidden; }` if concerned about other carousel elements having their visibility set (not sure of the performance impact).

This is the kind of thing I think I would probably want commented?

#### Issues this closes
resolves #616