### PR TITLE
No Recommended: Fix AccessKit disabled GIFs in hidden carousels appearing

### DIFF
--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -7,7 +7,7 @@ const hiddenClass = 'xkit-no-recommended-blog-carousels-hidden';
 const styleElement = buildStyle(`
   .${hiddenClass} { position: relative; }
   .${hiddenClass} > div { visibility: hidden; position: absolute; max-width: 100%; }
-  .${hiddenClass} > div img { visibility: hidden; }
+  .${hiddenClass} > div img, .${hiddenClass} > div canvas { visibility: hidden; }
 `);
 
 let listTimelineObjectSelector;


### PR DESCRIPTION
Okay, so, listen. Listen here. I, uh, I was just testing you, before.

#### User-facing changes
- Fixes GIFs from carousels sometimes appearing in the background between posts on accounts with Tumblr's latest changes to GIF loading... again, if you have AccessKit's Disable GIFs enabled.

#### Technical explanation
#618 fixes the GIF elements themselves, but not the canvas elements that Disable GIFs creates, something that definitely occurred to me last time and which I didn't fix just to make things interesting.

#### Issues this closes
n/a, I didn't write the issue