### PR TITLE
Quick Tags: Automatically change popup position

### DIFF
--- a/src/scripts/quick_tags.css
+++ b/src/scripts/quick_tags.css
@@ -27,6 +27,10 @@
   transform: translate(50%, 12px);
 }
 
+#quick-tags-post-option.above {
+  transform: translate(50%, calc(-100% - 12px - 22px));
+}
+
 @media (max-width: 650px) {
   #quick-tags {
     top: 50%;

--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -121,11 +121,22 @@ const togglePopupDisplay = async function ({ target, currentTarget }) {
   currentTarget[appendOrRemove](popupElement);
 };
 
+const appendWithoutViewportOverflow = (element, target) => {
+  element.classList.remove('above');
+  target.appendChild(element);
+  if (element.getBoundingClientRect().bottom > document.documentElement.clientHeight) {
+    element.classList.add('above');
+  }
+};
+
 const togglePostOptionPopupDisplay = async function ({ target, currentTarget }) {
   if (target === postOptionPopupElement || postOptionPopupElement.contains(target)) { return; }
 
-  const appendOrRemove = currentTarget.contains(postOptionPopupElement) ? 'removeChild' : 'appendChild';
-  currentTarget[appendOrRemove](postOptionPopupElement);
+  if (currentTarget.contains(postOptionPopupElement)) {
+    currentTarget.removeChild(postOptionPopupElement);
+  } else {
+    appendWithoutViewportOverflow(postOptionPopupElement, currentTarget);
+  }
 };
 
 const addTagsToPost = async function ({ postElement, inputTags = [] }) {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Here's one way to resolve #805: it makes the quick tags popup automatically choose the "above" location only if placement in the "below" location would overflow the viewport, with no user preference.

I don't think this is necessarily better than the user preference option, but I coded it to see how it felt.

`getBoundingClientRect()` is used rather than an `IntersectionObserver`, as this logic only needs to be run synchronously when the user presses the quick tags button. 

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable quick tags and create enough tag bundles for the quick tags popup to have meaningful size.
- Compose a post in the beta post editor.
- Click the quick tags button. The popup should appear in the normal, below-the-button position. Dismiss it.
- Increase the height of the post form by adding content.
- Click the quick tags button. The popup should appear above the quick tags button. It should not overflow off of the screen.

