### PR TITLE
New Script: Quotable Tags (automatic version)

### DIFF
--- a/src/scripts/_index.json
+++ b/src/scripts/_index.json
@@ -18,6 +18,7 @@
   "postblock",
   "quick_reblog",
   "quick_tags",
+  "quotable_tags",
   "quote_replies",
   "scroll_to_bottom",
   "seen_posts",

--- a/src/scripts/quotable_tags.js
+++ b/src/scripts/quotable_tags.js
@@ -1,0 +1,50 @@
+import { keyToCss } from '../util/css_map.js';
+import { inject } from '../util/inject.js';
+import { pageModifications } from '../util/mutations.js';
+
+const tagElementSelector = `${keyToCss('tagsEditor')} ${keyToCss('editableTag')}`;
+
+const doTagSmartQuotes = async () => {
+  const selectedTagsElement = document.getElementById('selected-tags');
+  if (!selectedTagsElement) { return; }
+
+  const reactKey = Object.keys(selectedTagsElement).find(key =>
+    key.startsWith('__reactFiber')
+  );
+  let fiber = selectedTagsElement[reactKey];
+
+  while (fiber !== null) {
+    let tags = fiber.stateNode?.state?.tags;
+    if (Array.isArray(tags) && tags.some(tag => tag.includes('"'))) {
+      tags = tags.map(tag =>
+        tag
+          .replace(/^"/, '\u201C')
+          .replace(/ "/g, ' \u201C')
+          .replace(/"/g, '\u201D')
+      );
+      fiber.stateNode.setState({ tags });
+      break;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+const onTagBlur = () => inject(doTagSmartQuotes);
+
+const processTagElements = tagElements => {
+  inject(doTagSmartQuotes);
+  tagElements.forEach(tagElement => tagElement.addEventListener('blur', onTagBlur));
+};
+
+export const main = async function () {
+  pageModifications.register(tagElementSelector, processTagElements);
+};
+
+export const clean = async function () {
+  pageModifications.unregister(processTagElements);
+
+  [...document.querySelectorAll(tagElementSelector)].forEach(tagElement =>
+    tagElement.removeEventListener('blur', onTagBlur)
+  );
+};

--- a/src/scripts/quotable_tags.json
+++ b/src/scripts/quotable_tags.json
@@ -1,0 +1,9 @@
+{
+  "title": "Quotable Tags",
+  "description": "Write “double quotes” in post tags",
+  "icon": {
+    "class_name": "ri-double-quotes-l",
+    "color": "white",
+    "background_color": "#ac445d"
+  }
+}


### PR DESCRIPTION
Considerations:
a) tweak or script
b) this method (replace only on tag creation or editable tag blur event) does not work if you type a tag, don't hit enter, and press post, or if you edit a tag, don't deselect it, and press post. I did not find out a great way to improve upon this; calling setstate while the user is editing is bad, and intercepting and delaying the post action is possible but awkward
c) I have another branch that neatly sidesteps this by making the "replace my straight quotes with smart quotes" button a manual post action button that only appears if you have any straight quotes, but is that worth it? probably not
d) if script, this name is rather silly; I have some ideas but no good ones

#### User-facing changes
- Adds functionality that automatically replaces quotes in tags with smart quotes so that they can be posted as quote characters instead of causing bugs.

#### Technical explanation


#### Issues this closes
resolves #733