### PR TITLE
Quote Replies: Control "save draft" post form button 

### DIFF
--- a/src/scripts/quote_replies.js
+++ b/src/scripts/quote_replies.js
@@ -4,6 +4,7 @@ import { inject } from '../util/inject.js';
 import { pageModifications } from '../util/mutations.js';
 import { notify } from '../util/notifications.js';
 import { getPreferences } from '../util/preferences.js';
+import { editPostFormStatus } from '../util/react_props.js';
 import { buildSvg } from '../util/remixicon.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 
@@ -16,6 +17,8 @@ const activitySelector = `${keyToCss('notification')} > ${keyToCss('activity')}`
 
 let originalPostTag;
 let tagReplyingBlog;
+
+const sleep = ms => new Promise(resolve => setTimeout(() => resolve(), ms));
 
 const getNotificationProps = function () {
   const notificationElement = document.currentScript.parentElement;
@@ -113,6 +116,13 @@ export const main = async function () {
 
   if (responseId !== undefined && /^\/blog\/.+\/drafts/.test(location.pathname)) {
     document.querySelector(`[href*="/edit/"][href$="/${responseId}"]`)?.click();
+
+    const setPostNow = () => {
+      pageModifications.unregister(setPostNow);
+      editPostFormStatus('now');
+    };
+    pageModifications.register(`${keyToCss('postFormButton')} button`, setPostNow);
+    sleep(5000).then(() => pageModifications.unregister(setPostNow));
   }
 };
 


### PR DESCRIPTION
Just for fun. Not sure if I would actually do this one either.

#### User-facing changes
- Users no longer need to change the post form status button from "save draft" to "post now" when using quote replies.

This, of course, further obfuscates the reason why the user is now on their drafts page after they send the post, which is not explained in the preference panel or UI, and is rather confusing.

#### Technical explanation
The undocumented, unstable React internals poking from #739 makes its triumphant return.

#### Issues this closes
n/a