### PR TITLE
NotificationBlock: Fix notifications not being hidden

### DIFF
--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -19,7 +19,7 @@ let blockedPostTargetIDs;
 const styleElement = buildStyle();
 const buildCss = () => `:is(${
   blockedPostTargetIDs.map(rootId => `[data-target-root-post-id="${rootId}"]`).join(', ')
-}) { display: none; }`;
+}) { display: none !important; }`;
 
 const unburyTargetPostIds = async (notificationSelector) => {
   [...document.querySelectorAll(notificationSelector)]


### PR DESCRIPTION
#### User-facing changes
- NotificationBlock works.

#### Technical explanation
The `:is()` selector used to hide notifications has less specificity than the simple class selector that Tumblr uses to set `display: flex`.

#### Issues this closes
None; I need to write a PSA to people about actually submitting issues instead of just complaining in the tags.