### PR TITLE
Notify on extension import failure

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -85,29 +85,9 @@
     const installedScripts = await getInstalledScripts();
     const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
 
-    const warningElements = new Set();
-
     installedScripts
       .filter(scriptName => enabledScripts.includes(scriptName))
-      .forEach((scriptName) => {
-        const warningElement = document.createElement('div');
-        warningElement.className = 'visible';
-        warningElement.replaceChildren(`XKit Rewritten failed to import ${scriptName.replaceAll('_', ' ')}`);
-        warningElements.add(warningElement);
-
-        runScript(scriptName).then(() => {
-          warningElements.delete(warningElement);
-          warningElement.remove();
-        });
-      });
-
-    setTimeout(async () => {
-      if (warningElements.size) {
-        const { addToastContainerToPage } = await import('../util/notifications.js');
-        const toastContainer = await addToastContainerToPage();
-        toastContainer.append(...warningElements);
-      }
-    }, 3000);
+      .forEach(runScript);
   };
 
   const waitForReactLoaded = () => new Promise(resolve => {

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -85,9 +85,29 @@
     const installedScripts = await getInstalledScripts();
     const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
 
+    const warningElements = new Set();
+
     installedScripts
       .filter(scriptName => enabledScripts.includes(scriptName))
-      .forEach(runScript);
+      .forEach((scriptName) => {
+        const warningElement = document.createElement('div');
+        warningElement.className = 'visible';
+        warningElement.replaceChildren(`XKit Rewritten failed to import ${scriptName.replaceAll('_', ' ')}`);
+        warningElements.add(warningElement);
+
+        runScript(scriptName).then(() => {
+          warningElements.delete(warningElement);
+          warningElement.remove();
+        });
+      });
+
+    setTimeout(async () => {
+      if (warningElements.size) {
+        const { addToastContainerToPage } = await import('../util/notifications.js');
+        const toastContainer = await addToastContainerToPage();
+        toastContainer.append(...warningElements);
+      }
+    }, 3000);
   };
 
   const waitForReactLoaded = () => new Promise(resolve => {

--- a/src/util/notifications.js
+++ b/src/util/notifications.js
@@ -6,7 +6,7 @@ const toastContainer = dom('div', { id: 'xkit-toasts' });
 const drawerContentSelectorPromise = keyToCss('drawerContent');
 const sidebarSelectorPromise = keyToCss('sidebar');
 
-const addToastContainerToPage = async () => {
+export const addToastContainerToPage = async () => {
   const drawerContentSelector = await drawerContentSelectorPromise;
   const sidebarSelector = await sidebarSelectorPromise;
 
@@ -21,6 +21,8 @@ const addToastContainerToPage = async () => {
     toastContainer.dataset.inSidebar = targetNode.matches(sidebarSelector);
     targetNode.append(toastContainer);
   }
+
+  return toastContainer;
 };
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/util/notifications.js
+++ b/src/util/notifications.js
@@ -6,7 +6,7 @@ const toastContainer = dom('div', { id: 'xkit-toasts' });
 const drawerContentSelectorPromise = keyToCss('drawerContent');
 const sidebarSelectorPromise = keyToCss('sidebar');
 
-export const addToastContainerToPage = async () => {
+const addToastContainerToPage = async () => {
   const drawerContentSelector = await drawerContentSelectorPromise;
   const sidebarSelector = await sidebarSelectorPromise;
 
@@ -21,8 +21,6 @@ export const addToastContainerToPage = async () => {
     toastContainer.dataset.inSidebar = targetNode.matches(sidebarSelector);
     targetNode.append(toastContainer);
   }
-
-  return toastContainer;
 };
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));


### PR DESCRIPTION
This code is to easily test #636, which I am still trying to reproduce on any other computer.

#### User-facing changes
- Displays a (persistent) notification if any of the XKit scripts take longer than three seconds to import on the initial extension load. When a script successfully imports, its notification is removed, so only scripts that are currently not active are persistently displayed.

Of course, this only allows this behavior to be tested when the extension is loaded unpacked; if the Chrome web store version did not ever cause this, it would be mostly irrelevant. I have had the Chrome web store version do the same thing, though.

#### Technical explanation


#### Issues this closes
