### PR TITLE
Quick Reblog: Display blog avatars in blog selector

### DIFF
--- a/src/scripts/quick_reblog.css
+++ b/src/scripts/quick_reblog.css
@@ -87,6 +87,20 @@ div:first-child + span + #quick-reblog {
   font-weight: bold;
 }
 
+#quick-reblog .select-container {
+  display: flex;
+}
+
+#quick-reblog .avatar {
+  flex: none;
+  height: 26px;
+  width: 26px;
+  margin: 4px 0 4px 4px;
+
+  background-size: cover;
+  border-radius: 2px;
+}
+
 #quick-reblog .quick-tags {
   font-size: .875rem;
   line-height: 1.125;

--- a/src/scripts/quick_reblog.css
+++ b/src/scripts/quick_reblog.css
@@ -14,6 +14,10 @@
   max-width: 250px;
 }
 
+#quick-reblog [hidden] {
+  display: none !important;
+}
+
 @media (max-width: 650px) {
   #quick-reblog {
     top: 50%;

--- a/src/scripts/quick_reblog.css
+++ b/src/scripts/quick_reblog.css
@@ -82,6 +82,7 @@ div:first-child + span + #quick-reblog {
 
 #quick-reblog select {
   padding-left: 0.5ch;
+  min-width: 0%;
 
   font-family: var(--font-family);
   font-weight: bold;

--- a/src/scripts/quick_reblog.css
+++ b/src/scripts/quick_reblog.css
@@ -80,13 +80,18 @@ div:first-child + span + #quick-reblog {
   border-radius: 0;
   color: inherit;
   background-color: inherit;
-  padding: 1ch;
   margin-bottom: 2px;
 }
 
+#quick-reblog input {
+  padding: 1ch;
+}
+
 #quick-reblog select {
-  padding-left: 0.5ch;
-  min-width: 0%;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
 
   font-family: var(--font-family);
   font-weight: bold;
@@ -94,13 +99,14 @@ div:first-child + span + #quick-reblog {
 
 #quick-reblog .select-container {
   display: flex;
+  padding: 4px;
 }
 
 #quick-reblog .avatar {
   flex: none;
   height: 26px;
   width: 26px;
-  margin: 4px 0 4px 4px;
+  margin-right: 2px;
 
   background-size: cover;
   border-radius: 2px;

--- a/src/scripts/quick_reblog.css
+++ b/src/scripts/quick_reblog.css
@@ -80,11 +80,11 @@ div:first-child + span + #quick-reblog {
   border-radius: 0;
   color: inherit;
   background-color: inherit;
-  margin-bottom: 2px;
 }
 
 #quick-reblog input {
   padding: 1ch;
+  margin-bottom: 2px;
 }
 
 #quick-reblog select {
@@ -100,6 +100,9 @@ div:first-child + span + #quick-reblog {
 #quick-reblog .select-container {
   display: flex;
   padding: 4px;
+  margin-bottom: 2px;
+
+  background-color: inherit;
 }
 
 #quick-reblog .avatar {

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -44,7 +44,6 @@ let accountKey;
 
 let popupPosition;
 let showBlogSelector;
-let showBlogAvatar;
 let rememberLastBlog;
 let showCommentInput;
 let quickTagsIntegration;
@@ -290,7 +289,6 @@ export const main = async function () {
   ({
     popupPosition,
     showBlogSelector,
-    showBlogAvatar,
     rememberLastBlog,
     showCommentInput,
     quickTagsIntegration,
@@ -329,7 +327,6 @@ export const main = async function () {
   renderBlogAvatar();
 
   blogSelectorContainer.hidden = !showBlogSelector;
-  blogAvatar.hidden = !showBlogAvatar;
   commentInput.hidden = !showCommentInput;
   quickTagsList.hidden = !quickTagsIntegration;
   tagsInput.hidden = !showTagsInput;

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -307,7 +307,6 @@ export const main = async function () {
   blogSelector.replaceChildren(
     ...userBlogs.map(({ name, uuid }) => Object.assign(document.createElement('option'), { value: uuid, textContent: name }))
   );
-  renderBlogAvatar();
 
   if (rememberLastBlog) {
     for (const { uuid } of userBlogs) {
@@ -327,6 +326,7 @@ export const main = async function () {
 
     blogSelector.addEventListener('change', updateRememberedBlog);
   }
+  renderBlogAvatar();
 
   blogSelectorContainer.hidden = !showBlogSelector;
   blogAvatar.hidden = !showBlogAvatar;

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -22,6 +22,11 @@
       "label": "Show the blog selector",
       "default": true
     },
+    "showBlogAvatar": {
+      "type": "checkbox",
+      "label": "Show your avatar next to the blog selector",
+      "default": true
+    },
     "rememberLastBlog": {
       "type": "checkbox",
       "label": "Remember the last selected blog in the popup",

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -22,11 +22,6 @@
       "label": "Show the blog selector",
       "default": true
     },
-    "showBlogAvatar": {
-      "type": "checkbox",
-      "label": "Show your avatar next to the blog selector",
-      "default": true
-    },
     "rememberLastBlog": {
       "type": "checkbox",
       "label": "Remember the last selected blog in the popup",


### PR DESCRIPTION
#### User-facing changes
- Adds an option to display avatars beside the Quick Reblog blog selector.

#### Technical explanation
I threw CSS at the wall until the select element correctly resized. Can you do this without `display: flex` and `flex: none` (and a bunch of manual padding)? Probably, but apparently I can't figure out how to.

Quick Reblog could use a bit of a rewrite to use `dom()`.

#### Issues this closes
resolves #716