### PR TITLE
AccessKit Disable GIFs: Use native poster elements 

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -20,16 +20,6 @@
 
 .xkit-paused-gif {
   position: absolute;
-  visibility: visible;
-
-  background-color: rgb(var(--white));
-}
-
-*:hover > .xkit-paused-gif,
-*:hover > .xkit-paused-gif-label,
-.xkit-paused-gif-container:hover .xkit-paused-gif,
-.xkit-paused-gif-container:hover .xkit-paused-gif-label {
-  display: none;
 }
 
 .xkit-paused-background-gif:not(:hover) {

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -5,14 +5,16 @@ import { buildStyle, postSelector } from '../../util/interface.js';
 
 const className = 'accesskit-disable-gifs';
 
+const hoverContainer = `${keyToCss('placeholder')}, .xkit-paused-gif-container`;
+const disabledElement = `.xkit-paused-gif, .xkit-paused-gif-label, ${keyToCss('poster')}`;
+
 const styleElement = buildStyle(`
-  figure ${keyToCss('poster')} {
+  figure ${keyToCss('poster')}, .xkit-paused-gif {
     visibility: visible !important;
     background-color: rgb(var(--white));
   }
 
-  figure:hover ${keyToCss('poster')},
-  .xkit-paused-gif-container:hover ${keyToCss('poster')} {
+  :is(${hoverContainer}):hover :is(${disabledElement}) {
     display: none;
   }
 `);

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -108,7 +108,7 @@ export const main = async function () {
   pageModifications.register(posterSelector, processPosters);
 
   const gifImageLegacy = `
-    ${keyToCss('tagImage', 'takeoverBanner')} img[srcset*=".gif"]:not(${keyToCss('poster')})
+    ${keyToCss('tagImage', 'takeoverBanner', 'blogCard')} img[srcset*=".gif"]:not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImageLegacy, processGifsLegacy);
 

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -11,14 +11,14 @@ const hoverContainer = `${keyToCss('placeholder', 'takeoverBanner', 'postCard')}
 const disabledElement = `.xkit-paused-gif, .xkit-paused-gif-label, ${posterSelector}`;
 
 const styleElement = buildStyle(`
-  ${posterSelector}, .xkit-paused-gif {
-    visibility: visible !important;
-    background-color: rgb(var(--white));
-  }
+${posterSelector}, .xkit-paused-gif {
+  visibility: visible !important;
+  background-color: rgb(var(--white));
+}
 
-  :is(${hoverContainer}):hover :is(${disabledElement}) {
-    display: none;
-  }
+:is(${hoverContainer}):hover :is(${disabledElement}) {
+  display: none;
+}
 `);
 
 const processPosters = function (posterElements) {

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -7,7 +7,7 @@ const className = 'accesskit-disable-gifs';
 
 const posterSelector = `figure ${keyToCss('poster')}`;
 
-const hoverContainer = `${keyToCss('placeholder')}, .xkit-paused-gif-container, ${keyToCss('postCard')}`;
+const hoverContainer = `${keyToCss('placeholder', 'takeoverBanner', 'postCard')}, .xkit-paused-gif-container`;
 const disabledElement = `.xkit-paused-gif, .xkit-paused-gif-label, ${posterSelector}`;
 
 const styleElement = buildStyle(`

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -108,7 +108,7 @@ export const main = async function () {
   pageModifications.register(posterSelector, processPosters);
 
   const gifImageLegacy = `
-    ${keyToCss('tagImage', 'takeoverBanner', 'blogCard')} :is(img[srcset*=".gif"], video[src]):not(${keyToCss('poster')})
+    ${keyToCss('tagImage', 'takeoverBanner', 'blogCard')} img[srcset*=".gif"]:not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImageLegacy, processGifsLegacy);
 

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -5,7 +5,7 @@ import { buildStyle, postSelector } from '../../util/interface.js';
 
 const className = 'accesskit-disable-gifs';
 
-const hoverContainer = `${keyToCss('placeholder')}, .xkit-paused-gif-container`;
+const hoverContainer = `${keyToCss('placeholder')}, .xkit-paused-gif-container, ${keyToCss('postCard')}`;
 const disabledElement = `.xkit-paused-gif, .xkit-paused-gif-label, ${keyToCss('poster')}`;
 
 const styleElement = buildStyle(`

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -108,7 +108,7 @@ export const main = async function () {
   pageModifications.register(posterSelector, processPosters);
 
   const gifImageLegacy = `
-    ${keyToCss('tagImage', 'takeoverBanner', 'blogCard')} img[srcset*=".gif"]:not(${keyToCss('poster')})
+    ${keyToCss('tagImage', 'takeoverBanner', 'blogCard')} :is(img[srcset*=".gif"], video[src]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImageLegacy, processGifsLegacy);
 

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -5,11 +5,13 @@ import { buildStyle, postSelector } from '../../util/interface.js';
 
 const className = 'accesskit-disable-gifs';
 
+const posterSelector = `figure ${keyToCss('poster')}`;
+
 const hoverContainer = `${keyToCss('placeholder')}, .xkit-paused-gif-container, ${keyToCss('postCard')}`;
-const disabledElement = `.xkit-paused-gif, .xkit-paused-gif-label, ${keyToCss('poster')}`;
+const disabledElement = `.xkit-paused-gif, .xkit-paused-gif-label, ${posterSelector}`;
 
 const styleElement = buildStyle(`
-  figure ${keyToCss('poster')}, .xkit-paused-gif {
+  ${posterSelector}, .xkit-paused-gif {
     visibility: visible !important;
     background-color: rgb(var(--white));
   }
@@ -103,7 +105,7 @@ export const main = async function () {
   document.body.classList.add(className);
   document.head.append(styleElement);
 
-  pageModifications.register(`figure ${keyToCss('poster')}`, processPosters);
+  pageModifications.register(posterSelector, processPosters);
 
   const gifImageLegacy = `
     ${keyToCss('tagImage', 'takeoverBanner')} img[srcset*=".gif"]:not(${keyToCss('poster')})

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -11,7 +11,7 @@ const styleElement = buildStyle(`
     background-color: rgb(var(--white));
   }
 
-  figure:hover > ${keyToCss('poster')},
+  figure:hover ${keyToCss('poster')},
   .xkit-paused-gif-container:hover ${keyToCss('poster')} {
     display: none;
   }


### PR DESCRIPTION
"special cases: the ~~movie~~ xkit extension"

#### User-facing changes
- Fixes disable gifs not working when gifs are served as mp4.

#### Technical explanation
Takes advantage of Tumblr's non-animated "poster" elements that are used to hide gifs while they load... but only in gifs that are part of a post body (currently checking for `figure` elements); other locations where gifs are rendered do not use posters, so the old canvas-based code is still used for those.

A huge mess, basically.

#### Issues this closes
resolves #664
