### PR TITLE
Themed Posts: Implement per-trail-item theming

### DIFF
--- a/src/scripts/themed_posts.js
+++ b/src/scripts/themed_posts.js
@@ -81,8 +81,11 @@ export const main = async function () {
 
   styleElement.textContent += `
     article ${reblogSelector} {
-      margin-top: 0;
-      padding-bottom: 1px;
+      box-shadow: 0px 15px 0px 0px RGB(var(--white));
+    }
+    article ${await keyToCss('holder')} {
+      padding-bottom: 15px;
+      margin-bottom: -15px;
     }
   `;
 

--- a/src/scripts/themed_posts.js
+++ b/src/scripts/themed_posts.js
@@ -2,15 +2,20 @@ import { buildStyle, filterPostElements, blogViewSelector } from '../util/interf
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
 import { timelineObject } from '../util/react_props.js';
+import { keyToCss } from '../util/css_map.js';
 
 const styleElement = buildStyle();
 const blogs = new Set();
 const groupsFromHex = /^#(?<red>[A-Fa-f0-9]{1,2})(?<green>[A-Fa-f0-9]{1,2})(?<blue>[A-Fa-f0-9]{1,2})$/;
 
+let reblogSelector;
+
 let enableOnPeepr;
 let blacklistedUsernames;
 
 let blacklist;
+
+let reblogTrailTheming = true;
 
 const hexToRGB = (hex) => {
   const { red, green, blue } = hex.match(groupsFromHex).groups;
@@ -24,40 +29,62 @@ const processPosts = async function (postElements) {
   filterPostElements(postElements, { includeFiltered: true }).forEach(async postElement => {
     if (postElement.matches(blogViewSelector) && !enableOnPeepr) return;
 
-    const { blog: { name, theme } } = await timelineObject(postElement);
+    const { blog, trail = [] } = await timelineObject(postElement);
 
-    if (blacklist.includes(name)) return;
+    const blogData = [
+      blog,
+      ...reblogTrailTheming ? trail.map(item => item.blog) : []
+    ];
 
-    if (!blogs.has(name)) {
-      blogs.add(name);
+    blogData.forEach(({ name, theme }) => {
+      if (blacklist.includes(name)) return;
 
-      const {
-        backgroundColor,
-        titleColor,
-        linkColor
-      } = theme;
+      if (!blogs.has(name)) {
+        blogs.add(name);
 
-      const backgroundColorRGB = hexToRGB(backgroundColor);
-      const titleColorRGB = hexToRGB(titleColor);
-      const linkColorRGB = hexToRGB(linkColor);
+        const {
+          backgroundColor,
+          titleColor,
+          linkColor
+        } = theme;
 
-      styleElement.textContent += `
-        [data-xkit-themed="${name}"] {
-          --white: ${backgroundColorRGB};
-          --black: ${titleColorRGB};
-          --accent: ${linkColorRGB};
-          --color-primary-link: rgb(var(--accent));
-        }
-      `;
+        const backgroundColorRGB = hexToRGB(backgroundColor);
+        const titleColorRGB = hexToRGB(titleColor);
+        const linkColorRGB = hexToRGB(linkColor);
+
+        styleElement.textContent += `
+          [data-xkit-themed="${name}"] {
+            --white: ${backgroundColorRGB};
+            --black: ${titleColorRGB};
+            --accent: ${linkColorRGB};
+            --color-primary-link: rgb(var(--accent));
+          }
+        `;
+      }
+    });
+
+    postElement.dataset.xkitThemed = blog.name ?? '';
+
+    if (reblogTrailTheming) {
+      [...postElement.querySelectorAll(reblogSelector)].forEach((reblog, i) => {
+        reblog.dataset.xkitThemed = trail[i]?.blog?.name ?? '';
+      });
     }
-
-    postElement.dataset.xkitThemed = name;
   });
 };
 
 export const main = async function () {
-  ({ enableOnPeepr, blacklistedUsernames } = await getPreferences('themed_posts'));
+  ({ reblogTrailTheming, enableOnPeepr, blacklistedUsernames } = await getPreferences('themed_posts'));
   blacklist = blacklistedUsernames.split(',').map(username => username.trim());
+
+  reblogSelector = await keyToCss('reblog');
+
+  styleElement.textContent += `
+    article ${reblogSelector} {
+      margin-top: 0;
+      padding-bottom: 1px;
+    }
+  `;
 
   document.head.append(styleElement);
   onNewPosts.addListener(processPosts);

--- a/src/scripts/themed_posts.json
+++ b/src/scripts/themed_posts.json
@@ -7,6 +7,11 @@
     "background_color": "peru"
   },
   "preferences": {
+    "reblogTrailTheming": {
+      "type": "checkbox",
+      "label": "Theme every reblog trail item individually",
+      "default": false
+    },
     "enableOnPeepr": {
       "type": "checkbox",
       "label": "Enable theming on the blog view",


### PR DESCRIPTION
Okay, now I see what the "oh no" was all about. Ow, my eyes.

I have no idea how to fix the margin issues with `reblog` elements here. When a reblog ends in a paragraph, the paragraph has a 15px margin that collapses with the `reblog` element margin, but that makes a gap in the colored sections. Adding a 15px bottom padding makes the gap too large in this case but correct when the `reblog` ends in a media element; adding a tiny bottom padding just to remove the margin collapse makes the gap too small when the `reblog` ends in a media element; you can't color in margins.

Unless someone wants to solve this or tell me the forbidden knowledge... yeah, I've got nothing.

#### User-facing changes
- Adds an option to individually theme every reblog trail item, as requested by Cyle. Blinds the user.

#### Technical explanation
The box model hates me.

#### Issues this closes
n/a