### PR TITLE
No Recommended: Apply blog carousel CSS to tag carousels

### DIFF
--- a/src/scripts/no_recommended/hide_tag_carousels.js
+++ b/src/scripts/no_recommended/hide_tag_carousels.js
@@ -4,7 +4,11 @@ import { pageModifications } from '../../util/mutations.js';
 
 const hiddenClass = 'xkit-no-recommended-tag-carousels-hidden';
 
-const styleElement = buildStyle(`.${hiddenClass} > div { display: none; }`);
+const styleElement = buildStyle(`
+  .${hiddenClass} { position: relative; }
+  .${hiddenClass} > div { visibility: hidden; position: absolute; max-width: 100%; }
+  .${hiddenClass} > div img, .${hiddenClass} > div canvas { visibility: hidden; }
+`);
 
 let tagCardCarouselItemSelector;
 let listTimelineObjectSelector;


### PR DESCRIPTION
#### User-facing changes
- Extremely minor (basically irrelevant) performance increase when "hide tag carousels" is enabled.

#### Technical explanation
This applies the changes in #282 (and the subsequent tweaks) to the hide tag carousels script. Tumblr loads far fewer recommended tags than recommended blogs before giving up (it seems like the tag list is quite short, while apparently there's a nigh-unlimited supply of recommended blogs and it might actually be some kind of timeout in that case). But, you know, why not.

#### Issues this closes
n/a