### PR TITLE
Mass Deleter: Improve date formatting

### DIFF
--- a/src/scripts/mass_deleter.js
+++ b/src/scripts/mass_deleter.js
@@ -18,6 +18,14 @@ const createNowString = () => {
 
   return `${YYYY}-${MM}-${DD}T${hh}:${mm}`;
 };
+const dateTimeFormat = new Intl.DateTimeFormat(document.documentElement.lang, {
+  year: 'numeric',
+  month: 'long',
+  day: 'numeric',
+  hour: 'numeric',
+  minute: 'numeric',
+  timeZoneName: 'short'
+});
 
 const showDeleteDraftsPrompt = () => {
   const form = dom('form', { id: 'xkit-mass-deleter-delete-drafts' }, { submit: confirmDeleteDrafts }, [
@@ -40,12 +48,15 @@ const confirmDeleteDrafts = event => {
   const blogName = location.pathname.split('/')[2];
   const { elements } = event.currentTarget;
   const beforeMs = elements.before.valueAsNumber + timezoneOffsetMs;
-  const beforeString = new Date(beforeMs).toLocaleString();
+
+  const beforeString = dateTimeFormat.format(new Date(beforeMs));
+  const beforeElement = dom('span', { style: 'white-space: nowrap; font-weight: bold;' }, null, [beforeString]);
+
   const before = beforeMs / 1000;
 
   showModal({
     title: 'Delete drafts?',
-    message: [`Every draft on this blog dated before ${beforeString} will be deleted.`],
+    message: ['Every draft on this blog dated before ', beforeElement, ' will be deleted.'],
     buttons: [
       modalCancelButton,
       dom(


### PR DESCRIPTION
#### User-facing changes

Improves the visual presentation of the date in the Mass Deleter confirmation dialogue, removing d/m/y vs m/d/y ambiguity and the unnecessary seconds display and including the timezone.

| before | after |
| - | - |
|<img src="https://user-images.githubusercontent.com/8336245/187145176-7b55c49b-8f73-4bc4-b036-0641765392a0.png"> | <img src="https://user-images.githubusercontent.com/8336245/187145180-e8503f61-aaea-41d3-b0fe-d0b93510052f.png"> |

#### Technical explanation
Feeds the configured page locale to Intl.DateTimeFormat even though the UI text is of course English. I think this probably makes sense...?

#### Issues this closes
n/a