### PR TITLE
AccessKit de-animated carousel: Pause background instead of removing

### DIFF
--- a/src/scripts/accesskit/boring_tag_chiclets.js
+++ b/src/scripts/accesskit/boring_tag_chiclets.js
@@ -1,9 +1,14 @@
 import { keyToCss } from '../../util/css_map.js';
 import { pageModifications } from '../../util/mutations.js';
 
+const tagChicletVideoSelector = `${keyToCss('tagChicletWrapper')} > video`;
+
 const processTagChicletVideos = videos => videos.forEach(video => video.pause());
 
 export const main = async () =>
-  pageModifications.register(`${keyToCss('tagChicletWrapper')} > video`, processTagChicletVideos);
+  pageModifications.register(tagChicletVideoSelector, processTagChicletVideos);
 
-export const clean = async () => pageModifications.unregister(processTagChicletVideos);
+export const clean = async () => {
+  pageModifications.unregister(processTagChicletVideos);
+  [...document.querySelectorAll(tagChicletVideoSelector)].forEach(video => video.play());
+};

--- a/src/scripts/accesskit/boring_tag_chiclets.js
+++ b/src/scripts/accesskit/boring_tag_chiclets.js
@@ -3,10 +3,15 @@ import { pageModifications } from '../../util/mutations.js';
 
 const tagChicletVideoSelector = `${keyToCss('tagChicletWrapper')} > video`;
 
-const processTagChicletVideos = videos => videos.forEach(video => video.pause());
+const processTagChicletVideos = videos =>
+  videos.forEach(video => {
+    video.pause();
+    video.currentTime = 0;
+  });
 
-export const main = async () =>
+export const main = async () => {
   pageModifications.register(tagChicletVideoSelector, processTagChicletVideos);
+};
 
 export const clean = async () => {
   pageModifications.unregister(processTagChicletVideos);

--- a/src/scripts/accesskit/boring_tag_chiclets.js
+++ b/src/scripts/accesskit/boring_tag_chiclets.js
@@ -1,18 +1,9 @@
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle } from '../../util/interface.js';
+import { pageModifications } from '../../util/mutations.js';
 
-const styleElement = buildStyle(`
-${keyToCss('tagChicletWrapper')} {
-  background-image: none !important;
-  color: rgb(var(--black));
-  background-color: rgb(var(--secondary-accent));
-}
+const processtagChicletVideos = videos => videos.forEach(video => video.pause());
 
-${keyToCss('tagChicletWrapper')} > video,
-${keyToCss('tagChicletWrapper')} > ${keyToCss('tagChicletBgShader')} {
-  display: none !important;
-}
-`);
+export const main = async () =>
+  pageModifications.register(`${keyToCss('tagChicletWrapper')} > video`, processtagChicletVideos);
 
-export const main = async () => document.head.append(styleElement);
-export const clean = async () => styleElement.remove();
+export const clean = async () => pageModifications.unregister(processtagChicletVideos);

--- a/src/scripts/accesskit/boring_tag_chiclets.js
+++ b/src/scripts/accesskit/boring_tag_chiclets.js
@@ -1,9 +1,9 @@
 import { keyToCss } from '../../util/css_map.js';
 import { pageModifications } from '../../util/mutations.js';
 
-const processtagChicletVideos = videos => videos.forEach(video => video.pause());
+const processTagChicletVideos = videos => videos.forEach(video => video.pause());
 
 export const main = async () =>
-  pageModifications.register(`${keyToCss('tagChicletWrapper')} > video`, processtagChicletVideos);
+  pageModifications.register(`${keyToCss('tagChicletWrapper')} > video`, processTagChicletVideos);
 
-export const clean = async () => pageModifications.unregister(processtagChicletVideos);
+export const clean = async () => pageModifications.unregister(processTagChicletVideos);


### PR DESCRIPTION
...Surely it's not this easy?

#### User-facing changes
- Pauses the animated chiclets in the unnamed-carousel-formerly-known-as-"you're-caught-up!" to de-animate them.

#### Technical explanation


#### Issues this closes
 resolves #729
