### PR TITLE
new experimental script: title counts

### DIFF
--- a/src/scripts/_index.json
+++ b/src/scripts/_index.json
@@ -26,6 +26,7 @@
   "tag_replacer",
   "tag_tracking_plus",
   "themed_posts",
+  "title_counts",
   "timeformat",
   "timestamps",
   "trim_reblogs",

--- a/src/scripts/title_counts.js
+++ b/src/scripts/title_counts.js
@@ -1,0 +1,78 @@
+import { inject } from '../util/inject.js';
+import { getPreferences } from '../util/preferences.js';
+
+let observer;
+let mode;
+
+const unburyPollerContext = () => {
+  const postElement = document.currentScript.parentElement;
+  const reactKey = Object.keys(postElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = postElement[reactKey];
+
+  while (fiber) {
+    const { pollerContext } = fiber.memoizedProps || {};
+    if (pollerContext !== undefined) {
+      console.log(fiber);
+      return pollerContext;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+const countRegex = /^\(\d+\) /;
+
+const onTitleChanged = async (...args) => {
+  console.log('onTitleChanged', args);
+  observer?.disconnect();
+
+  const title = document.head.querySelector('title');
+  const currentTitle = title.textContent;
+
+  if (mode === 'notifications') {
+    const {
+      notificationCount = 0,
+      unopenedGifts = 0,
+      unreadMessagesCount = 0,
+      unseenPosts = 0
+    } = await inject(unburyPollerContext, [], document.querySelector('header'));
+
+    console.log('pollerContext', {
+      notificationCount,
+      unopenedGifts,
+      unreadMessagesCount,
+      unseenPosts
+    });
+
+    const count = notificationCount + unopenedGifts + unreadMessagesCount;
+
+    title.textContent = currentTitle.replace(countRegex, count ? `(${count}) ` : '');
+  } else {
+    title.textContent = currentTitle.replace(countRegex, '');
+    console.log('mode none');
+  }
+
+  observer?.observe(title, { characterData: true, subtree: true });
+  debouncedOnTitleChanged();
+};
+
+const debounce = (func, ms) => {
+  let timeoutID;
+  return (...args) => {
+    clearTimeout(timeoutID);
+    timeoutID = setTimeout(() => func(...args), ms);
+  };
+};
+
+const debouncedOnTitleChanged = debounce(onTitleChanged, 35000);
+
+export const main = async () => {
+  ({ mode } = await getPreferences('title_counts'));
+  observer = new MutationObserver(onTitleChanged);
+  onTitleChanged();
+};
+
+export const clean = async () => {
+  observer.disconnect();
+  observer = undefined;
+};

--- a/src/scripts/title_counts.js
+++ b/src/scripts/title_counts.js
@@ -10,7 +10,7 @@ const unburyPollerContext = () => {
   let fiber = postElement[reactKey];
 
   while (fiber) {
-    const { pollerContext } = fiber.memoizedProps || {};
+    const { pollerContext } = fiber.stateNode?.props || {};
     if (pollerContext !== undefined) {
       console.log(fiber);
       return pollerContext;

--- a/src/scripts/title_counts.js
+++ b/src/scripts/title_counts.js
@@ -46,7 +46,7 @@ const onTitleChanged = async (...args) => {
 
     const count = notificationCount + unopenedGifts + unreadMessagesCount;
 
-    title.textContent = currentTitle.replace(countRegex, count ? `(${count}) ` : '');
+    title.textContent = `${count ? `(${count}) ` : ''}${currentTitle.replace(countRegex, '')}`;
   } else {
     title.textContent = currentTitle.replace(countRegex, '');
     console.log('mode none');

--- a/src/scripts/title_counts.json
+++ b/src/scripts/title_counts.json
@@ -1,0 +1,20 @@
+{
+  "title": "Title Count Options",
+  "description": "",
+  "icon": {
+    "class_name": "ri-chat-follow-up-line",
+    "color": "white",
+    "background_color": "#000000"
+  },
+  "preferences": {
+    "mode": {
+      "type": "select",
+      "label": "mode",
+      "options": [
+        { "value": "notifications", "label": "notifications" },
+        { "value": "none", "label": "none" }
+      ],
+      "default": "notifications"
+    }
+  }
+}


### PR DESCRIPTION
**edit:** currently broken; soft navigation replaces the title element

Experimenting with editing the tab title text with the user's notification count instead of their unseen posts count.

As of this initial commit, unburyPollerContext inexplicably gives me outdated pollerContext values, so the count lags behind by like a minute. Can't figure out why this is.

More general discussion: should XKit Rewritten implement what Tab Titles did (not that I know exactly what that is offhand), have essentially this functionality to change the count (if I can get it to work and we either view pollerContext extraction as stable, get it from the DOM and live with it not working in mobile view, or have it added to `window.tumblr`), or just have an option to remove the count (which I would just make a tweak)?

<!--
### Description

  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<!--
### Testing steps

  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

