### PR TITLE
New tweak: disable L-to-like

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -89,6 +89,11 @@
       "type": "checkbox",
       "label": "Hide the \"Now, where were we?\" button",
       "default": false
+    },
+    "disable_like_shortcut": {
+      "type": "checkbox",
+      "label": "Disable the L-to-like keyboard shortcut",
+      "default": false
     }
   }
 }

--- a/src/scripts/tweaks/disable_like_shortcut.js
+++ b/src/scripts/tweaks/disable_like_shortcut.js
@@ -1,0 +1,8 @@
+const stopLKey = event => {
+  if (event.code === 'KeyL') {
+    event.stopPropagation();
+  }
+};
+
+export const main = async () => document.body.addEventListener('keydown', stopLKey);
+export const clean = async () => document.body.removeEventListener('keydown', stopLKey);


### PR DESCRIPTION
#### User-facing changes
- Adds a tweak that disables the L-to-like keyboard shortcut.

#### Technical explanation
The event listener that handles page-wide keyboard shortcuts are attached directly to the document element (`document.addEventListener("keydown", this.onKeyDown)`), so this prevents the L key event from reaching it even when no element is selected (`document.activeElement` is the body element).

I could inject a function that calls `disableHotkeys('KeyL')` and `enableHotkeys('KeyL')` on the big app component in the Redpop internals instead, which is sort of cuter but way more complicated and prone to breakage for no reason.

#### Issues this closes
resolves #535