### PR TITLE
Fix link to Firefox extension documentation.

### DIFF
--- a/docs/Chapter 2 - Getting started.md
+++ b/docs/Chapter 2 - Getting started.md
@@ -20,7 +20,7 @@ If you're unable to get set up locally, all you need to do is go to the **Action
 
 The extension source code is located in `src/`. Before loading your development version, first be sure to disable the release version if you have it installed on the browser you're testing on.
 
-- Firefox: [Loading a temporary extension](https://developer.mozilla.org/en-US/docs/Tools/about:debugging#Extensions)
+- Firefox: [Loading a temporary extension](https://firefox-source-docs.mozilla.org/devtools-user/about_colon_debugging/index.html#extensions)
 - Chromium: [Load an unpacked extension](https://developer.chrome.com/docs/extensions/mv2/getstarted/#manifest)
 
 Be sure to reload the extension each time you modify its files, and refresh any open Tumblr tabs in that browser. Otherwise, your changes may not be reflected.


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
The link to how to a temporary extension was broken due to Mozilla changing how colons in URLs are interpreted, in addition to changing the subdomain from `developer` to `firefox-source-docs`. 

This small PR fixes this behavior.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Just click on the link!