### PR TITLE
Fix animated chiclet handling

### DIFF
--- a/src/scripts/accesskit/boring_tag_chiclets.js
+++ b/src/scripts/accesskit/boring_tag_chiclets.js
@@ -1,9 +1,18 @@
 import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
-const styleElement = buildStyle(`${keyToCss('tagChicletWrapper')} {
-  background-image: none !important; color: rgb(var(--black)); background-color: rgb(var(--secondary-accent));
-}`);
+const styleElement = buildStyle(`
+  ${keyToCss('tagChicletWrapper')} {
+    background-image: none !important;
+    color: rgb(var(--black));
+    background-color: rgb(var(--secondary-accent));
+  }
+
+  ${keyToCss('tagChicletWrapper')} > video,
+  ${keyToCss('tagChicletWrapper')} > ${keyToCss('tagChicletBgShader')} {
+    display: none !important;
+  }
+`);
 
 export const main = async () => document.head.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/accesskit/boring_tag_chiclets.js
+++ b/src/scripts/accesskit/boring_tag_chiclets.js
@@ -2,16 +2,16 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
-  ${keyToCss('tagChicletWrapper')} {
-    background-image: none !important;
-    color: rgb(var(--black));
-    background-color: rgb(var(--secondary-accent));
-  }
+${keyToCss('tagChicletWrapper')} {
+  background-image: none !important;
+  color: rgb(var(--black));
+  background-color: rgb(var(--secondary-accent));
+}
 
-  ${keyToCss('tagChicletWrapper')} > video,
-  ${keyToCss('tagChicletWrapper')} > ${keyToCss('tagChicletBgShader')} {
-    display: none !important;
-  }
+${keyToCss('tagChicletWrapper')} > video,
+${keyToCss('tagChicletWrapper')} > ${keyToCss('tagChicletBgShader')} {
+  display: none !important;
+}
 `);
 
 export const main = async () => document.head.append(styleElement);

--- a/src/scripts/vanilla_video.js
+++ b/src/scripts/vanilla_video.js
@@ -1,5 +1,6 @@
 import { getPreferences } from '../util/preferences.js';
 import { pageModifications } from '../util/mutations.js';
+import { keyToCss } from '../util/css_map.js';
 
 const vanillaVideoClass = 'xkit-vanilla-video-player';
 
@@ -37,7 +38,7 @@ export const onStorageChanged = async function (changes, areaName) {
 
 export const main = async function () {
   ({ defaultVolume } = await getPreferences('vanilla_video'));
-  pageModifications.register(`video:not([src], .${vanillaVideoClass})`, cloneVideoElements);
+  pageModifications.register(`${keyToCss('videoPlayer')} video:not([src], .${vanillaVideoClass})`, cloneVideoElements);
 };
 
 export const clean = async function () {

--- a/src/scripts/vanilla_video.js
+++ b/src/scripts/vanilla_video.js
@@ -38,7 +38,7 @@ export const onStorageChanged = async function (changes, areaName) {
 
 export const main = async function () {
   ({ defaultVolume } = await getPreferences('vanilla_video'));
-  pageModifications.register(`${keyToCss('videoPlayer')} video:not([src], .${vanillaVideoClass})`, cloneVideoElements);
+  pageModifications.register(`${keyToCss('videoPlayer')} video:not(.${vanillaVideoClass})`, cloneVideoElements);
 };
 
 export const clean = async function () {


### PR DESCRIPTION
"Chiclet" doesn't look like a word anymore.

#### User-facing changes
Two fixes to the handling of the animated "chiclet" elements in the dashboard (ex-"you're caught up!") carousel and https://www.tumblr.com/timeline/trending:
- Prevents Vanilla Videos from messing with chiclet appearance
- Fixes AccessKit's de-animation function

#### Technical explanation
Vanilla Video: I don't know if there are videos that should be included that do not use the `videoPlayer` class.

#### Issues this closes
resolves #695 (though it mentions more work that is a good idea)
addresses the core issue in #696, but does not implement its suggestion of improved functionality (could update that issue or close it and create a new enhancement issue) 