### PR TITLE
Seen Posts: Hide seen posts completely

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "XKit Rewritten",
-  "version": "0.21.0",
+  "version": "0.21.1",
 
   "short_name": "XKit",
   "author": "April Sylph",

--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -2,3 +2,7 @@ body:not(.xkit-seen-posts-only-dim-avatar) .xkit-seen-posts-seen:not(:hover),
 body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article > :first-child img {
   opacity: 0.5;
 }
+
+body.xkit-seen-posts-hide .xkit-seen-posts-seen {
+  display: none;
+}

--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -4,5 +4,5 @@ body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article >
 }
 
 body.xkit-seen-posts-hide .xkit-seen-posts-seen article {
-  display: none;
+  display: none !important;
 }

--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -3,6 +3,6 @@ body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article >
   opacity: 0.5;
 }
 
-body.xkit-seen-posts-hide .xkit-seen-posts-seen article {
+body.xkit-seen-posts-hide .xkit-seen-posts-seen {
   display: none !important;
 }

--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -3,6 +3,6 @@ body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article >
   opacity: 0.5;
 }
 
-body.xkit-seen-posts-hide .xkit-seen-posts-seen {
+body.xkit-seen-posts-hide .xkit-seen-posts-seen article {
   display: none;
 }

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -8,6 +8,7 @@ const includeFiltered = true;
 
 const dimClass = 'xkit-seen-posts-seen';
 const onlyDimAvatarsClass = 'xkit-seen-posts-only-dim-avatar';
+const hideClass = 'xkit-seen-posts-hide';
 
 const storageKey = 'seen_posts.seenPosts';
 let seenPosts = [];
@@ -30,9 +31,16 @@ const dimPosts = function (postElements) {
 
 export const onStorageChanged = async function (changes, areaName) {
   const {
+    'seen_posts.preferences.hideSeenPosts': hideSeenPostsChanges,
     'seen_posts.preferences.onlyDimAvatars': onlyDimAvatarsChanges,
     [storageKey]: seenPostsChanges
   } = changes;
+
+  if (hideSeenPostsChanges && hideSeenPostsChanges.oldValue !== undefined) {
+    const { newValue: hideSeenPosts } = hideSeenPostsChanges;
+    const addOrRemoveHide = hideSeenPosts ? 'add' : 'remove';
+    document.body.classList[addOrRemoveHide](hideClass);
+  }
 
   if (onlyDimAvatarsChanges && onlyDimAvatarsChanges.oldValue !== undefined) {
     const { newValue: onlyDimAvatars } = onlyDimAvatarsChanges;
@@ -48,7 +56,10 @@ export const onStorageChanged = async function (changes, areaName) {
 export const main = async function () {
   ({ [storageKey]: seenPosts = [] } = await browser.storage.local.get(storageKey));
 
-  const { onlyDimAvatars } = await getPreferences('seen_posts');
+  const { hideSeenPosts, onlyDimAvatars } = await getPreferences('seen_posts');
+  if (hideSeenPosts) {
+    document.body.classList.add(hideClass);
+  }
   if (onlyDimAvatars) {
     document.body.classList.add(onlyDimAvatarsClass);
   }
@@ -59,6 +70,7 @@ export const main = async function () {
 export const clean = async function () {
   onNewPosts.removeListener(dimPosts);
   $(`.${excludeClass}`).removeClass(excludeClass);
+  $(`.${hideClass}`).removeClass(hideClass);
   $(`.${dimClass}`).removeClass(dimClass);
   $(`.${onlyDimAvatarsClass}`).removeClass(onlyDimAvatarsClass);
 };

--- a/src/scripts/seen_posts.json
+++ b/src/scripts/seen_posts.json
@@ -9,6 +9,11 @@
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#seen-posts",
   "relatedTerms": [ "Read Posts" ],
   "preferences": {
+    "hideSeenPosts": {
+      "type": "checkbox",
+      "label": "Hide seen posts from dashboard",
+      "default": false
+    },
     "onlyDimAvatars": {
       "type": "checkbox",
       "label": "Only dim avatars on seen posts",


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
As per #869, adds a preference to the Seen Posts script to allow users to hide seen posts on the dashboard using a CSS style.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
User should be able to browse as usual, but when their dashboard updates with new posts, any posts they have viewed will be hidden, leaving only new posts and old ones that have not been viewed.
