### PR TITLE
Tag Replacer/Mass Unliker/Mass Deleter: Remove ads from api response

### DIFF
--- a/src/scripts/mass_deleter.js
+++ b/src/scripts/mass_deleter.js
@@ -76,7 +76,11 @@ const deleteDrafts = async function ({ blogName, before }) {
   while (resource) {
     await Promise.all([
       apiFetch(resource).then(({ response }) => {
-        drafts.push(...response.posts.filter(({ timestamp }) => timestamp < before));
+        const posts = response.posts
+          .filter(({ canEdit }) => canEdit === true)
+          .filter(({ timestamp }) => timestamp < before);
+
+        drafts.push(...posts);
         resource = response.links?.next?.href;
 
         foundPostsElement.textContent = `Found ${drafts.length} drafts${resource ? '...' : '.'}`;

--- a/src/scripts/mass_deleter.js
+++ b/src/scripts/mass_deleter.js
@@ -166,7 +166,11 @@ const clearQueue = async function () {
   while (resource) {
     await Promise.all([
       apiFetch(resource).then(({ response }) => {
-        queuedPosts.push(...response.posts.filter(({ queuedState }) => queuedState === 'queued'));
+        const posts = response.posts
+          .filter(({ canEdit }) => canEdit === true)
+          .filter(({ queuedState }) => queuedState === 'queued');
+
+        queuedPosts.push(...posts);
         resource = response.links?.next?.href;
 
         foundPostsElement.textContent = `Found ${queuedPosts.length} queued posts${resource ? '...' : '.'}`;

--- a/src/scripts/mass_unliker.js
+++ b/src/scripts/mass_unliker.js
@@ -14,7 +14,8 @@ const gatherLikes = async function () {
 
   while (resource) {
     const { response } = await apiFetch(resource);
-    likes.push(...response.likedPosts);
+    const posts = response.likedPosts.filter(({ reblogKey }) => reblogKey);
+    likes.push(...posts);
     gatherStatusElement.textContent = `Found ${likes.length} liked posts...`;
     resource = response.links?.next?.href;
   }

--- a/src/scripts/tag_replacer.js
+++ b/src/scripts/tag_replacer.js
@@ -137,7 +137,8 @@ const replaceTag = async ({ uuid, oldTag, newTag, appendOnly }) => {
   while (resource) {
     await Promise.all([
       apiFetch(resource).then(({ response }) => {
-        taggedPosts.push(...response.posts);
+        const posts = response.posts.filter(object => object.objectType === 'post');
+        taggedPosts.push(...posts);
         resource = response.links?.next?.href;
 
         gatherStatus.textContent = `Found ${taggedPosts.length} posts${resource ? '...' : '.'}`;

--- a/src/scripts/tag_replacer.js
+++ b/src/scripts/tag_replacer.js
@@ -137,7 +137,7 @@ const replaceTag = async ({ uuid, oldTag, newTag, appendOnly }) => {
   while (resource) {
     await Promise.all([
       apiFetch(resource).then(({ response }) => {
-        const posts = response.posts.filter(object => object.objectType === 'post');
+        const posts = response.posts.filter(({ canEdit }) => canEdit === true);
         taggedPosts.push(...posts);
         resource = response.links?.next?.href;
 


### PR DESCRIPTION
#### User-facing changes
- Tag replacer's counts will no longer be incorrect because Tumblr serves ads in the API request now (???)
- Maybe this fixes tag replacer failures (#673), but I kind of doubt it. The number always being exactly five seems too specific. (I did not observe that problem in my brief test, so I naturally didn't observe this change fixing it, either.)

#### Technical explanation
My ads had `"objectType": "client_side_ad_waterfall",` and my posts had `"objectType": "post",`.

There are a whole bunch of other API calls in the codebase to check for ads and filter, I guess.

#### Issues this closes
n/a