### PR TITLE
Quick Tags: fix default content field

### DIFF
--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -148,7 +148,7 @@ const addTagsToPost = async function ({ postElement, inputTags = [] }) {
 
   const {
     response: {
-      content = {},
+      content = [],
       layout,
       state = 'published',
       publishOn,


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Implements the same fix in Quick Tags as made to Trim Reblogs and the Quick Flags PR.
