### PR TITLE
Popup: Don't toggle script preference if empty

### DIFF
--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -17,7 +17,8 @@ const writeEnabled = async function ({ currentTarget }) {
   const detailsElement = currentTarget.closest('details');
   let { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
 
-  detailsElement.open = checked;
+  const hasPreferences = detailsElement.querySelector('.preferences:not(:empty)');
+  if (hasPreferences) detailsElement.open = checked;
 
   if (checked) {
     enabledScripts.push(id);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

> Feels very natural, I like it. A nice point for iteration would be to exclude scripts with no preferences from this behaviour.

_Originally posted by @AprilSylph in https://github.com/AprilSylph/XKit-Rewritten/pull/817#pullrequestreview-1180588835_

This excludes scripts with no preferences from the linked behavior.

(Arguably slightly more consistent to close open preferences when toggling a script off even if the script in question has no preferences, but also arguably not, and does it matter?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Toggle a script with preferences on/off. The visibility of its preferences dropdown should change.
- Toggle a script with no preferences on/off. The visibility of its preferences dropdown should not change.
- Open a script's preference pane, then toggle it off. This one is now inconsistent, but I don't think it matters much.