### PR TITLE
AccessKit: Fix paused transparent GIFs

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -20,6 +20,8 @@
 .xkit-paused-gif {
   position: absolute;
   visibility: visible;
+
+  background-color: rgb(var(--white));
 }
 
 figure:hover .xkit-paused-gif,


### PR DESCRIPTION
Oh, I guess it's "pause GIFs" now, huh.

#### User-facing changes
- Fixes animated GIFs being visible through the paused GIF overlay if the image in question has transparency.

#### Technical explanation


#### Issues this closes
resolves #617