### PR TITLE
Rename "you're caught up" carousel references

### DIFF
--- a/src/scripts/accesskit.json
+++ b/src/scripts/accesskit.json
@@ -16,7 +16,7 @@
     },
     "boring_tag_chiclets": {
       "type": "checkbox",
-      "label": "De-animate the \"You're caught up\" carousel",
+      "label": "De-animate the dashboard \"caught up\" carousel",
       "default": false
     },
     "disable_animations": {

--- a/src/scripts/accesskit.json
+++ b/src/scripts/accesskit.json
@@ -16,7 +16,7 @@
     },
     "boring_tag_chiclets": {
       "type": "checkbox",
-      "label": "De-animate the dashboard \"caught up\" carousel",
+      "label": "De-animate the Changes/Shop/etc. links carousel",
       "default": false
     },
     "disable_animations": {

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -31,7 +31,7 @@
     },
     "caught_up_line": {
       "type": "checkbox",
-      "label": "Turn the dashboard \"caught up\" carousel into a separating line",
+      "label": "Turn the Changes/Shop/etc. links carousel into a separating line",
       "default": false
     },
     "no_focus_shadow": {

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -31,7 +31,7 @@
     },
     "caught_up_line": {
       "type": "checkbox",
-      "label": "Turn \"You're caught up\" into a separating line",
+      "label": "Turn the dashboard \"caught up\" carousel into a separating line",
       "default": false
     },
     "no_focus_shadow": {


### PR DESCRIPTION
I don't know. I hate this. Can we put a picture of the element in question inline in the settings panel?

#### Issues this closes
resolves #643