### PR TITLE
New tweak: Hide after-post popup

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -89,6 +89,11 @@
       "type": "checkbox",
       "label": "Hide the \"Now, where were we?\" button",
       "default": false
+    },
+    "hide_after_post_popup": {
+      "type": "checkbox",
+      "label": "Hide the the popups that appear after posting",
+      "default": false
     }
   }
 }

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -92,7 +92,7 @@
     },
     "hide_after_post_popup": {
       "type": "checkbox",
-      "label": "Hide the the popups that appear after posting",
+      "label": "Hide the new post celebration banner",
       "default": false
     }
   }

--- a/src/scripts/tweaks/hide_after_post_popup.js
+++ b/src/scripts/tweaks/hide_after_post_popup.js
@@ -1,0 +1,14 @@
+import { pageModifications } from '../../util/mutations.js';
+
+const processModals = modals =>
+  modals.forEach(modal => {
+    modal.parentElement.style.display = 'none';
+  });
+
+export const main = async function () {
+  pageModifications.register('#after-post-actions', processModals);
+};
+
+export const clean = async function () {
+  pageModifications.unregister(processModals);
+};

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -1,5 +1,4 @@
 import { postSelector } from './interface.js';
-const rootNode = document.getElementById('root');
 
 const mutationsPool = [];
 let repaintQueued = false;
@@ -39,12 +38,12 @@ export const pageModifications = Object.freeze({
     if (!selector) return;
 
     if (modifierFunction.length === 0) {
-      const shouldRun = rootNode.querySelector(selector) !== null;
+      const shouldRun = document.body.querySelector(selector) !== null;
       if (shouldRun) modifierFunction();
       return;
     }
 
-    const matchingElements = [...rootNode.querySelectorAll(selector)];
+    const matchingElements = [...document.body.querySelectorAll(selector)];
     if (matchingElements.length !== 0) {
       modifierFunction(matchingElements);
     }
@@ -92,4 +91,4 @@ const observer = new MutationObserver(mutations => {
   }
 });
 
-observer.observe(rootNode, { childList: true, subtree: true });
+observer.observe(document.body, { childList: true, subtree: true });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds a tweak that hides the `#after-post-actions` popup elements that appear after creating or reblogging a post using the full beta post editor form.

The small popup that appears after using the native Tumblr quick reblog is unaffected.

Technical details:
 - This toast container is portaled outside of the `#root` element, so it was not detected by our postModifications utility until I expanded its scope to include document.body. This didn't seem to have a negative impact.
 - I set an inline style; this could just as easily be a class.

Unsure of:
- UI copy improvements.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Enable tweaks and this new tweak.

Create and post a new post using the beta post editor. There should be no popup and no confetti after the form is submitted.

Reblog a post using the beta post editor. There should be no purple popup after the form is submitted.

Fast-reblog a post using the native fast reblog. There should still be a small popup indicating success. Repeat this with quick queue.