### PR TITLE
Tweaks: Add full note count tweak

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -24,6 +24,11 @@
       "label": "Highlight contributed content on reblogs",
       "default": false
     },
+    "show_full_note_count": {
+      "type": "checkbox",
+      "label": "Show the full note count on posts",
+      "default": false
+    },
     "show_all_tags": {
       "type": "checkbox",
       "label": "Show every line of tags by default",

--- a/src/scripts/tweaks/show_full_note_count.js
+++ b/src/scripts/tweaks/show_full_note_count.js
@@ -1,10 +1,16 @@
 import { pageModifications } from '../../util/mutations.js';
-import { translate } from '../../util/language_data.js';
+import { translate, languageData } from '../../util/language_data.js';
 import { buildStyle } from '../../util/interface.js';
 import { timelineObject } from '../../util/react_props.js';
 import { keyToCss } from '../../util/css_map.js';
 
-const numberFormat = new Intl.NumberFormat();
+const createNumberFormat = async () => {
+  const { code } = await languageData;
+  const locale = code.replaceAll('_', '-');
+  return new Intl.NumberFormat(locale);
+};
+
+const numberFormat = await createNumberFormat().catch(() => new Intl.NumberFormat());
 
 const notes = translate('notes');
 const note = translate('note');

--- a/src/scripts/tweaks/show_full_note_count.js
+++ b/src/scripts/tweaks/show_full_note_count.js
@@ -1,12 +1,11 @@
 import { pageModifications } from '../../util/mutations.js';
-import { translate, languageData } from '../../util/language_data.js';
+import { translate } from '../../util/language_data.js';
 import { buildStyle, postSelector } from '../../util/interface.js';
 import { timelineObject } from '../../util/react_props.js';
 import { keyToCss } from '../../util/css_map.js';
 
 const createNumberFormat = async () => {
-  const { code } = await languageData;
-  const locale = code.replaceAll('_', '-');
+  const locale = document.documentElement.lang;
   return new Intl.NumberFormat(locale);
 };
 

--- a/src/scripts/tweaks/show_full_note_count.js
+++ b/src/scripts/tweaks/show_full_note_count.js
@@ -38,7 +38,7 @@ export const main = async function () {
 };
 
 export const clean = async function () {
-  styleElement.remove();
   pageModifications.unregister(formatNoteElements);
+  styleElement.remove();
   $('[data-full-notes]').removeAttr('data-full-notes');
 };

--- a/src/scripts/tweaks/show_full_note_count.js
+++ b/src/scripts/tweaks/show_full_note_count.js
@@ -1,0 +1,42 @@
+import { pageModifications } from '../../util/mutations.js';
+import { translate } from '../../util/language_data.js';
+import { buildStyle } from '../../util/interface.js';
+import { timelineObject } from '../../util/react_props.js';
+import { keyToCss } from '../../util/css_map.js';
+
+const numberFormat = new Intl.NumberFormat();
+
+const notes = translate('notes');
+const note = translate('note');
+
+const styleElement = buildStyle(`
+  [data-full-notes] {
+    font-size: 0px;
+  }
+
+  [data-full-notes]::after {
+    content: attr(data-full-notes);
+    font-size: 1rem;
+  }
+`);
+
+const formatNoteElements = function (noteElements) {
+  noteElements.forEach(async noteElement => {
+    const { noteCount } = await timelineObject(noteElement);
+    if (!noteCount) return;
+
+    const label = noteCount === 1 ? note : notes;
+    noteElement.dataset.fullNotes = `${numberFormat.format(noteCount)} ${label}`;
+  });
+};
+
+export const main = async function () {
+  document.head.append(styleElement);
+  pageModifications.register(`article footer ${keyToCss('noteCountContainer')} > span`, formatNoteElements);
+};
+
+export const clean = async function () {
+  styleElement.remove();
+  pageModifications.unregister(formatNoteElements);
+  $('[data-full-notes]').removeAttr('data-full-notes');
+};

--- a/src/scripts/tweaks/show_full_note_count.js
+++ b/src/scripts/tweaks/show_full_note_count.js
@@ -4,12 +4,8 @@ import { buildStyle, postSelector } from '../../util/interface.js';
 import { timelineObject } from '../../util/react_props.js';
 import { keyToCss } from '../../util/css_map.js';
 
-const createNumberFormat = async () => {
-  const locale = document.documentElement.lang;
-  return new Intl.NumberFormat(locale);
-};
-
-const numberFormat = await createNumberFormat().catch(() => new Intl.NumberFormat());
+const { lang } = document.documentElement;
+const numberFormat = new Intl.NumberFormat(lang);
 
 const notes = translate('notes');
 const note = translate('note');

--- a/src/scripts/tweaks/show_full_note_count.js
+++ b/src/scripts/tweaks/show_full_note_count.js
@@ -1,6 +1,6 @@
 import { pageModifications } from '../../util/mutations.js';
 import { translate, languageData } from '../../util/language_data.js';
-import { buildStyle } from '../../util/interface.js';
+import { buildStyle, postSelector } from '../../util/interface.js';
 import { timelineObject } from '../../util/react_props.js';
 import { keyToCss } from '../../util/css_map.js';
 
@@ -28,7 +28,8 @@ const styleElement = buildStyle(`
 
 const formatNoteElements = function (noteElements) {
   noteElements.forEach(async noteElement => {
-    const { noteCount } = await timelineObject(noteElement);
+    const postElement = noteElement.closest(postSelector) ?? noteElement.closest('article');
+    const { noteCount } = await timelineObject(postElement);
     if (!noteCount) return;
 
     const label = noteCount === 1 ? note : notes;


### PR DESCRIPTION
#### User-facing changes
- Adds a tweak to display full note counts (1,234) instead of compact note counts (1.2k)

#### Technical explanation
Very similar to timeformat.

Using a pseudo element makes the note count non-selectable, which I personally find sort of annoying, but it looks like the note count isn't currently selectable anyway. Opinions on changing this?

#### Issues this closes
resolves #576