### PR TITLE
No Recommended: hide "more like this" after liking posts

### DIFF
--- a/src/scripts/no_recommended.json
+++ b/src/scripts/no_recommended.json
@@ -33,6 +33,11 @@
       "label": "Hide related posts in the photo lightbox",
       "default": false
     },
+    "hide_liked_related_posts": {
+      "type": "checkbox",
+      "label": "Hide related posts after you like a post",
+      "default": false
+    },
     "hide_recommended_blogs": {
       "type": "checkbox",
       "label": "Hide recommended blogs in the sidebar",

--- a/src/scripts/no_recommended/hide_liked_related_posts.js
+++ b/src/scripts/no_recommended/hide_liked_related_posts.js
@@ -8,7 +8,7 @@ const hiddenClass = 'xkit-no-recommended-related-posts-hidden';
 const styleElement = buildStyle(`
   .${hiddenClass} { position: relative; }
   .${hiddenClass} > div { visibility: hidden; position: absolute; max-width: 100%; }
-  .${hiddenClass} > div img, .${hiddenClass} > div canvas { visibility: hidden; }
+  .${hiddenClass} > div :is(img, video, canvas) { display: none }
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');

--- a/src/scripts/no_recommended/hide_liked_related_posts.js
+++ b/src/scripts/no_recommended/hide_liked_related_posts.js
@@ -6,9 +6,9 @@ import { relatedPosts } from '../../util/react_props.js';
 const hiddenClass = 'xkit-no-recommended-related-posts-hidden';
 
 const styleElement = buildStyle(`
-  .${hiddenClass} { position: relative; }
-  .${hiddenClass} > div { visibility: hidden; position: absolute; max-width: 100%; }
-  .${hiddenClass} > div :is(img, video, canvas) { display: none }
+.${hiddenClass} { position: relative; }
+.${hiddenClass} > div { visibility: hidden; position: absolute; max-width: 100%; }
+.${hiddenClass} > div :is(img, video, canvas) { display: none }
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');

--- a/src/scripts/no_recommended/hide_liked_related_posts.js
+++ b/src/scripts/no_recommended/hide_liked_related_posts.js
@@ -1,0 +1,35 @@
+import { keyToCss } from '../../util/css_map.js';
+import { buildStyle, postSelector } from '../../util/interface.js';
+import { translate } from '../../util/language_data.js';
+import { pageModifications } from '../../util/mutations.js';
+
+const hiddenClass = 'xkit-no-recommended-related-posts-hidden';
+
+const styleElement = buildStyle(`
+  .${hiddenClass} { position: relative; }
+  .${hiddenClass} > div { visibility: hidden; position: absolute; max-width: 100%; }
+  .${hiddenClass} > div img, .${hiddenClass} > div canvas { visibility: hidden; }
+`);
+
+const listTimelineObjectSelector = keyToCss('listTimelineObject');
+const titleSelector = `${postSelector} + ${listTimelineObjectSelector} ${keyToCss('titleObject')}`;
+const moreLikeThis = translate('More like this');
+
+const hideRelatedRows = titleObjects => titleObjects
+  .filter(titleObject => titleObject.innerText === moreLikeThis)
+  .map(titleObject => titleObject.closest(listTimelineObjectSelector))
+  .forEach(listTimelineObject => {
+    listTimelineObject.classList.add(hiddenClass);
+    listTimelineObject.nextElementSibling.classList.add(hiddenClass);
+  });
+
+export const main = async function () {
+  document.head.append(styleElement);
+  pageModifications.register(titleSelector, hideRelatedRows);
+};
+
+export const clean = async function () {
+  pageModifications.unregister(hideRelatedRows);
+  styleElement.remove();
+  $(`.${hiddenClass}`).removeClass(hiddenClass);
+};

--- a/src/scripts/no_recommended/hide_liked_related_posts.js
+++ b/src/scripts/no_recommended/hide_liked_related_posts.js
@@ -1,7 +1,7 @@
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle, postSelector } from '../../util/interface.js';
-import { translate } from '../../util/language_data.js';
+import { buildStyle } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
+import { relatedPosts } from '../../util/react_props.js';
 
 const hiddenClass = 'xkit-no-recommended-related-posts-hidden';
 
@@ -12,20 +12,20 @@ const styleElement = buildStyle(`
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');
-const titleSelector = `${postSelector} + ${listTimelineObjectSelector} ${keyToCss('titleObject')}`;
-const moreLikeThis = translate('More like this');
 
-const hideRelatedRows = titleObjects => titleObjects
-  .filter(titleObject => titleObject.innerText === moreLikeThis)
-  .map(titleObject => titleObject.closest(listTimelineObjectSelector))
-  .forEach(listTimelineObject => {
-    listTimelineObject.classList.add(hiddenClass);
-    listTimelineObject.nextElementSibling.classList.add(hiddenClass);
+const hideRelatedRows = chicletRows => chicletRows
+  .forEach(async chicletRow => {
+    const relatedPostsData = await relatedPosts(chicletRow);
+    if (relatedPostsData) {
+      const listTimelineObject = chicletRow.closest(listTimelineObjectSelector);
+      listTimelineObject.classList.add(hiddenClass);
+      listTimelineObject.previousElementSibling.classList.add(hiddenClass);
+    }
   });
 
 export const main = async function () {
   document.head.append(styleElement);
-  pageModifications.register(titleSelector, hideRelatedRows);
+  pageModifications.register(keyToCss('chicletRow'), hideRelatedRows);
 };
 
 export const clean = async function () {


### PR DESCRIPTION
my brain is fried, I don't think this is good UI copy (should it use "more like this" maybe?), and I can't remember if the "more like this" string is already used elsewhere

#### User-facing changes
- Adds an option to No Recommended to hide the "more like this" recommended posts that appear after you like a post

#### Technical explanation
In a departure from the other carousel hiding scripts, this targets the header text instead of the DOM structure of the recommendation bit; I don't know if `chicletRow` is already used elsewhere/will get used elsewhere.

If Staff adds RNG to the title, then idk, I give up :P

#### Issues this closes
resolves #637