### PR TITLE
Scroll to Bottom: minor performance improvement

### DIFF
--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -11,6 +11,7 @@ const loaderSelector = `
 ${keyToCss('timeline', 'blogRows')} > ${keyToCss('loader')},
 ${keyToCss('notifications')} + ${keyToCss('loader')}
 `;
+const knightRiderLoaderSelector = `:is(${loaderSelector}) > ${keyToCss('knightRiderLoader')}`;
 
 let scrollToBottomButton;
 let active = false;
@@ -28,7 +29,7 @@ ${keyToCss('isPeeprShowing')} #${scrollToBottomButtonId} {
 
 const scrollToBottom = () => {
   window.scrollTo({ top: document.documentElement.scrollHeight });
-  const loaders = [...document.querySelectorAll(loaderSelector)]
+  const loaders = [...document.querySelectorAll(knightRiderLoaderSelector)]
     .filter(element => element.matches(blogViewSelector) === false);
 
   if (loaders.length === 0) {


### PR DESCRIPTION
Realistically, don't worry about it. A slow selector rule is just an API request throttle in disguise anyway (as if we _did_ want to throttle scroll to bottom on purpose to make it close to holding pagedown, the delay should ideally be synchronous CPU load so there's no flickering effect.)

#### User-facing changes
- Scroll to Bottom is slightly faster.

#### Technical explanation
The last selector in a single querySelector rule is evaluated on every DOM element and will short circuit when it fails to match around 99.995% of the time, making the descendent selectors irrelevant. `loader` has, at the time of writing, 33 entries in the css map, while `knightRiderLoader` has one, so this is a ~33x speedup of the selector even though it's a longer string.

Mostly just thought that was cool to note.

#### Issues this closes
n/a