### PR TITLE
Add tweak 'Hide activity notification badge'

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -80,6 +80,11 @@
       "label": "Hide my follower count where possible",
       "default": false
     },
+    "hide_activity_notification_badge": {
+      "type": "checkbox",
+      "label": "Hide the activity notification badge",
+      "default": false
+    },
     "no_where_were_we": {
       "type": "checkbox",
       "label": "Hide the \"Now, where were we?\" button",

--- a/src/scripts/tweaks/hide_activity_notification_badge.js
+++ b/src/scripts/tweaks/hide_activity_notification_badge.js
@@ -1,9 +1,12 @@
-import { keyToClasses } from '../../util/css_map.js';
+import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 import { translate } from '../../util/language_data.js';
 
-const badgeSelector = keyToClasses('notificationBadge').map(cssClass => `button[aria-label="${translate('Activity')}"] .${cssClass}`).join(',');
-const styleElement = buildStyle(`${badgeSelector} { display: none; }`);
+const styleElement = buildStyle(`
+button[aria-label="${translate('Activity')}"] ${keyToCss('notificationBadge')} {
+  display: none;
+}
+`);
 
 export const main = async () => document.head.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/hide_activity_notification_badge.js
+++ b/src/scripts/tweaks/hide_activity_notification_badge.js
@@ -1,7 +1,7 @@
 import { keyToClasses } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
-const badgeSelector = keyToClasses('notificationBadge').map(cssClass => `button[aria-label="${activityAriaLabel}"] .${cssClass}`).join(',');
+const badgeSelector = keyToClasses('notificationBadge').map(cssClass => `button[aria-label="${translate('Activity')}"] .${cssClass}`).join(',');
 const styleElement = buildStyle(`${badgeSelector} { display: none; }`);
 
 export const main = async () => document.head.append(styleElement);

--- a/src/scripts/tweaks/hide_activity_notification_badge.js
+++ b/src/scripts/tweaks/hide_activity_notification_badge.js
@@ -1,0 +1,8 @@
+import { keyToClasses } from '../../util/css_map.js';
+import { buildStyle } from '../../util/interface.js';
+
+const badgeSelector = keyToClasses('notificationBadge').map(cssClass => `button[aria-label="${activityAriaLabel}"] .${cssClass}`).join(',');
+const styleElement = buildStyle(`${badgeSelector} { display: none; }`);
+
+export const main = async () => document.head.append(styleElement);
+export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/hide_activity_notification_badge.js
+++ b/src/scripts/tweaks/hide_activity_notification_badge.js
@@ -1,5 +1,6 @@
 import { keyToClasses } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
+import { translate } from '../util/language_data.js';
 
 const badgeSelector = keyToClasses('notificationBadge').map(cssClass => `button[aria-label="${translate('Activity')}"] .${cssClass}`).join(',');
 const styleElement = buildStyle(`${badgeSelector} { display: none; }`);

--- a/src/scripts/tweaks/hide_activity_notification_badge.js
+++ b/src/scripts/tweaks/hide_activity_notification_badge.js
@@ -1,6 +1,6 @@
 import { keyToClasses } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
-import { translate } from '../util/language_data.js';
+import { translate } from '../../util/language_data.js';
 
 const badgeSelector = keyToClasses('notificationBadge').map(cssClass => `button[aria-label="${translate('Activity')}"] .${cssClass}`).join(',');
 const styleElement = buildStyle(`${badgeSelector} { display: none; }`);


### PR DESCRIPTION
'Hide activity notification badge' based on the version in Xkit 7

#### User-facing changes
Option to hide the notification badge on the activity button on desktop

#### Technical explanation
I got the names from the tweak in Xkit 7

#### Issues this closes
no open issue, I went right to (draft) PR

I am not a "real" developer, and this is my first ever PR. Hope I did things somewhat right.