### PR TITLE
NotificationBlock: Fix menu item missing on non-editable posts

### DIFF
--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -80,12 +80,9 @@ const onButtonClicked = async function ({ currentTarget }) {
   });
 };
 
-const blockPostFilter = async ({ blog, rebloggedFromName, id, rebloggedRootId }) => {
+const blockPostFilter = async ({ blog, id, rebloggedRootId }) => {
   const rootId = rebloggedRootId || id;
-  return (
-    (userBlogNames.includes(blog.name) || userBlogNames.includes(rebloggedFromName)) &&
-    blockedPostTargetIDs.includes(rootId) === false
-  );
+  return userBlogNames.includes(blog.name) && blockedPostTargetIDs.includes(rootId) === false;
 };
 
 const unblockPostFilter = async ({ id, rebloggedRootId }) => {

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -80,9 +80,12 @@ const onButtonClicked = async function ({ currentTarget }) {
   });
 };
 
-const blockPostFilter = async ({ blog, id, rebloggedRootId }) => {
+const blockPostFilter = async ({ blogName, rebloggedRootName, rebloggedFromName, id, rebloggedRootId }) => {
   const rootId = rebloggedRootId || id;
-  return userBlogNames.includes(blog.name) && blockedPostTargetIDs.includes(rootId) === false;
+  const yourOriginalPost = userBlogNames.includes(rebloggedRootName);
+  const yourReblog = userBlogNames.includes(blogName) || userBlogNames.includes(rebloggedFromName);
+
+  return (yourOriginalPost || yourReblog) && blockedPostTargetIDs.includes(rootId) === false;
 };
 
 const unblockPostFilter = async ({ id, rebloggedRootId }) => {

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -82,10 +82,11 @@ const onButtonClicked = async function ({ currentTarget }) {
 
 const blockPostFilter = async ({ blogName, rebloggedRootName, rebloggedFromName, id, rebloggedRootId }) => {
   const rootId = rebloggedRootId || id;
-  const yourOriginalPost = userBlogNames.includes(rebloggedRootName);
-  const yourReblog = userBlogNames.includes(blogName) || userBlogNames.includes(rebloggedFromName);
+  const canReceiveActivity = userBlogNames.includes(blogName) ||
+    userBlogNames.includes(rebloggedFromName) ||
+    userBlogNames.includes(rebloggedRootName);
 
-  return (yourOriginalPost || yourReblog) && blockedPostTargetIDs.includes(rootId) === false;
+  return canReceiveActivity && blockedPostTargetIDs.includes(rootId) === false;
 };
 
 const unblockPostFilter = async ({ id, rebloggedRootId }) => {

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -5,6 +5,7 @@ import { inject } from '../util/inject.js';
 import { keyToCss } from '../util/css_map.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 import { dom } from '../util/dom.js';
+import { userBlogNames } from '../util/user.js';
 
 const storageKey = 'notificationblock.blockedPostTargetIDs';
 const meatballButtonBlockId = 'notificationblock-block';
@@ -79,9 +80,9 @@ const onButtonClicked = async function ({ currentTarget }) {
   });
 };
 
-const blockPostFilter = async ({ id, canEdit, rebloggedRootId }) => {
+const blockPostFilter = async ({ blog, id, rebloggedRootId }) => {
   const rootId = rebloggedRootId || id;
-  return canEdit && blockedPostTargetIDs.includes(rootId) === false;
+  return userBlogNames.includes(blog.name) && blockedPostTargetIDs.includes(rootId) === false;
 };
 
 const unblockPostFilter = async ({ id, rebloggedRootId }) => {

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -80,9 +80,12 @@ const onButtonClicked = async function ({ currentTarget }) {
   });
 };
 
-const blockPostFilter = async ({ blog, id, rebloggedRootId }) => {
+const blockPostFilter = async ({ blog, rebloggedFromName, id, rebloggedRootId }) => {
   const rootId = rebloggedRootId || id;
-  return userBlogNames.includes(blog.name) && blockedPostTargetIDs.includes(rootId) === false;
+  return (
+    (userBlogNames.includes(blog.name) || userBlogNames.includes(rebloggedFromName)) &&
+    blockedPostTargetIDs.includes(rootId) === false
+  );
 };
 
 const unblockPostFilter = async ({ id, rebloggedRootId }) => {


### PR DESCRIPTION
#### User-facing changes
- NotificationBlock menu items appear on non-editable posts

#### Technical explanation
The notificationblock menu item appears on any post from any of the user's blogs, regardless of whether the user has edit access to that post.

This makes sense for blazed posts the user has made, as well as group blog posts that the user didn't make and can't edit, as the user can still see notifications on those.

#### Issues this closes
resolves #627
(for real this time)