### PR TITLE
Sidebar utility: Don't insert items in /blog/view

### DIFF
--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -1,5 +1,6 @@
 import { keyToCss } from './css_map.js';
 import { dom } from './dom.js';
+import { blogViewSelector } from './interface.js';
 import { pageModifications } from './mutations.js';
 
 $('#xkit-sidebar').remove();
@@ -89,12 +90,12 @@ const addSidebarToPage = () => {
   const firstSidebarItem = document.querySelector(sidebarItemSelector);
   const firstNavSubHeader = document.querySelector(navSubHeaderSelector);
 
-  if (firstSidebarItem) {
+  if (firstSidebarItem && firstSidebarItem.matches(blogViewSelector) === false) {
     const target = getComputedStyle(firstSidebarItem).position === 'sticky'
       ? firstSidebarItem
       : firstSidebarItem.nextElementSibling;
     firstSidebarItem.parentNode.insertBefore(sidebarItems, target);
-  } else if (firstNavSubHeader) {
+  } else if (firstNavSubHeader && firstNavSubHeader.matches(blogViewSelector) === false) {
     firstNavSubHeader.parentNode.insertBefore(sidebarItems, firstNavSubHeader);
   }
 };


### PR DESCRIPTION
#### User-facing changes
- Sidebar items are not inserted inconsistently into the blog view container.

#### Technical explanation
This used to be inconsistent (the standalone blog view would have sidebar items sometimes, depending on which sidebar items Tumblr inserted and which DOM structure they used; the modal blog view would never have them).

#### Issues this closes
resolves #720