### PR TITLE
Trim Reblogs: allow legacy trimming with warning

### DIFF
--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -1,5 +1,6 @@
 import { createControlButtonTemplate, cloneControlButton } from '../util/control_buttons.js';
 import { keyToCss } from '../util/css_map.js';
+import { dom } from '../util/dom.js';
 import { filterPostElements, postSelector } from '../util/interface.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 import { onNewPosts } from '../util/mutations.js';
@@ -31,8 +32,20 @@ const onButtonClicked = async function ({ currentTarget }) {
     try {
       const { response: { shouldOpenInLegacy } } = await apiFetch(`/v2/blog/${rebloggedRootUuid}/posts/${rebloggedRootId}`);
       if (shouldOpenInLegacy) {
-        notify('Legacy posts cannot be trimmed.');
-        return;
+        await new Promise(resolve => {
+          showModal({
+            title: 'Note: Legacy post',
+            message: [
+              'The root post of this thread was originally created with the legacy post editor.',
+              '\n\n',
+              'On these threads, Trim Reblogs may work normally, have no effect, or require a repeat of the trim action to completely remove the desired trail items.'
+            ],
+            buttons: [
+              modalCancelButton,
+              dom('button', { class: 'blue' }, { click: () => resolve() }, ['Continue'])
+            ]
+          });
+        });
       }
       unsureOfLegacyStatus = false;
     } catch (exception) {


### PR DESCRIPTION
#### User-facing changes
- Trim Reblogs puts up an informational message but lets you continue if you try to trim a legacy post.

I just did four legacy post trim tests and all of them worked fine the first time, so it seems silly to totally lock this out.

Honestly, if this works well enough, maybe it doesn't need a second modal and it can just be added to the confirmation modal?

#### Technical explanation
`await new Promise` can serve as a cutesy way to stop a logic flow while enabling a resume button, but there are certainly more normal ways.

#### Issues this closes
n/a