### PR TITLE
Tweaks: Increase unsticky tab bar tweak consistency

### DIFF
--- a/src/scripts/tweaks/unsticky_tab_bar.js
+++ b/src/scripts/tweaks/unsticky_tab_bar.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
-  ${keyToCss('tabsHeader')} { position: static !important; transform: none !important; }
+  ${keyToCss('tabsHeader')} { position: static !important; }
   ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} { top: 69px !important; }
 `);
 

--- a/src/scripts/tweaks/unsticky_tab_bar.js
+++ b/src/scripts/tweaks/unsticky_tab_bar.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
-  ${keyToCss('tabsHeader')} { position: static; transform: none; }
+  ${keyToCss('tabsHeader')} { position: static !important; transform: none !important; }
   ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} { top: 69px !important; }
 `);
 


### PR DESCRIPTION
#### User-facing changes
- The unsticky tab bar tweak should not sometimes fail.

#### Technical explanation
I don't actually know how to test this, as usually it works fine as is, and I don't know how to get the XKit Rewritten rule applied before the Redpop one or how that could possibly happen.

#### Issues this closes
resolves #759