### PR TITLE
manually move quick tags up

### DIFF
--- a/src/scripts/quick_tags.css
+++ b/src/scripts/quick_tags.css
@@ -27,6 +27,10 @@
   transform: translate(50%, 12px);
 }
 
+#quick-tags-post-option.above {
+  transform: translate(50%, calc(-100% - 12px - 22px));
+}
+
 @media (max-width: 650px) {
   #quick-tags {
     top: 50%;

--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -14,6 +14,7 @@ const excludeClass = 'xkit-quick-tags-done';
 const tagsClass = 'xkit-quick-tags-tags';
 const controlIconSelector = keyToCss('controlIcon');
 
+let popupPosition;
 let originalPostTag;
 let answerTag;
 let autoTagAsker;
@@ -105,7 +106,8 @@ export const onStorageChanged = async function (changes, areaName) {
   if (Object.keys(changes).some(key => key.startsWith('quick_tags'))) {
     if (Object.keys(changes).includes(storageKey)) populatePopups();
 
-    ({ originalPostTag, answerTag, autoTagAsker } = await getPreferences('quick_tags'));
+    ({ popupPosition, originalPostTag, answerTag, autoTagAsker } = await getPreferences('quick_tags'));
+    postOptionPopupElement.className = popupPosition;
     if (originalPostTag || answerTag || autoTagAsker) {
       pageModifications.register('#selected-tags', processPostForm);
     } else {
@@ -233,7 +235,8 @@ export const main = async function () {
 
   populatePopups();
 
-  ({ originalPostTag, answerTag, autoTagAsker } = await getPreferences('quick_tags'));
+  ({ popupPosition, originalPostTag, answerTag, autoTagAsker } = await getPreferences('quick_tags'));
+  postOptionPopupElement.className = popupPosition;
   if (originalPostTag || answerTag || autoTagAsker) {
     pageModifications.register('#selected-tags', processPostForm);
   }

--- a/src/scripts/quick_tags.json
+++ b/src/scripts/quick_tags.json
@@ -9,6 +9,15 @@
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#quick-tags",
   "relatedTerms": [ "Auto Tagger", "AutoTagger", "XInbox" ],
   "preferences": {
+    "popupPosition": {
+      "type": "select",
+      "label": "Popup position",
+      "options": [
+        { "value": "above", "label": "Above button" },
+        { "value": "below", "label": "Below button" }
+      ],
+      "default": "below"
+    },
     "originalPostTag": {
       "type": "text",
       "label": "Original post tag",


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

The other way to resolve #805: this adds a preference essentially identical to the one in Quick Reblog that specifies whether the quick reblog popup appears above or below the button.

I don't think this is necessarily better than the automatic option, but I coded it to see how it felt.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable quick tags and create enough tag bundles for the quick tags popup to have meaningful size.
- Compose a post in the beta post editor.
- Click the quick tags button. The popup should appear in the normal, below-the-button position. Dismiss it.
- Change the popup position preference to above.
- Click the quick tags button. The popup should appear above the quick tags button.