### PR TITLE
proof of concept: editable reblogs

### DIFF
--- a/src/scripts/_index.json
+++ b/src/scripts/_index.json
@@ -4,6 +4,7 @@
   "classic_search",
   "cleanfeed",
   "collapsed_queue",
+  "editable_reblogs",
   "hide_avatars",
   "limit_checker",
   "mass_deleter",

--- a/src/scripts/editable_reblogs.js
+++ b/src/scripts/editable_reblogs.js
@@ -22,6 +22,43 @@ let controlButtonTemplate;
 //   name: 'anonymous'
 // };
 
+const trailToNPF = (trail, skipFirstFewItems = 0) => {
+  const trailToInclude = trail.slice(skipFirstFewItems);
+  if (trailToInclude.length === 0) {
+    throw new Error('generateEditableContent error, post is too big or something');
+  }
+
+  const newContent = trailToInclude.flatMap(
+    ({ blog, content, layout, post: { id, timestamp } }) => [
+      {
+        type: 'text',
+        subtype: 'heading2',
+        text: `${blog.name}:`,
+        formatting: [
+          { type: 'bold', start: 0, end: blog.name.length + 1 },
+          {
+            type: 'link',
+            start: 0,
+            end: blog.name.length,
+            url: `tumblr.com/${blog.name}/${id}`
+          }
+        ]
+      },
+      ...content,
+      { type: 'text', text: '-------------------------------------' }
+    ]
+  );
+
+  // npf layout concat + block id manipulation + readmore removal goes here
+  const newLayout = [];
+
+  // if (there are too many blocks) {
+  //   return generateEditableContent(skipFirstFewItems + 1)
+  // }
+
+  return { newContent, newLayout };
+};
+
 const onButtonClicked = async function ({ currentTarget: controlButton }) {
   // TODO: blog selection
   const targetBlog = primaryBlogName;
@@ -92,44 +129,7 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
 
   const trailWithNew = [...trail, ...newTrailItem];
 
-  const generateEditableContent = (skipFirstFewItems = 0) => {
-    const trailToInclude = trailWithNew.slice(skipFirstFewItems);
-    if (trailToInclude.length === 0) {
-      throw new Error('generateEditableContent error, post is too big or something');
-    }
-
-    const newContent = trailToInclude.flatMap(
-      ({ blog, content, layout, post: { id, timestamp } }) => [
-        {
-          type: 'text',
-          subtype: 'heading2',
-          text: `${blog.name}:`,
-          formatting: [
-            { type: 'bold', start: 0, end: blog.name.length + 1 },
-            {
-              type: 'link',
-              start: 0,
-              end: blog.name.length,
-              url: `tumblr.com/${blog.name}/${id}`
-            }
-          ]
-        },
-        ...content,
-        { type: 'text', text: '-------------------------------------' }
-      ]
-    );
-
-    // npf layout concat + block id manipulation + readmore removal goes here
-    const newLayout = [];
-
-    // if (there are too many blocks) {
-    //   return generateEditableContent(skipFirstFewItems + 1)
-    // }
-
-    return { newContent, newLayout };
-  };
-
-  const { newContent, newLayout } = generateEditableContent();
+  const { newContent, newLayout } = trailToNPF(trailWithNew);
 
   const excludeTrailItems = [...trailWithNew.keys()];
 

--- a/src/scripts/editable_reblogs.js
+++ b/src/scripts/editable_reblogs.js
@@ -1,0 +1,201 @@
+import { createControlButtonTemplate, cloneControlButton } from '../util/control_buttons.js';
+import { keyToCss } from '../util/css_map.js';
+import { dom } from '../util/dom.js';
+import { filterPostElements, postSelector } from '../util/interface.js';
+import { showModal, modalCancelButton, hideModal } from '../util/modals.js';
+import { onNewPosts } from '../util/mutations.js';
+import { timelineObject } from '../util/react_props.js';
+import { apiFetch, softNavigate } from '../util/tumblr_helpers.js';
+import { primaryBlogName } from '../util/user.js';
+
+const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+
+const symbolId = 'ri-edit-box-line';
+const buttonClass = 'xkit-editable-reblogs-button';
+
+const controlIconSelector = keyToCss('controlIcon');
+
+let controlButtonTemplate;
+
+// const blogPlaceholder = {
+//   avatar: [{ url: 'https://assets.tumblr.com/pop/src/assets/images/avatar/anonymous_avatar_96-223fabe0.png' }],
+//   name: 'anonymous'
+// };
+
+const onButtonClicked = async function ({ currentTarget: controlButton }) {
+  // TODO: blog selection
+  const targetBlog = primaryBlogName;
+
+  const postElement = controlButton.closest(postSelector);
+
+  const {
+    rebloggedRootUuid,
+    rebloggedRootId,
+    blog,
+    id,
+    reblogKey,
+    timestamp,
+    content = [],
+    layout,
+    trail = [],
+    shouldOpenInLegacy
+  } = await timelineObject(postElement);
+
+  try {
+    const rootShouldOpenInLegacy =
+      rebloggedRootUuid && rebloggedRootId
+        ? (await apiFetch(`/v2/blog/${rebloggedRootUuid}/posts/${rebloggedRootId}`)).response
+            .shouldOpenInLegacy
+        : shouldOpenInLegacy;
+
+    if (rootShouldOpenInLegacy) {
+      await new Promise(resolve => {
+        showModal({
+          title: 'Note: Legacy post',
+          message: [
+            'The root post of this thread was originally created with the legacy post editor.',
+            '\n\n',
+            'On these threads, Editable Reblogs may work normally, have no effect, or require use of Trim Reblogs to completely remove the extra trail items.'
+          ],
+          buttons: [
+            modalCancelButton,
+            dom('button', { class: 'blue' }, { click: () => resolve() }, ['Continue'])
+          ]
+        });
+      });
+    }
+  } catch (exception) {
+    await new Promise(resolve => {
+      showModal({
+        title: 'Note: Possible legacy post',
+        message: [
+          'The root post of this thread may have been originally created with the legacy post editor.',
+          '\n\n',
+          'On these threads, Editable Reblogs may work normally, have no effect, or require use of Trim Reblogs to completely remove the extra trail items.'
+        ],
+        buttons: [
+          modalCancelButton,
+          dom('button', { class: 'blue' }, { click: () => resolve() }, ['Continue'])
+        ]
+      });
+    });
+  }
+
+  showModal({
+    title: 'Creating edited draft...',
+    message: ['Please wait.']
+  });
+  const minimumTimer = sleep(500);
+
+  const newTrailItem =
+    content && content.length ? [{ blog, content, layout, post: { id, timestamp } }] : [];
+
+  const trailWithNew = [...trail, ...newTrailItem];
+
+  const generateEditableContent = (skipFirstFewItems = 0) => {
+    const trailToInclude = trailWithNew.slice(skipFirstFewItems);
+    if (trailToInclude.length === 0) {
+      throw new Error('generateEditableContent error, post is too big or something');
+    }
+
+    const newContent = trailToInclude.flatMap(
+      ({ blog, content, layout, post: { id, timestamp } }) => [
+        {
+          type: 'text',
+          subtype: 'heading2',
+          text: `${blog.name}:`,
+          formatting: [
+            { type: 'bold', start: 0, end: blog.name.length + 1 },
+            {
+              type: 'link',
+              start: 0,
+              end: blog.name.length,
+              url: `tumblr.com/${blog.name}/${id}`
+            }
+          ]
+        },
+        ...content,
+        { type: 'text', text: '-------------------------------------' }
+      ]
+    );
+
+    // npf layout concat + block id manipulation + readmore removal goes here
+    const newLayout = [];
+
+    // if (there are too many blocks) {
+    //   return generateEditableContent(skipFirstFewItems + 1)
+    // }
+
+    return { newContent, newLayout };
+  };
+
+  const { newContent, newLayout } = generateEditableContent();
+
+  const excludeTrailItems = [...trailWithNew.keys()];
+
+  const requestPath = `/v2/blog/${targetBlog}/posts`;
+  const requestBody = {
+    content: newContent,
+    layout: newLayout,
+    exclude_trail_items: excludeTrailItems,
+    parent_post_id: id,
+    parent_tumblelog_uuid: blog.uuid,
+    reblog_key: reblogKey,
+    state: 'draft'
+  };
+  try {
+    const {
+      meta,
+      response: { displayText, id }
+    } = await apiFetch(requestPath, { method: 'POST', body: requestBody });
+    await minimumTimer;
+    if (meta.status === 201) {
+      showModal({
+        title: displayText,
+        message: [`will navigate to draft ${id} now`]
+      });
+    }
+    await sleep(1500);
+    hideModal();
+    softNavigate(`/edit/${primaryBlogName}/${id}`);
+  } catch (e) {
+    console.log(e);
+  }
+};
+
+const processPosts = postElements =>
+  filterPostElements(postElements).forEach(async postElement => {
+    const existingButton = postElement.querySelector(`.${buttonClass}`);
+    if (existingButton !== null) {
+      return;
+    }
+
+    const reblogIcon = postElement.querySelector(
+      `footer ${controlIconSelector} use[href="#managed-icon__reblog"]`
+    );
+    console.log(reblogIcon);
+    if (!reblogIcon) {
+      return;
+    }
+
+    const { canReblog } = await timelineObject(postElement);
+    if (!canReblog) {
+      return;
+    }
+
+    const clonedControlButton = cloneControlButton(controlButtonTemplate, {
+      click: onButtonClicked
+    });
+    const controlIcon = reblogIcon.closest(controlIconSelector);
+    controlIcon.before(clonedControlButton);
+  });
+
+export const main = async function () {
+  controlButtonTemplate = createControlButtonTemplate(symbolId, buttonClass);
+  onNewPosts.addListener(processPosts);
+};
+
+export const clean = async function () {
+  onNewPosts.removeListener(processPosts);
+  $(`.${buttonClass}`).remove();
+};

--- a/src/scripts/editable_reblogs.js
+++ b/src/scripts/editable_reblogs.js
@@ -5,7 +5,7 @@ import { filterPostElements, postSelector } from '../util/interface.js';
 import { showModal, modalCancelButton, hideModal } from '../util/modals.js';
 import { onNewPosts } from '../util/mutations.js';
 import { timelineObject } from '../util/react_props.js';
-import { apiFetch, softNavigate } from '../util/tumblr_helpers.js';
+import { apiFetch, navigate } from '../util/tumblr_helpers.js';
 import { primaryBlogName } from '../util/user.js';
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
@@ -157,7 +157,7 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
     }
     await sleep(1500);
     hideModal();
-    softNavigate(`/edit/${primaryBlogName}/${id}`);
+    navigate(`/edit/${primaryBlogName}/${id}`);
   } catch (e) {
     console.log(e);
   }

--- a/src/scripts/editable_reblogs.json
+++ b/src/scripts/editable_reblogs.json
@@ -1,0 +1,10 @@
+{
+  "title": "Editable Reblogs",
+  "description": "yes really",
+  "icon": {
+    "class_name": "ri-edit-box-line",
+    "color": "white",
+    "background_color": "#000000"
+  },
+  "relatedTerms": [ "Trim Reblogs", "Editable Reblogs" ]
+}

--- a/src/util/tumblr_helpers.js
+++ b/src/util/tumblr_helpers.js
@@ -1,4 +1,3 @@
-import { keyToCss } from './css_map.js';
 import { inject } from './inject.js';
 
 /**
@@ -46,27 +45,3 @@ export const apiFetch = async function (...args) {
     args
   );
 };
-
-const controlSoftNavigation = location => {
-  const element = document.currentScript.parentElement;
-  const reactKey = Object.keys(element).find(key => key.startsWith('__reactFiber'));
-  let fiber = element[reactKey];
-
-  while (fiber !== null) {
-    const { navigate } = fiber.memoizedProps || {};
-    if (navigate !== undefined) {
-      navigate(location);
-      return;
-    } else {
-      fiber = fiber.return;
-    }
-  }
-  window.open(location);
-};
-
-export const softNavigate = location =>
-  inject(
-    controlSoftNavigation,
-    [location],
-    document.querySelector(keyToCss('bluespaceLayout'))
-  );

--- a/src/util/tumblr_helpers.js
+++ b/src/util/tumblr_helpers.js
@@ -1,3 +1,4 @@
+import { keyToCss } from './css_map.js';
 import { inject } from './inject.js';
 
 /**
@@ -45,3 +46,27 @@ export const apiFetch = async function (...args) {
     args
   );
 };
+
+const controlSoftNavigation = location => {
+  const element = document.currentScript.parentElement;
+  const reactKey = Object.keys(element).find(key => key.startsWith('__reactFiber'));
+  let fiber = element[reactKey];
+
+  while (fiber !== null) {
+    const { navigate } = fiber.memoizedProps || {};
+    if (navigate !== undefined) {
+      navigate(location);
+      return;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+  window.open(location);
+};
+
+export const softNavigate = location =>
+  inject(
+    controlSoftNavigation,
+    [location],
+    document.querySelector(keyToCss('bluespaceLayout'))
+  );

--- a/src/util/tumblr_helpers.js
+++ b/src/util/tumblr_helpers.js
@@ -45,3 +45,12 @@ export const apiFetch = async function (...args) {
     args
   );
 };
+
+export const navigate = location =>
+  inject(location => window.tumblr.navigate(location), [location]);
+
+export const onClickNavigate = event => {
+  if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
+  event.preventDefault();
+  navigate(event.currentTarget.href);
+};


### PR DESCRIPTION
Before you ask: no. Barring a miracle, we're not doing this. 

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<img width="681" alt="Screen Shot 2022-11-19 at 1 47 56 PM" src="https://user-images.githubusercontent.com/8336245/202872790-7c58e148-c143-46cc-b8e4-859205d90497.png">


Demonstrates some of the ability to do what Editable Reblogs did in legacy XKit: on the press of a button, this opens a reblog form with the real Tumblr trail missing and the previous post contents copied into the editable part of the form.

Well, not really. Because there's no real good way to format this kind of thing right now, as NPF doesn't allow most formatting to be inside an indented block, so it's pretty hard to make it clear where one fake trail item ends and the next begins.

Right now this also removes `layout` data, which blows up photosets that are intended to have images side by side, and has no way of selecting which blog you want to reblog to, both of which would be fixable but are outside the scope of the proof of concept I wanted to create.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Don't.
