### PR TITLE
Popup: Toggle script preference open toggling script

### DIFF
--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -17,6 +17,8 @@ const writeEnabled = async function ({ currentTarget }) {
   const detailsElement = currentTarget.closest('details');
   let { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
 
+  detailsElement.open = checked;
+
   if (checked) {
     enabledScripts.push(id);
     detailsElement.classList.remove('disabled');


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This toggles the open/closed state of a script's preferences when toggling it on/off. This ensures that new users will be aware of the existence of script preferences as soon as they toggle on their first script.

There are scenarios where this is slightly inconvenient (toggling more than one script at once necessitates some scrolling unless you go bottom to top), but that seems fairly niche.

This PR currently closes the preference pane when you toggle a script off as well as opening the preference pane when you toggle a script on; this felt more natural to me than only performing this action on enable.

There is some risk of users not realizing you can open the preference pane without clicking the toggle now, but that seems even more niche than the problem this solves and does not actually impede functionality.

Resolves #815.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Open the extension preference pane and toggle a script on. Its preference pane should open.
- Open the extension preference pane, open a script's preference pane, and toggle it on. It should stay open.
- Open the extension preference pane, open a script's preference pane, and toggle it off. Its preference pane should close.
- Open the extension preference pane and toggle a script off. It should stay closed.


