### PR TITLE
Scroll to Bottom: Stop at bottom + Fix button color

### DIFF
--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -7,7 +7,10 @@ const scrollToBottomButtonId = 'xkit-scroll-to-bottom-button';
 $(`[id="${scrollToBottomButtonId}"]`).remove();
 const activeClass = 'xkit-scroll-to-bottom-active';
 
-const loaderSelector = `${keyToCss('timeline')} > ${keyToCss('loader')}`;
+const loaderSelector = `
+${keyToCss('timeline', 'blogRows')} > ${keyToCss('loader')},
+${keyToCss('notifications')} + ${keyToCss('loader')}
+`;
 
 let scrollToBottomButton;
 let active = false;

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -30,9 +30,7 @@ const scrollToBottom = () => {
   const loaders = [...document.querySelectorAll(loaderSelector)]
     .filter(element => element.matches(blogViewSelector) === false);
 
-  const glassContainerOpen = document.getElementById('glass-container')?.hasChildNodes();
-
-  if (loaders.length === 0 || glassContainerOpen) {
+  if (loaders.length === 0) {
     stopScrolling();
   }
 };

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -14,8 +14,7 @@ let active = false;
 
 const styleElement = buildStyle(`
 ${keyToCss('isPeeprShowing')} #${scrollToBottomButtonId} {
-  opacity: 0;
-  pointer-events: none;
+  display: none;
 }
 
 .${activeClass} svg use {

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -17,7 +17,8 @@ let active = false;
 
 const styleElement = buildStyle(`
 ${keyToCss('isPeeprShowing')} #${scrollToBottomButtonId} {
-  display: none;
+  opacity: 0;
+  pointer-events: none;
 }
 
 .${activeClass} svg use {

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -1,13 +1,13 @@
 import { keyToClasses, keyToCss } from '../util/css_map.js';
 import { translate } from '../util/language_data.js';
 import { pageModifications } from '../util/mutations.js';
-import { buildStyle } from '../util/interface.js';
+import { blogViewSelector, buildStyle } from '../util/interface.js';
 
 const scrollToBottomButtonId = 'xkit-scroll-to-bottom-button';
 $(`[id="${scrollToBottomButtonId}"]`).remove();
 const activeClass = 'xkit-scroll-to-bottom-active';
 
-const knightRiderLoaderSelector = `main ${keyToCss('loader')} ${keyToCss('knightRiderLoader')}`;
+const loaderSelector = `${keyToCss('timeline')} > ${keyToCss('loader')}`;
 
 let scrollToBottomButton;
 let active = false;
@@ -25,7 +25,10 @@ ${keyToCss('isPeeprShowing')} #${scrollToBottomButtonId} {
 
 const scrollToBottom = () => {
   window.scrollTo({ top: document.documentElement.scrollHeight });
-  if (document.querySelector(knightRiderLoaderSelector) === null) {
+  const loaders = [...document.querySelectorAll(loaderSelector)]
+    .filter(element => element.matches(blogViewSelector) === false);
+
+  if (loaders.length === 0) {
     stopScrolling();
   }
 };

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -30,7 +30,9 @@ const scrollToBottom = () => {
   const loaders = [...document.querySelectorAll(loaderSelector)]
     .filter(element => element.matches(blogViewSelector) === false);
 
-  if (loaders.length === 0) {
+  const glassContainerOpen = document.getElementById('glass-container')?.hasChildNodes();
+
+  if (loaders.length === 0 || glassContainerOpen) {
     stopScrolling();
   }
 };

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -5,17 +5,21 @@ import { buildStyle } from '../util/interface.js';
 
 const scrollToBottomButtonId = 'xkit-scroll-to-bottom-button';
 $(`[id="${scrollToBottomButtonId}"]`).remove();
+const activeClass = 'xkit-scroll-to-bottom-active';
 
 const knightRiderLoaderSelector = `main ${keyToCss('loader')} ${keyToCss('knightRiderLoader')}`;
 
 let scrollToBottomButton;
-let scrollToBottomIcon;
 let active = false;
 
 const styleElement = buildStyle(`
 ${keyToCss('isPeeprShowing')} #${scrollToBottomButtonId} {
   opacity: 0;
   pointer-events: none;
+}
+
+.${activeClass} svg use {
+  --icon-color-primary: rgb(var(--yellow));
 }
 `);
 
@@ -30,14 +34,14 @@ const observer = new ResizeObserver(scrollToBottom);
 const startScrolling = () => {
   observer.observe(document.documentElement);
   active = true;
-  scrollToBottomIcon.style.fill = 'rgb(var(--yellow))';
+  scrollToBottomButton.classList.add(activeClass);
   scrollToBottom();
 };
 
 const stopScrolling = () => {
   observer.disconnect();
   active = false;
-  if (scrollToBottomIcon) scrollToBottomIcon.style.fill = '';
+  scrollToBottomButton?.classList.remove(activeClass);
 };
 
 const onClick = () => active ? stopScrolling() : startScrolling();
@@ -63,8 +67,7 @@ const addButtonToPage = async function ([scrollToTopButton]) {
     scrollToBottomButton.addEventListener('click', onClick);
     scrollToBottomButton.id = scrollToBottomButtonId;
 
-    scrollToBottomIcon = scrollToBottomButton.querySelector('svg');
-    scrollToBottomIcon.style.fill = active ? 'rgb(var(--yellow))' : '';
+    scrollToBottomButton.classList[active ? 'add' : 'remove'](activeClass);
   }
 
   scrollToTopButton.after(scrollToBottomButton);


### PR DESCRIPTION
#### User-facing changes
- Scroll to bottom's button correctly turns yellow when active.
- Scroll to bottom correctly stops when it gets to the "bottom" of the page.
- ~~Scroll to bottom stops if you open the blog view modal while scrolling (otherwise it would continue in the background; #488 was not implemented)~~
- Minor visual fix on non-glass /blog/view pages, which have a visible scroll to top button but no visible scroll to bottom button (as per reasoning in #488)

Note: the script does not work on https://www.tumblr.com/following before or after this PR due to Tumblr quirks (there isn't a persistent loading indicator on the page and it looks to me like the site doesn't change behavior when you get to the end of the list)

#### Technical explanation
n/a

#### Issues this closes
resolves #712
addresses only the comment in #619 ("scrolling doesn't stop when there are no more posts on the page"); do not close this issue