### PR TITLE
AccessKit Visible Alt Text: Keep newlines

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -70,6 +70,7 @@ figure.accesskit-visible-alt-text figcaption {
   line-height: 1.5;
   text-align: center;
   overflow-wrap: break-word;
+  white-space: pre-line;
 
   user-select: text;
   cursor: initial;


### PR DESCRIPTION
#### User-facing changes
- Newlines in image alt text are displayed in AccessKit's visible alt text display instead of ignored. This matches Tumblr's alt text display.

#### Technical explanation
Pretty sure this doesn't mess with any of our other fixes probably maybe.

#### Issues this closes
n/a