### PR TITLE
Tag Replacer: Add extra API filter for peace of mind

### DIFF
--- a/src/scripts/tag_replacer.js
+++ b/src/scripts/tag_replacer.js
@@ -137,7 +137,7 @@ const replaceTag = async ({ uuid, oldTag, newTag, appendOnly }) => {
   while (resource) {
     await Promise.all([
       apiFetch(resource).then(({ response }) => {
-        const posts = response.posts.filter(({ canEdit }) => canEdit === true);
+        const posts = response.posts.filter(({ canEdit, tags }) => canEdit === true && tags.includes(oldTag));
         taggedPosts.push(...posts);
         resource = response.links?.next?.href;
 

--- a/src/scripts/tag_replacer.js
+++ b/src/scripts/tag_replacer.js
@@ -137,7 +137,7 @@ const replaceTag = async ({ uuid, oldTag, newTag, appendOnly }) => {
   while (resource) {
     await Promise.all([
       apiFetch(resource).then(({ response }) => {
-        const posts = response.posts.filter(({ canEdit, tags }) => canEdit === true && tags.includes(oldTag));
+        const posts = response.posts.filter(({ canEdit, tags }) => canEdit === true && tags.some(tag => tag.toLowerCase() === oldTag.toLowerCase()));
         taggedPosts.push(...posts);
         resource = response.links?.next?.href;
 


### PR DESCRIPTION
#### User-facing changes
- Probably none; small chance of fixing unexpected tag replacer behavior.

#### Technical explanation
In the off chance that the tag-filtered version of the `/v2/blog/[blog]/posts` can have or ever gets recommended posts (related posts from your blog without that specific tag?), this adds a filter to remove them. Yes, this is probably paranoia.

#### Issues this closes
n/a