### PR TITLE
Unsticky tab bar tweak: Remove scroll handler entirely

### DIFF
--- a/src/scripts/tweaks/unsticky_tab_bar.js
+++ b/src/scripts/tweaks/unsticky_tab_bar.js
@@ -1,4 +1,5 @@
 import { keyToCss } from '../../util/css_map.js';
+import { inject } from '../../util/inject.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
@@ -6,5 +7,24 @@ const styleElement = buildStyle(`
   ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} { top: 69px !important; }
 `);
 
-export const main = async () => document.head.append(styleElement);
+const removeScrollHandler = () => {
+  const bluespaceLayout = document.currentScript.parentElement;
+  const reactKey = Object.keys(bluespaceLayout).find(key => key.startsWith('__reactFiber'));
+  let fiber = bluespaceLayout[reactKey];
+
+  while (fiber !== null) {
+    if (fiber.stateNode?.onScroll !== undefined) {
+      const onScroll = fiber.stateNode.onScroll;
+      window.removeEventListener('scroll', onScroll);
+      return;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+export const main = async () => {
+  document.head.append(styleElement);
+  inject(removeScrollHandler, [], document.querySelector(keyToCss('bluespaceLayout')));
+};
 export const clean = async () => styleElement.remove();


### PR DESCRIPTION
This cannot really be cleanly reversed, and the code in question can very likely be improved on Tumblr's side, so I wouldn't actually merge this. Committing so I don't lose it.

#### User-facing changes
- Removes the performance impact from the sticky tab bar as well as visually disabling it.

#### Technical explanation


#### Issues this closes
