### PR TITLE
Replace jQuery cleanup functions with vanilla JS

### DIFF
--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -2,7 +2,7 @@ import { pageModifications } from '../../util/mutations.js';
 import { keyToCss } from '../../util/css_map.js';
 import { dom } from '../../util/dom.js';
 import { postSelector } from '../../util/interface.js';
-import { remove, removeClass } from '../../util/cleanup.js';
+import { removeElementsByClassName, removeClass } from '../../util/cleanup.js';
 
 const className = 'accesskit-disable-gifs';
 
@@ -100,6 +100,6 @@ export const clean = async function () {
     wrapper.replaceWith(...wrapper.children)
   );
 
-  remove('xkit-paused-gif', 'xkit-paused-gif-label');
+  removeElementsByClassName('xkit-paused-gif', 'xkit-paused-gif-label');
   removeClass('xkit-accesskit-disabled-gif', 'xkit-paused-background-gif');
 };

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -2,6 +2,7 @@ import { pageModifications } from '../../util/mutations.js';
 import { keyToCss } from '../../util/css_map.js';
 import { dom } from '../../util/dom.js';
 import { postSelector } from '../../util/interface.js';
+import { remove, removeClass } from '../../util/cleanup.js';
 
 const className = 'accesskit-disable-gifs';
 
@@ -99,7 +100,6 @@ export const clean = async function () {
     wrapper.replaceWith(...wrapper.children)
   );
 
-  $('.xkit-paused-gif, .xkit-paused-gif-label').remove();
-  $('.xkit-accesskit-disabled-gif').removeClass('xkit-accesskit-disabled-gif');
-  $('.xkit-paused-background-gif').removeClass('xkit-paused-background-gif');
+  remove('xkit-paused-gif', 'xkit-paused-gif-label');
+  removeClass('xkit-accesskit-disabled-gif', 'xkit-paused-background-gif');
 };

--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -1,3 +1,4 @@
+import { removeClass } from '../../util/cleanup.js';
 import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 import { translate } from '../../util/language_data.js';
@@ -55,7 +56,7 @@ const onStorageChanged = async function (changes, areaName) {
 
   mode = modeChanges.newValue;
   $(`.${processedClass} figcaption`).remove();
-  $(`.${processedClass}`).removeClass(processedClass);
+  removeClass(processedClass);
   pageModifications.trigger(processImages);
 };
 
@@ -74,5 +75,5 @@ export const clean = async function () {
   styleElement.remove();
 
   $(`.${processedClass} figcaption`).remove();
-  $(`.${processedClass}`).removeClass(processedClass);
+  removeClass(processedClass);
 };

--- a/src/scripts/anti_capitalism.js
+++ b/src/scripts/anti_capitalism.js
@@ -1,3 +1,4 @@
+import { removeClass } from '../util/cleanup.js';
 import { keyToCss } from '../util/css_map.js';
 import { dom } from '../util/dom.js';
 import { buildStyle } from '../util/interface.js';
@@ -67,5 +68,5 @@ export const main = async () => {
 export const clean = async () => {
   pageModifications.unregister(processVideoCTAs);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(hiddenClass);
 };

--- a/src/scripts/classic_search.js
+++ b/src/scripts/classic_search.js
@@ -1,5 +1,6 @@
 import { getPreferences } from '../util/preferences.js';
 import { pageModifications } from '../util/mutations.js';
+import { remove, removeClass } from '../util/cleanup.js';
 
 let newTab;
 
@@ -40,8 +41,8 @@ export const clean = async function () {
   pageModifications.unregister(replaceSearchForm);
 
   searchInputParent.appendChild(searchInputElement);
-  $('.classic-search').remove();
-  $('.xkit-classic-search-done').removeClass('xkit-classic-search-done');
+  remove('classic-search');
+  removeClass('xkit-classic-search-done');
 };
 
 export const stylesheet = true;

--- a/src/scripts/classic_search.js
+++ b/src/scripts/classic_search.js
@@ -1,6 +1,6 @@
 import { getPreferences } from '../util/preferences.js';
 import { pageModifications } from '../util/mutations.js';
-import { remove, removeClass } from '../util/cleanup.js';
+import { removeElementsByClassName, removeClass } from '../util/cleanup.js';
 
 let newTab;
 
@@ -41,7 +41,7 @@ export const clean = async function () {
   pageModifications.unregister(replaceSearchForm);
 
   searchInputParent.appendChild(searchInputElement);
-  remove('classic-search');
+  removeElementsByClassName('classic-search');
   removeClass('xkit-classic-search-done');
 };
 

--- a/src/scripts/cleanfeed.js
+++ b/src/scripts/cleanfeed.js
@@ -4,6 +4,7 @@ import { buildStyle, filterPostElements } from '../util/interface.js';
 import { translate } from '../util/language_data.js';
 import { timelineObject } from '../util/react_props.js';
 import { getPreferences } from '../util/preferences.js';
+import { removeClass } from '../util/cleanup.js';
 
 const hiddenClass = 'xkit-cleanfeed-filtered';
 const styleElement = buildStyle();
@@ -49,7 +50,7 @@ export const clean = async function () {
   onNewPosts.removeListener(processPosts);
   styleElement.remove();
 
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(hiddenClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/collapsed_queue.js
+++ b/src/scripts/collapsed_queue.js
@@ -2,6 +2,7 @@ import { filterPostElements } from '../util/interface.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
 import { keyToCss } from '../util/css_map.js';
+import { removeClass } from '../util/cleanup.js';
 
 const excludeClass = 'xkit-collapsed-queue-done';
 const wrapperClass = 'xkit-collapsed-queue-wrapper';
@@ -45,7 +46,7 @@ export const clean = async function () {
     wrapper.replaceWith(...container.children);
   });
 
-  $(`.${excludeClass}`).removeClass(excludeClass);
+  removeClass(excludeClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -6,7 +6,7 @@ import { keyToCss } from '../util/css_map.js';
 import { onNewPosts } from '../util/mutations.js';
 import { dom } from '../util/dom.js';
 import { getPreferences } from '../util/preferences.js';
-import { remove, removeClass } from '../util/cleanup.js';
+import { removeElementsByClassName, removeClass } from '../util/cleanup.js';
 
 const mutualIconClass = 'xkit-mutual-icon';
 const hiddenClass = 'xkit-mutual-checker-hidden';
@@ -92,7 +92,7 @@ export const clean = async function () {
   onNewPosts.removeListener(addIcons);
 
   removeClass(mutualsClass, hiddenClass);
-  remove(mutualIconClass);
+  removeElementsByClassName(mutualIconClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -6,6 +6,7 @@ import { keyToCss } from '../util/css_map.js';
 import { onNewPosts } from '../util/mutations.js';
 import { dom } from '../util/dom.js';
 import { getPreferences } from '../util/preferences.js';
+import { remove, removeClass } from '../util/cleanup.js';
 
 const mutualIconClass = 'xkit-mutual-icon';
 const hiddenClass = 'xkit-mutual-checker-hidden';
@@ -90,9 +91,8 @@ export const main = async function () {
 export const clean = async function () {
   onNewPosts.removeListener(addIcons);
 
-  $(`.${mutualsClass}`).removeClass(mutualsClass);
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
-  $(`.${mutualIconClass}`).remove();
+  removeClass(mutualsClass, hiddenClass);
+  remove(mutualIconClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -1,3 +1,4 @@
+import { removeClass } from '../../util/cleanup.js';
 import { keyToCss } from '../../util/css_map.js';
 import { buildStyle, postSelector } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
@@ -28,5 +29,5 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(hideBlogCarousels);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(hiddenClass);
 };

--- a/src/scripts/no_recommended/hide_radar.js
+++ b/src/scripts/no_recommended/hide_radar.js
@@ -1,6 +1,7 @@
 import { pageModifications } from '../../util/mutations.js';
 import { translate } from '../../util/language_data.js';
 import { buildStyle } from '../../util/interface.js';
+import { removeClass } from '../../util/cleanup.js';
 
 const hiddenClass = 'xkit-no-recommended-radar-hidden';
 
@@ -20,5 +21,5 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(checkForRadar);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(hiddenClass);
 };

--- a/src/scripts/no_recommended/hide_recommended_blogs.js
+++ b/src/scripts/no_recommended/hide_recommended_blogs.js
@@ -2,6 +2,7 @@ import { keyToCss } from '../../util/css_map.js';
 import { pageModifications } from '../../util/mutations.js';
 import { translate } from '../../util/language_data.js';
 import { buildStyle } from '../../util/interface.js';
+import { removeClass } from '../../util/cleanup.js';
 
 const hiddenClass = 'xkit-no-recommended-blogs-hidden';
 
@@ -28,5 +29,5 @@ export const clean = async function () {
   pageModifications.unregister(hideDashboardRecommended);
   pageModifications.unregister(hideTagPageRecommended);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(hiddenClass);
 };

--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -1,3 +1,4 @@
+import { removeClass } from '../../util/cleanup.js';
 import { buildStyle, filterPostElements } from '../../util/interface.js';
 import { onNewPosts } from '../../util/mutations.js';
 import { timelineObject } from '../../util/react_props.js';
@@ -32,7 +33,6 @@ export const main = async function () {
 
 export const clean = async function () {
   onNewPosts.removeListener(processPosts);
-  $(`.${excludeClass}`).removeClass(excludeClass);
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(hiddenClass, excludeClass);
   styleElement.remove();
 };

--- a/src/scripts/no_recommended/hide_tag_carousels.js
+++ b/src/scripts/no_recommended/hide_tag_carousels.js
@@ -1,3 +1,4 @@
+import { removeClass } from '../../util/cleanup.js';
 import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
@@ -30,5 +31,5 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(hideTagCarousels);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(hiddenClass);
 };

--- a/src/scripts/painter.js
+++ b/src/scripts/painter.js
@@ -3,6 +3,7 @@ import { timelineObject } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
+import { removeClass } from '../util/cleanup.js';
 
 let ownColour;
 let originalColour;
@@ -65,7 +66,7 @@ const strip = function () {
     .css('border-top', '')
     .css('border-image-source', '')
     .css('border-image-slice', '');
-  $(`.${excludeClass}`).removeClass(excludeClass);
+  removeClass(excludeClass);
 };
 
 export const main = async function () {

--- a/src/scripts/postblock.js
+++ b/src/scripts/postblock.js
@@ -4,6 +4,7 @@ import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 import { timelineObject } from '../util/react_props.js';
 import { onNewPosts, pageModifications } from '../util/mutations.js';
 import { dom } from '../util/dom.js';
+import { removeClass } from '../util/cleanup.js';
 
 const meatballButtonId = 'postblock';
 const meatballButtonLabel = 'Block this post';
@@ -66,7 +67,7 @@ export const clean = async function () {
   unregisterMeatballItem(meatballButtonId);
   onNewPosts.removeListener(processPosts);
 
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(hiddenClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -1,3 +1,4 @@
+import { remove, removeClass } from '../util/cleanup.js';
 import { cloneControlButton, createControlButtonTemplate } from '../util/control_buttons.js';
 import { keyToCss } from '../util/css_map.js';
 import { postSelector } from '../util/interface.js';
@@ -246,9 +247,8 @@ export const clean = async function () {
 
   unregisterPostOption('quick-tags');
 
-  $(`.${buttonClass}`).remove();
-  $(`.${excludeClass}`).removeClass(excludeClass);
-  $(`.${tagsClass}`).remove();
+  removeClass(excludeClass);
+  remove(buttonClass, tagsClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -1,4 +1,4 @@
-import { remove, removeClass } from '../util/cleanup.js';
+import { removeElementsByClassName, removeClass } from '../util/cleanup.js';
 import { cloneControlButton, createControlButtonTemplate } from '../util/control_buttons.js';
 import { keyToCss } from '../util/css_map.js';
 import { postSelector } from '../util/interface.js';
@@ -248,7 +248,7 @@ export const clean = async function () {
   unregisterPostOption('quick-tags');
 
   removeClass(excludeClass);
-  remove(buttonClass, tagsClass);
+  removeElementsByClassName(buttonClass, tagsClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/quote_replies.js
+++ b/src/scripts/quote_replies.js
@@ -1,4 +1,4 @@
-import { remove } from '../util/cleanup.js';
+import { removeElementsByClassName } from '../util/cleanup.js';
 import { keyToCss } from '../util/css_map.js';
 import { dom } from '../util/dom.js';
 import { inject } from '../util/inject.js';
@@ -119,7 +119,7 @@ export const main = async function () {
 
 export const clean = async function () {
   pageModifications.unregister(processNotifications);
-  remove(buttonClass);
+  removeElementsByClassName(buttonClass);
 };
 
 export const onStorageChanged = async function (changes) {

--- a/src/scripts/quote_replies.js
+++ b/src/scripts/quote_replies.js
@@ -1,3 +1,4 @@
+import { remove } from '../util/cleanup.js';
 import { keyToCss } from '../util/css_map.js';
 import { dom } from '../util/dom.js';
 import { inject } from '../util/inject.js';
@@ -118,7 +119,7 @@ export const main = async function () {
 
 export const clean = async function () {
   pageModifications.unregister(processNotifications);
-  $(`.${buttonClass}`).remove();
+  remove(buttonClass);
 };
 
 export const onStorageChanged = async function (changes) {

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -1,6 +1,7 @@
 import { filterPostElements } from '../util/interface.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
+import { removeClass } from '../util/cleanup.js';
 
 const excludeClass = 'xkit-seen-posts-done';
 const timeline = /\/v2\/timeline\/dashboard/;
@@ -58,9 +59,7 @@ export const main = async function () {
 
 export const clean = async function () {
   onNewPosts.removeListener(dimPosts);
-  $(`.${excludeClass}`).removeClass(excludeClass);
-  $(`.${dimClass}`).removeClass(dimClass);
-  $(`.${onlyDimAvatarsClass}`).removeClass(onlyDimAvatarsClass);
+  removeClass(excludeClass, removeClass, onlyDimAvatarsClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/shorten_posts.js
+++ b/src/scripts/shorten_posts.js
@@ -3,6 +3,7 @@ import { onNewPosts } from '../util/mutations.js';
 import { getPreferences } from '../util/preferences.js';
 import { keyToCss } from '../util/css_map.js';
 import { dom } from '../util/dom.js';
+import { remove, removeClass } from '../util/cleanup.js';
 
 let showTags;
 let maxHeight;
@@ -69,9 +70,8 @@ export const clean = async function () {
 
   styleElement.remove();
 
-  $(`.${excludeClass}`).removeClass(excludeClass);
-  $(`.${shortenClass}`).removeClass(shortenClass);
-  $(`.${tagsClass}, .${buttonClass}`).remove();
+  removeClass(excludeClass, shortenClass);
+  remove(tagsClass, buttonClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/shorten_posts.js
+++ b/src/scripts/shorten_posts.js
@@ -3,7 +3,7 @@ import { onNewPosts } from '../util/mutations.js';
 import { getPreferences } from '../util/preferences.js';
 import { keyToCss } from '../util/css_map.js';
 import { dom } from '../util/dom.js';
-import { remove, removeClass } from '../util/cleanup.js';
+import { removeElementsByClassName, removeClass } from '../util/cleanup.js';
 
 let showTags;
 let maxHeight;
@@ -71,7 +71,7 @@ export const clean = async function () {
   styleElement.remove();
 
   removeClass(excludeClass, shortenClass);
-  remove(tagsClass, buttonClass);
+  removeElementsByClassName(tagsClass, buttonClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -5,6 +5,7 @@ import { onNewPosts } from '../util/mutations.js';
 import { keyToCss } from '../util/css_map.js';
 import { translate } from '../util/language_data.js';
 import { userBlogs } from '../util/user.js';
+import { remove, removeClass, removeDataset } from '../util/cleanup.js';
 
 const hiddenClass = 'xkit-show-originals-hidden';
 const lengthenedClass = 'xkit-show-originals-lengthened';
@@ -131,10 +132,9 @@ export const main = async function () {
 export const clean = async function () {
   onNewPosts.removeListener(processPosts);
 
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
-  $('[data-show-originals]').removeAttr('data-show-originals');
-  $(`.${lengthenedClass}`).removeClass(lengthenedClass);
-  $(`.${controlsClass}`).remove();
+  removeClass(hiddenClass, lengthenedClass);
+  removeDataset('showOriginals');
+  remove(controlsClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -5,7 +5,7 @@ import { onNewPosts } from '../util/mutations.js';
 import { keyToCss } from '../util/css_map.js';
 import { translate } from '../util/language_data.js';
 import { userBlogs } from '../util/user.js';
-import { remove, removeClass, removeDataset } from '../util/cleanup.js';
+import { removeElementsByClassName, removeClass, removeDataset } from '../util/cleanup.js';
 
 const hiddenClass = 'xkit-show-originals-hidden';
 const lengthenedClass = 'xkit-show-originals-lengthened';
@@ -134,7 +134,7 @@ export const clean = async function () {
 
   removeClass(hiddenClass, lengthenedClass);
   removeDataset('showOriginals');
-  remove(controlsClass);
+  removeElementsByClassName(controlsClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/themed_posts.js
+++ b/src/scripts/themed_posts.js
@@ -3,6 +3,7 @@ import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
 import { timelineObject } from '../util/react_props.js';
 import { keyToCss } from '../util/css_map.js';
+import { removeDataset } from '../util/cleanup.js';
 
 const styleElement = buildStyle();
 const blogs = new Set();
@@ -99,7 +100,7 @@ export const clean = async function () {
   styleElement.remove();
   styleElement.textContent = '';
 
-  $('[data-xkit-themed]').removeAttr('data-xkit-themed');
+  removeDataset('xkitThemed');
 
   blogs.clear();
 };

--- a/src/scripts/timeformat.js
+++ b/src/scripts/timeformat.js
@@ -1,4 +1,5 @@
 import moment from '../lib/moment.js';
+import { removeDataset } from '../util/cleanup.js';
 import { pageModifications } from '../util/mutations.js';
 import { getPreferences } from '../util/preferences.js';
 
@@ -46,7 +47,7 @@ export const main = async function () {
 
 export const clean = async function () {
   pageModifications.unregister(formatTimeElements);
-  $('[data-formatted-time]').removeAttr('data-formatted-time');
+  removeDataset('formattedTime');
 };
 
 export const stylesheet = true;

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -1,4 +1,4 @@
-import { remove } from '../util/cleanup.js';
+import { removeElementsByClassName } from '../util/cleanup.js';
 import { createControlButtonTemplate, cloneControlButton } from '../util/control_buttons.js';
 import { keyToCss } from '../util/css_map.js';
 import { filterPostElements, postSelector } from '../util/interface.js';
@@ -126,5 +126,5 @@ export const main = async function () {
 
 export const clean = async function () {
   onNewPosts.removeListener(processPosts);
-  remove(buttonClass);
+  removeElementsByClassName(buttonClass);
 };

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -1,3 +1,4 @@
+import { remove } from '../util/cleanup.js';
 import { createControlButtonTemplate, cloneControlButton } from '../util/control_buttons.js';
 import { keyToCss } from '../util/css_map.js';
 import { filterPostElements, postSelector } from '../util/interface.js';
@@ -125,5 +126,5 @@ export const main = async function () {
 
 export const clean = async function () {
   onNewPosts.removeListener(processPosts);
-  $(`.${buttonClass}`).remove();
+  remove(buttonClass);
 };

--- a/src/scripts/tweaks/caught_up_line.js
+++ b/src/scripts/tweaks/caught_up_line.js
@@ -1,3 +1,4 @@
+import { removeClass } from '../../util/cleanup.js';
 import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
@@ -34,6 +35,5 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(createCaughtUpLine);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
-  $(`.${borderClass}`).removeClass(borderClass);
+  removeClass(hiddenClass, borderClass);
 };

--- a/src/scripts/tweaks/hide_filtered_posts.js
+++ b/src/scripts/tweaks/hide_filtered_posts.js
@@ -1,6 +1,7 @@
 import { pageModifications } from '../../util/mutations.js';
 import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
+import { removeClass } from '../../util/cleanup.js';
 
 const hiddenClass = 'xkit-tweaks-hide-filtered-posts-hidden';
 const styleElement = buildStyle(`.${hiddenClass} { display: none; }`);
@@ -19,5 +20,5 @@ export const clean = async function () {
   pageModifications.unregister(hideFilteredPosts);
   styleElement.remove();
 
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(hiddenClass);
 };

--- a/src/scripts/tweaks/hide_liked_posts.js
+++ b/src/scripts/tweaks/hide_liked_posts.js
@@ -1,6 +1,7 @@
 import { onNewPosts } from '../../util/mutations.js';
 import { buildStyle, filterPostElements } from '../../util/interface.js';
 import { isMyPost, timelineObject } from '../../util/react_props.js';
+import { removeClass } from '../../util/cleanup.js';
 
 const timeline = /\/v2\/timeline\/dashboard/;
 
@@ -25,5 +26,5 @@ export const clean = async function () {
   onNewPosts.removeListener(processPosts);
   styleElement.remove();
 
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(hiddenClass);
 };

--- a/src/scripts/tweaks/hide_my_posts.js
+++ b/src/scripts/tweaks/hide_my_posts.js
@@ -1,6 +1,7 @@
 import { onNewPosts } from '../../util/mutations.js';
 import { buildStyle, filterPostElements } from '../../util/interface.js';
 import { isMyPost } from '../../util/react_props.js';
+import { removeClass } from '../../util/cleanup.js';
 
 const excludeClass = 'xkit-tweaks-hide-my-posts-done';
 const timeline = /\/v2\/timeline\/dashboard/;
@@ -27,6 +28,5 @@ export const clean = async function () {
   onNewPosts.removeListener(processPosts);
   styleElement.remove();
 
-  $(`.${excludeClass}`).removeClass(excludeClass);
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  removeClass(excludeClass, hiddenClass);
 };

--- a/src/scripts/tweaks/show_full_note_count.js
+++ b/src/scripts/tweaks/show_full_note_count.js
@@ -3,6 +3,7 @@ import { translate } from '../../util/language_data.js';
 import { buildStyle, postSelector } from '../../util/interface.js';
 import { timelineObject } from '../../util/react_props.js';
 import { keyToCss } from '../../util/css_map.js';
+import { removeDataset } from '../../util/cleanup.js';
 
 const { lang } = document.documentElement;
 const numberFormat = new Intl.NumberFormat(lang);
@@ -40,5 +41,5 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(formatNoteElements);
   styleElement.remove();
-  $('[data-full-notes]').removeAttr('data-full-notes');
+  removeDataset('fullNotes');
 };

--- a/src/scripts/vanilla_audio.js
+++ b/src/scripts/vanilla_audio.js
@@ -1,6 +1,7 @@
 import { keyToCss } from '../util/css_map.js';
 import { getPreferences } from '../util/preferences.js';
 import { pageModifications } from '../util/mutations.js';
+import { removeClass } from '../util/cleanup.js';
 
 const trackInfoSelector = keyToCss('trackInfo');
 
@@ -42,7 +43,7 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(addAudioControls);
   $(`.${excludeClass} + audio[controls]`).remove();
-  $(`.${excludeClass}`).removeClass(excludeClass);
+  removeClass(excludeClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/vanilla_video.js
+++ b/src/scripts/vanilla_video.js
@@ -1,5 +1,6 @@
 import { getPreferences } from '../util/preferences.js';
 import { pageModifications } from '../util/mutations.js';
+import { remove } from '../util/cleanup.js';
 
 const vanillaVideoClass = 'xkit-vanilla-video-player';
 
@@ -42,7 +43,7 @@ export const main = async function () {
 
 export const clean = async function () {
   pageModifications.unregister(cloneVideoElements);
-  $(`.${vanillaVideoClass}`).remove();
+  remove(vanillaVideoClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/vanilla_video.js
+++ b/src/scripts/vanilla_video.js
@@ -1,6 +1,6 @@
 import { getPreferences } from '../util/preferences.js';
 import { pageModifications } from '../util/mutations.js';
-import { remove } from '../util/cleanup.js';
+import { removeElementsByClassName } from '../util/cleanup.js';
 
 const vanillaVideoClass = 'xkit-vanilla-video-player';
 
@@ -43,7 +43,7 @@ export const main = async function () {
 
 export const clean = async function () {
   pageModifications.unregister(cloneVideoElements);
-  remove(vanillaVideoClass);
+  removeElementsByClassName(vanillaVideoClass);
 };
 
 export const stylesheet = true;

--- a/src/util/cleanup.js
+++ b/src/util/cleanup.js
@@ -2,37 +2,48 @@
  * Removes all elements on the current page with the given css class.
  * i.e. jQuery $(`.${className}`).remove();
  *
- * @param {string} className - class name to select elements to remove
+ * @param {...string} classNames - one or more class names to select elements to remove
  * @returns {void}
  */
-export const remove = className =>
-  [...document.querySelectorAll(`.${className}`)].forEach(element => element.remove());
+export const remove = (...classNames) =>
+  [...document.querySelectorAll(classNames.map(className => `.${className}`).join(','))]
+    .forEach(element => element.remove());
 
 /**
  * Removes the given css class from all elements on the current page that have it.
  * i.e. jQuery $(`.${className}`).removeClass(className);
  *
- * @param {string} className - class name to remove
+ * @param {...string} classNames - one or more class names to remove
  * @returns {void}
  */
-export const removeClass = className =>
-  [...document.querySelectorAll(`.${className}`)].forEach(element => element.classList.remove(className));
+export const removeClass = (...classNames) =>
+  classNames.forEach(className =>
+    [...document.querySelectorAll(`.${className}`)].forEach(element =>
+      element.classList.remove(className)
+    )
+  );
 
 /**
  * Removes the given data attribute from all elements on the current page that have it.
  * i.e. jQuery $(`[data-${dashStylename}]`).removeAttr(`data-${dashStylename}`);
  *
- * @param {string} dashStylename - data attribute to remove, in dash-style
+ * @param {...string} dashStylenames - one or more data attributes to remove, in dash-style
  * @returns {void}
  */
-export const removeAttr = dashStylename =>
-  [...document.querySelectorAll(`[data-${dashStylename}]`)].forEach(element => element.removeAttribute(`data-${dashStylename}`));
+export const removeAttr = (...dashStylenames) =>
+  dashStylenames.forEach(dashStylename =>
+    [...document.querySelectorAll(`[data-${dashStylename}]`)].forEach(element =>
+      element.removeAttribute(`data-${dashStylename}`)
+    )
+  );
 
 /**
  * Removes the given data attribute from all elements on the current page that have it.
  *
- * @param {string} camelCaseName - data attribute to remove, in camelCase
+ * @param {...string} camelCaseNames - one or more data attributes to remove, in camelCase
  * @returns {void}
  */
-export const removeDataset = camelCaseName =>
-  removeAttr(camelCaseName.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`));
+export const removeDataset = (...camelCaseNames) =>
+  camelCaseNames.forEach(camelCaseName =>
+    removeAttr(camelCaseName.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`))
+  );

--- a/src/util/cleanup.js
+++ b/src/util/cleanup.js
@@ -19,7 +19,7 @@ export const removeElementsByClassName = (...classNames) =>
   getElementsByClassName(...classNames).forEach(element => element.remove());
 
 /**
- * Removes the given css class from all elements on the current page that have it.
+ * Remove the given css class from all elements on the current page that have it.
  * i.e. jQuery $(`.${className}`).removeClass(className);
  *
  * @param {...string} classNames - one or more class names to remove
@@ -31,7 +31,7 @@ export const removeClass = (...classNames) =>
   );
 
 /**
- * Removes the given attribute from all elements on the current page that have it.
+ * Remove the given attribute from all elements on the current page that have it.
  * i.e. jQuery $(`[${dashStylename}]`).removeAttr(dashStylename);
  *
  * @param {...string} attributes - one or more attributes to remove, in dash-style
@@ -47,12 +47,10 @@ export const removeAttr = (...attributes) =>
 const dashStyle = string => string.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
 
 /**
- * Removes the given data attribute from all elements on the current page that have it.
+ * Remove the given data attribute from all elements on the current page that have it.
  *
  * @param {...string} dataAttributes - one or more data attributes to remove, in camelCase
  * @returns {void}
  */
 export const removeDataset = (...dataAttributes) =>
-  dataAttributes.forEach(dataAttribute =>
-    removeAttr(`data-${dashStyle(dataAttribute)}`)
-  );
+  dataAttributes.forEach(dataAttribute => removeAttr(`data-${dashStyle(dataAttribute)}`));

--- a/src/util/cleanup.js
+++ b/src/util/cleanup.js
@@ -24,26 +24,28 @@ export const removeClass = (...classNames) =>
   );
 
 /**
- * Removes the given data attribute from all elements on the current page that have it.
- * i.e. jQuery $(`[data-${dashStylename}]`).removeAttr(`data-${dashStylename}`);
+ * Removes the given attribute from all elements on the current page that have it.
+ * i.e. jQuery $(`[${dashStylename}]`).removeAttr(dashStylename);
  *
- * @param {...string} dashStylenames - one or more data attributes to remove, in dash-style
+ * @param {...string} attributes - one or more attributes to remove, in dash-style
  * @returns {void}
  */
-export const removeAttr = (...dashStylenames) =>
-  dashStylenames.forEach(dashStylename =>
-    [...document.querySelectorAll(`[data-${dashStylename}]`)].forEach(element =>
-      element.removeAttribute(`data-${dashStylename}`)
+export const removeAttr = (...attributes) =>
+  attributes.forEach(attribute =>
+    [...document.querySelectorAll(`[${attribute}]`)].forEach(element =>
+      element.removeAttribute(attribute)
     )
   );
+
+const dashStyle = string => string.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
 
 /**
  * Removes the given data attribute from all elements on the current page that have it.
  *
- * @param {...string} camelCaseNames - one or more data attributes to remove, in camelCase
+ * @param {...string} dataAttributes - one or more data attributes to remove, in camelCase
  * @returns {void}
  */
-export const removeDataset = (...camelCaseNames) =>
-  camelCaseNames.forEach(camelCaseName =>
-    removeAttr(camelCaseName.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`))
+export const removeDataset = (...dataAttributes) =>
+  dataAttributes.forEach(dataAttribute =>
+    removeAttr(`data-${dashStyle(dataAttribute)}`)
   );

--- a/src/util/cleanup.js
+++ b/src/util/cleanup.js
@@ -1,13 +1,22 @@
 /**
- * Removes all elements on the current page with the given css class.
+ * Get all elements on the current page with the given css class.
+ * (Elements may be returned more than once if called with multiple class names.)
+ *
+ * @param  {...string} classNames - one or more class names to select elements
+ * @returns {Element[]} All elements on the page with the given classnames
+ */
+const getElementsByClassName = (...classNames) =>
+  classNames.flatMap(className => [...document.getElementsByClassName(className)]);
+
+/**
+ * Remove all elements on the current page with the given css class.
  * i.e. jQuery $(`.${className}`).remove();
  *
  * @param {...string} classNames - one or more class names to select elements to remove
  * @returns {void}
  */
 export const removeElementsByClassName = (...classNames) =>
-  [...document.querySelectorAll(classNames.map(className => `.${className}`).join(','))]
-    .forEach(element => element.remove());
+  getElementsByClassName(...classNames).forEach(element => element.remove());
 
 /**
  * Removes the given css class from all elements on the current page that have it.
@@ -18,9 +27,7 @@ export const removeElementsByClassName = (...classNames) =>
  */
 export const removeClass = (...classNames) =>
   classNames.forEach(className =>
-    [...document.querySelectorAll(`.${className}`)].forEach(element =>
-      element.classList.remove(className)
-    )
+    getElementsByClassName(className).forEach(element => element.classList.remove(className))
   );
 
 /**

--- a/src/util/cleanup.js
+++ b/src/util/cleanup.js
@@ -2,7 +2,7 @@
  * Get all elements on the current page with the given css class.
  * (Elements may be returned more than once if called with multiple class names.)
  *
- * @param  {...string} classNames - one or more class names to select elements
+ * @param  {...string} classNames - One or more class names to select elements
  * @returns {Element[]} All elements on the page with the given classnames
  */
 const getElementsByClassName = (...classNames) =>
@@ -12,7 +12,7 @@ const getElementsByClassName = (...classNames) =>
  * Remove all elements on the current page with the given css class.
  * i.e. jQuery $(`.${className}`).remove();
  *
- * @param {...string} classNames - one or more class names to select elements to remove
+ * @param {...string} classNames - One or more class names to select elements to remove
  * @returns {void}
  */
 export const removeElementsByClassName = (...classNames) =>
@@ -22,7 +22,7 @@ export const removeElementsByClassName = (...classNames) =>
  * Remove the given css class from all elements on the current page that have it.
  * i.e. jQuery $(`.${className}`).removeClass(className);
  *
- * @param {...string} classNames - one or more class names to remove
+ * @param {...string} classNames - One or more class names to remove
  * @returns {void}
  */
 export const removeClass = (...classNames) =>
@@ -34,7 +34,7 @@ export const removeClass = (...classNames) =>
  * Remove the given attribute from all elements on the current page that have it.
  * i.e. jQuery $(`[${dashStylename}]`).removeAttr(dashStylename);
  *
- * @param {...string} attributes - one or more attributes to remove, in dash-style
+ * @param {...string} attributes - One or more attributes to remove, in dash-style
  * @returns {void}
  */
 export const removeAttr = (...attributes) =>
@@ -49,7 +49,7 @@ const dashStyle = string => string.replace(/[A-Z]/g, letter => `-${letter.toLowe
 /**
  * Remove the given data attribute from all elements on the current page that have it.
  *
- * @param {...string} dataAttributes - one or more data attributes to remove, in camelCase
+ * @param {...string} dataAttributes - One or more data attributes to remove, in camelCase
  * @returns {void}
  */
 export const removeDataset = (...dataAttributes) =>

--- a/src/util/cleanup.js
+++ b/src/util/cleanup.js
@@ -1,0 +1,38 @@
+/**
+ * Removes all elements on the current page with the given css class.
+ * i.e. jQuery $(`.${className}`).remove();
+ *
+ * @param {string} className - class name to select elements to remove
+ * @returns {void}
+ */
+export const remove = className =>
+  [...document.querySelectorAll(`.${className}`)].forEach(element => element.remove());
+
+/**
+ * Removes the given css class from all elements on the current page that have it.
+ * i.e. jQuery $(`.${className}`).removeClass(className);
+ *
+ * @param {string} className - class name to remove
+ * @returns {void}
+ */
+export const removeClass = className =>
+  [...document.querySelectorAll(`.${className}`)].forEach(element => element.classList.remove(className));
+
+/**
+ * Removes the given data attribute from all elements on the current page that have it.
+ * i.e. jQuery $(`[data-${dashStylename}]`).removeAttr(`data-${dashStylename}`);
+ *
+ * @param {string} dashStylename - data attribute to remove, in dash-style
+ * @returns {void}
+ */
+export const removeAttr = dashStylename =>
+  [...document.querySelectorAll(`[data-${dashStylename}]`)].forEach(element => element.removeAttribute(`data-${dashStylename}`));
+
+/**
+ * Removes the given data attribute from all elements on the current page that have it.
+ *
+ * @param {string} camelCaseName - data attribute to remove, in camelCase
+ * @returns {void}
+ */
+export const removeDataset = camelCaseName =>
+  removeAttr(camelCaseName.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`));

--- a/src/util/cleanup.js
+++ b/src/util/cleanup.js
@@ -5,7 +5,7 @@
  * @param {...string} classNames - one or more class names to select elements to remove
  * @returns {void}
  */
-export const remove = (...classNames) =>
+export const removeElementsByClassName = (...classNames) =>
   [...document.querySelectorAll(classNames.map(className => `.${className}`).join(','))]
     .forEach(element => element.remove());
 

--- a/src/util/control_buttons.js
+++ b/src/util/control_buttons.js
@@ -1,9 +1,9 @@
-import { remove } from './cleanup.js';
+import { removeElementsByClassName } from './cleanup.js';
 import { dom } from './dom.js';
 import { buildSvg } from './remixicon.js';
 
 // Remove outdated buttons when loading module
-remove('xkit-control-button-container');
+removeElementsByClassName('xkit-control-button-container');
 
 /**
  * Create a button template that can be cloned with cloneControlButton() for inserting into the controls of a post.

--- a/src/util/control_buttons.js
+++ b/src/util/control_buttons.js
@@ -1,8 +1,9 @@
+import { remove } from './cleanup.js';
 import { dom } from './dom.js';
 import { buildSvg } from './remixicon.js';
 
 // Remove outdated buttons when loading module
-$('.xkit-control-button-container').remove();
+remove('xkit-control-button-container');
 
 /**
  * Create a button template that can be cloned with cloneControlButton() for inserting into the controls of a post.

--- a/src/util/post_actions.js
+++ b/src/util/post_actions.js
@@ -2,9 +2,10 @@ import { buildSvg } from './remixicon.js';
 import { pageModifications } from './mutations.js';
 import { keyToCss } from './css_map.js';
 import { dom } from './dom.js';
+import { remove } from './cleanup.js';
 
 // Remove outdated post options when loading module
-$('.xkit-post-option').remove();
+remove('xkit-post-option');
 
 const fakePostActions = dom('div', { class: 'xkit-post-actions' });
 const postOptions = {};

--- a/src/util/post_actions.js
+++ b/src/util/post_actions.js
@@ -2,10 +2,10 @@ import { buildSvg } from './remixicon.js';
 import { pageModifications } from './mutations.js';
 import { keyToCss } from './css_map.js';
 import { dom } from './dom.js';
-import { remove } from './cleanup.js';
+import { removeElementsByClassName } from './cleanup.js';
 
 // Remove outdated post options when loading module
-remove('xkit-post-option');
+removeElementsByClassName('xkit-post-option');
 
 const fakePostActions = dom('div', { class: 'xkit-post-actions' });
 const postOptions = {};


### PR DESCRIPTION
Here's a totally random idea I had: rather than using jQuery's ergonomic "do XYZ to every element matched by this selector" functions in `clean()`, we could import them from a utility file.

This is mostly because I occasionally mistype ```$(`.${className}`).removeClass(className)```, or have to pause to dash-case a data attribute, and because VS Code automatically imports XKit Rewritten's utility files when it autocompletes.

#### User-facing changes
- n/a

#### Technical explanation
n/a

#### Issues this closes
n/a