### PR TITLE
Mass Deleter: Fix datetime input inconsistencies; chromium crash

### DIFF
--- a/src/scripts/mass_deleter.js
+++ b/src/scripts/mass_deleter.js
@@ -45,7 +45,7 @@ const confirmDeleteDrafts = event => {
 
   showModal({
     title: 'Delete drafts?',
-    message: [`Every draft on this blog dated before ${beforeString} will be deleted.`, '\n', `unix timestamp (s): ${before}`],
+    message: [`Every draft on this blog dated before ${beforeString} will be deleted.`],
     buttons: [
       modalCancelButton,
       dom(

--- a/src/scripts/mass_deleter.js
+++ b/src/scripts/mass_deleter.js
@@ -4,6 +4,8 @@ import { modalCancelButton, modalCompleteButton, showModal } from '../util/modal
 import { addSidebarItem, removeSidebarItem } from '../util/sidebar.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 
+const timezoneOffsetMs = new Date().getTimezoneOffset() * 60000;
+
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 const createNowString = () => {
   const now = new Date();
@@ -37,8 +39,9 @@ const confirmDeleteDrafts = event => {
 
   const blogName = location.pathname.split('/')[2];
   const { elements } = event.currentTarget;
-  const beforeString = elements.before.valueAsDate.toLocaleString();
-  const before = elements.before.valueAsNumber / 1000;
+  const beforeMs = elements.before.valueAsNumber + timezoneOffsetMs;
+  const beforeString = new Date(beforeMs).toLocaleString();
+  const before = beforeMs / 1000;
 
   showModal({
     title: 'Delete drafts?',

--- a/src/scripts/mass_deleter.js
+++ b/src/scripts/mass_deleter.js
@@ -45,7 +45,7 @@ const confirmDeleteDrafts = event => {
 
   showModal({
     title: 'Delete drafts?',
-    message: [`Every draft on this blog dated before ${beforeString} will be deleted.`],
+    message: [`Every draft on this blog dated before ${beforeString} will be deleted.`, '\n', `unix timestamp (s): ${before}`],
     buttons: [
       modalCancelButton,
       dom(


### PR DESCRIPTION
#### User-facing changes
- Mass Deleter works in Chrome/Edge/Opera/Brave/whatever.
- Mass Deleter's date input respects time zones.

#### Technical explanation
`<input type="datetime-local">`elements do not have a `valueAsDate` property in Chromium and do not respect time zones in either Chromium or Firefox. Fixed using the suggestions in the linked issues.

#### Issues this closes
resolves #534, resolves #640