### PR TITLE
Sidebar util: Condense multi-row sidebars

### DIFF
--- a/src/content_scripts/sidebar.css
+++ b/src/content_scripts/sidebar.css
@@ -43,6 +43,10 @@
 }
 
 .xkit-sidebar-item li {
+  padding: 0 10px;
+}
+
+.xkit-sidebar-item li:only-child {
   padding: 5px 10px;
 }
 

--- a/src/content_scripts/sidebar.css
+++ b/src/content_scripts/sidebar.css
@@ -46,6 +46,10 @@
   padding: 5px 10px;
 }
 
+.xkit-sidebar-item .many-rows li {
+  padding: 0 10px;
+}
+
 .xkit-sidebar-item li:hover {
   background-color: rgba(var(--white-on-dark), 0.07);
 }

--- a/src/content_scripts/sidebar.css
+++ b/src/content_scripts/sidebar.css
@@ -43,10 +43,6 @@
 }
 
 .xkit-sidebar-item li {
-  padding: 0 10px;
-}
-
-.xkit-sidebar-item li:only-child {
   padding: 5px 10px;
 }
 

--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -55,7 +55,7 @@ const buildSidebarRow = ({ label, onclick, count, carrot }) =>
 export const addSidebarItem = function ({ id, title, rows, visibility }) {
   const sidebarItem = dom('div', { id, class: 'xkit-sidebar-item' }, null, [
     dom('h1', null, null, [title]),
-    dom('ul', null, null, rows.map(buildSidebarRow))
+    dom('ul', rows.length > 2 ? { class: 'many-rows' } : null, null, rows.map(buildSidebarRow))
   ]);
 
   if (visibility instanceof Function) {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Tag Tracking+'s sidebar takes up a lot of vertical room on my display because each tracked tag is so tall, but I think the button height feels right for the scripts that have one button to open a UI popup.

This automatically vertically condenses sidebar lists with more than 2 items. (No idea if that's the ideal number. Discuss! If n = 1, there is also an easier way to do this; see reverted commit.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable Tag Tracking+ (with the sidebar option) and e.g. Limit Checker. Compare their sidebar items' styling.
- Track more/fewer tags to make your number of tracked tags more/less than 2. Observe the new styling.

<img width="346" src="https://user-images.githubusercontent.com/8336245/202055788-0d254778-91d5-4a57-96c5-4b7ccc1609ce.png">

