### PR TITLE
New Script: Delay Posting

### DIFF
--- a/src/scripts/_index.json
+++ b/src/scripts/_index.json
@@ -4,6 +4,7 @@
   "classic_search",
   "cleanfeed",
   "collapsed_queue",
+  "delay_posting",
   "hide_avatars",
   "limit_checker",
   "mass_deleter",

--- a/src/scripts/delay_posting.js
+++ b/src/scripts/delay_posting.js
@@ -1,0 +1,38 @@
+import { inject } from '../util/inject.js';
+import { registerPostOption, unregisterPostOption } from '../util/post_actions.js';
+import { getPreferences } from '../util/preferences.js';
+
+const symbolId = 'ri-timer-flash-line';
+let delayMs;
+
+const editPostSchedule = publishOnMs => {
+  const selectedTagsElement = document.getElementById('selected-tags');
+  if (!selectedTagsElement) return;
+
+  const reactKey = Object.keys(selectedTagsElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = selectedTagsElement[reactKey];
+
+  while (fiber !== null) {
+    if (fiber.stateNode?.setFormPostStatus && fiber.stateNode?.onChangePublishOnValue) {
+      fiber.stateNode.setFormPostStatus('scheduled');
+      fiber.stateNode.onChangePublishOnValue(new Date(publishOnMs));
+      break;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+export const main = async function () {
+  const { delaySeconds } = await getPreferences('delay_posting');
+  delayMs = (Number(delaySeconds) ?? 0) * 1000;
+
+  registerPostOption('delay-posting', {
+    symbolId,
+    onclick: () => inject(editPostSchedule, [Date.now() + delayMs])
+  });
+};
+
+export const clean = async function () {
+  unregisterPostOption('delay-posting');
+};

--- a/src/scripts/delay_posting.js
+++ b/src/scripts/delay_posting.js
@@ -1,44 +1,9 @@
-import { keyToCss } from '../util/css_map.js';
-import { inject } from '../util/inject.js';
 import { registerPostOption, unregisterPostOption } from '../util/post_actions.js';
 import { getPreferences } from '../util/preferences.js';
+import { editPostFormStatus } from '../util/react_props.js';
 
 const symbolId = 'ri-timer-flash-line';
 let delayMs;
-
-const controlPostFormStatus = (status, publishOn) => {
-  const button = document.currentScript.parentElement;
-  const reactKey = Object.keys(document.currentScript.parentElement).find(key => key.startsWith('__reactFiber'));
-
-  const isScheduled = status === 'scheduled';
-  let fiber = button[reactKey];
-  while (fiber !== null) {
-    if (fiber.stateNode?.state?.isDatePickerVisible !== undefined) {
-      fiber.stateNode.setState({ isDatePickerVisible: isScheduled });
-      break;
-    } else {
-      fiber = fiber.return;
-    }
-  }
-
-  fiber = button[reactKey];
-  while (fiber !== null) {
-    if (fiber.stateNode?.setFormPostStatus && fiber.stateNode?.onChangePublishOnValue) {
-      fiber.stateNode.setFormPostStatus(status);
-      if (publishOn) fiber.stateNode.onChangePublishOnValue(new Date(publishOn));
-      break;
-    } else {
-      fiber = fiber.return;
-    }
-  }
-};
-
-const editPostFormStatus = (status, publishOn) => {
-  const button = document.querySelector(`${keyToCss('postFormButton')} button`);
-  if (!button) throw new Error('Missing button element to edit post form status');
-
-  inject(controlPostFormStatus, [status, publishOn], button);
-};
 
 export const main = async function () {
   const { delaySeconds } = await getPreferences('delay_posting');
@@ -46,7 +11,7 @@ export const main = async function () {
 
   registerPostOption('delay-posting', {
     symbolId,
-    onclick: () => editPostFormStatus('scheduled', Date.now() + delayMs)
+    onclick: () => editPostFormStatus('scheduled', new Date(Date.now() + delayMs))
   });
 };
 

--- a/src/scripts/delay_posting.json
+++ b/src/scripts/delay_posting.json
@@ -1,0 +1,16 @@
+{
+  "title": "Delay Posting",
+  "description": "",
+  "icon": {
+    "class_name": "ri-timer-flash-line",
+    "color": "white",
+    "background_color": "#bb1f69"
+  },
+  "preferences": {
+    "delaySeconds": {
+      "type": "text",
+      "label": "Seconds to delay",
+      "default": "120"
+    }
+  }
+}


### PR DESCRIPTION
Honestly, I dunno if I would actually add this. But I was gonna try writing the code regardless of your opinion about whether it's a good idea because I wanted to see if I could, so.

#### User-facing changes
- Basically, it's undo send. Adds adds a button to the post form that automatically sets the form state to schedule the post a user-configurable time period in the future.

Presumably if this were a real script it would make sense to integrate with quick reblog too.

#### Technical explanation
I was going to say something about using private APIs, but honestly, that term doesn't seem to go far enough to describing calling functions from the React internals.

~~Oh, also, this currently messes up the mode dropdown slightly since the date/time picker doesn't show up unless you click "scheduled."~~

(And yes, you could totally just do this by clicking the post form elements programmatically instead of poking the React internals with a stick.)

#### Issues this closes
n/a