### PR TITLE
Trim Reblogs: Fix silent failure if original root post is deleted

### DIFF
--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -25,12 +25,17 @@ const onButtonClicked = async function ({ currentTarget }) {
     rebloggedRootId
   } = await timelineObject(postElement);
 
+  let unsureOfLegacyStatus = true;
+
   if (rebloggedRootUuid && rebloggedRootId) {
-    const { response: { shouldOpenInLegacy } } = await apiFetch(`/v2/blog/${rebloggedRootUuid}/posts/${rebloggedRootId}`);
-    if (shouldOpenInLegacy) {
-      notify('Legacy posts cannot be trimmed.');
-      return;
-    }
+    try {
+      const { response: { shouldOpenInLegacy } } = await apiFetch(`/v2/blog/${rebloggedRootUuid}/posts/${rebloggedRootId}`);
+      if (shouldOpenInLegacy) {
+        notify('Legacy posts cannot be trimmed.');
+        return;
+      }
+      unsureOfLegacyStatus = false;
+    } catch (e) {}
   }
 
   const {
@@ -62,7 +67,10 @@ const onButtonClicked = async function ({ currentTarget }) {
   showModal({
     title: 'Trim this post?',
     message: [
-      'All but the last trail item will be removed.'
+      'All but the last trail item will be removed.',
+      ...(unsureOfLegacyStatus
+        ? ['\n\n', "Warning: XKit can't tell if this post originated from the legacy post editor. Trimming may fail if so."]
+        : [])
     ],
     buttons: [
       modalCancelButton,

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -25,7 +25,7 @@ const onButtonClicked = async function ({ currentTarget }) {
     rebloggedRootId
   } = await timelineObject(postElement);
 
-  let unsureOfLegacyStatus = true;
+  let unsureOfLegacyStatus;
 
   if (rebloggedRootUuid && rebloggedRootId) {
     try {
@@ -35,7 +35,9 @@ const onButtonClicked = async function ({ currentTarget }) {
         return;
       }
       unsureOfLegacyStatus = false;
-    } catch (e) {}
+    } catch (exception) {
+      unsureOfLegacyStatus = true;
+    }
   }
 
   const {


### PR DESCRIPTION
I feel like our understanding of when trim reblogs does and doesn't work must be incomplete. Nevertheless, this seems like an improvement.

#### User-facing changes
- Trim Reblogs will warn the user but allow them to continue instead of silently failing if the root post cannot be retrieved to determine if the thread in question is legacy.

#### Technical explanation
Maybe `.catch(() => ({ response: {} }))` is more elegant? I find it a bit hard to proofread.

#### Issues this closes
resolves #563