### PR TITLE
Create NPF edit parameter utility

### DIFF
--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -6,7 +6,7 @@ import { notify } from '../util/notifications.js';
 import { registerPostOption, unregisterPostOption } from '../util/post_actions.js';
 import { getPreferences } from '../util/preferences.js';
 import { timelineObject, editPostFormTags } from '../util/react_props.js';
-import { apiFetch } from '../util/tumblr_helpers.js';
+import { apiFetch, createEditRequestBody } from '../util/tumblr_helpers.js';
 
 const symbolId = 'ri-price-tag-3-line';
 const buttonClass = 'xkit-quick-tags-button';
@@ -146,18 +146,8 @@ const addTagsToPost = async function ({ postElement, inputTags = [] }) {
   const postId = postElement.dataset.id;
   const { blog: { uuid } } = await timelineObject(postElement);
 
-  const {
-    response: {
-      content = [],
-      layout,
-      state = 'published',
-      publishOn,
-      date,
-      tags = [],
-      sourceUrlRaw,
-      slug = ''
-    }
-  } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}`);
+  const { response: postData } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}`);
+  const { tags = [] } = postData;
 
   const tagsToAdd = inputTags.filter(inputTag => tags.includes(inputTag) === false);
   if (tagsToAdd.length === 0) { return; }
@@ -168,14 +158,8 @@ const addTagsToPost = async function ({ postElement, inputTags = [] }) {
     const { response: { displayText } } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}`, {
       method: 'PUT',
       body: {
-        content,
-        layout,
-        state,
-        publish_on: publishOn,
-        date,
-        tags: tags.join(','),
-        source_url: sourceUrlRaw,
-        slug
+        ...createEditRequestBody(postData),
+        tags: tags.join(',')
       }
     });
 

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -6,7 +6,7 @@ import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 import { onNewPosts } from '../util/mutations.js';
 import { notify } from '../util/notifications.js';
 import { timelineObject } from '../util/react_props.js';
-import { apiFetch } from '../util/tumblr_helpers.js';
+import { apiFetch, createEditRequestBody } from '../util/tumblr_helpers.js';
 
 const symbolId = 'ri-scissors-cut-line';
 const buttonClass = 'xkit-trim-reblogs-button';
@@ -61,19 +61,8 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
     }
   }
 
-  const {
-    response: {
-      blog,
-      content = [],
-      layout,
-      state = 'published',
-      publishOn,
-      date,
-      tags = [],
-      slug = '',
-      trail = []
-    }
-  } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}?fields[blogs]=name,avatar`);
+  const { response: postData } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}?fields[blogs]=name,avatar`);
+  const { blog, content = [], trail = [] } = postData;
 
   if (!trail?.length) {
     notify('This post is too short to trim!');
@@ -127,13 +116,7 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
       const { response: { displayText } } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}`, {
         method: 'PUT',
         body: {
-          content,
-          layout,
-          state,
-          publish_on: publishOn,
-          date,
-          tags: tags.join(','),
-          slug,
+          ...createEditRequestBody(postData),
           exclude_trail_items: excludeTrailItems
         }
       });

--- a/src/util/tumblr_helpers.js
+++ b/src/util/tumblr_helpers.js
@@ -45,3 +45,45 @@ export const apiFetch = async function (...args) {
     args
   );
 };
+
+const snakeToCamel = word => word.replace(/_(.)/g, (match, g1) => g1.toUpperCase());
+
+/**
+ * @see https://github.com/tumblr/docs/blob/master/api.md#postspost-id---editing-a-post-neue-post-format
+ * @see https://github.com/tumblr/docs/blob/master/api.md#posts---createreblog-a-post-neue-post-format
+ */
+const editRequestParams = [
+  'content',
+  'layout',
+  'state',
+  'publish_on',
+  'date',
+  'tags',
+  'source_url',
+  'send_to_twitter',
+  'slug',
+  'interactability_reblog',
+
+  // not currently documented
+  'can_be_tipped',
+  'has_community_label',
+  'community_label_categories'
+].map(snakeToCamel);
+
+/**
+ * Create an NPF edit request body.
+ *
+ * @param {object} postData - camelCased /posts/{post-id} GET request response JSON
+ * @returns {object} editRequestBody - camelCased /posts/{post-id} PUT request body parameters
+ */
+export const createEditRequestBody = postData => {
+  const { tags, sourceUrlRaw, ...rest } = postData;
+
+  const entries = Object.entries({
+    ...rest,
+    tags: tags.join(','),
+    sourceUrl: sourceUrlRaw
+  });
+
+  return Object.fromEntries(entries.filter(([key, value]) => editRequestParams.includes(key)));
+};

--- a/src/util/tumblr_helpers.js
+++ b/src/util/tumblr_helpers.js
@@ -46,44 +46,45 @@ export const apiFetch = async function (...args) {
   );
 };
 
-const snakeToCamel = word => word.replace(/_(.)/g, (match, g1) => g1.toUpperCase());
-
-/**
- * @see https://github.com/tumblr/docs/blob/master/api.md#postspost-id---editing-a-post-neue-post-format
- * @see https://github.com/tumblr/docs/blob/master/api.md#posts---createreblog-a-post-neue-post-format
- */
-const editRequestParams = [
-  'content',
-  'layout',
-  'state',
-  'publish_on',
-  'date',
-  'tags',
-  'source_url',
-  'send_to_twitter',
-  'slug',
-  'interactability_reblog',
-
-  // not currently documented
-  'can_be_tipped',
-  'has_community_label',
-  'community_label_categories'
-].map(snakeToCamel);
-
 /**
  * Create an NPF edit request body.
  *
+ * @see https://github.com/tumblr/docs/blob/master/api.md#postspost-id---editing-a-post-neue-post-format
+ * @see https://github.com/tumblr/docs/blob/master/api.md#posts---createreblog-a-post-neue-post-format
  * @param {object} postData - camelCased /posts/{post-id} GET request response JSON
  * @returns {object} editRequestBody - camelCased /posts/{post-id} PUT request body parameters
  */
 export const createEditRequestBody = postData => {
-  const { tags, sourceUrlRaw, ...rest } = postData;
+  const {
+    content,
+    layout,
+    state,
+    publishOn,
+    date,
+    tags,
+    sourceUrl,
+    sourceUrlRaw,
+    slug,
+    interactabilityReblog,
 
-  const entries = Object.entries({
-    ...rest,
+    canBeTipped,
+    hasCommunityLabel,
+    communityLabelCategories
+  } = postData;
+
+  return {
+    content,
+    layout,
+    state,
+    publishOn,
+    date,
     tags: tags.join(','),
-    sourceUrl: sourceUrlRaw
-  });
+    sourceUrl: sourceUrlRaw ?? sourceUrl,
+    slug,
+    interactabilityReblog,
 
-  return Object.fromEntries(entries.filter(([key, value]) => editRequestParams.includes(key)));
+    canBeTipped,
+    hasCommunityLabel,
+    communityLabelCategories
+  };
 };


### PR DESCRIPTION
This primarily serves to ensure that Quick Tags has no side effects. Makes sense to do anyway, though, I think.

Does this need default values to handle missing data?

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As proposed in #838, this creates a utility function that encapsulates the logic for, "I want to edit a post using the NPF API endpoints; what do I start with so that I don't change anything besides what I want to change?" It takes the JSON response from the `/posts/{post-id}` GET request, removes irrelevant fields, and applies a few transformations, which Quick Tags and Trim Reblogs both had implemented separately.

It ensures that there is one place to add future properties that should be passed through or future transformations that should be added.

The functional change here is passing through `can_be_tipped` (which is necessary) and `has_community_label`, and `community_label_categories` (which do not seem necessary).

For discussion: According to my testing, the list of passed-through properties could actually be shorter; for example, `source_url` is optional; should this err on the side of passing the maximum amount of data in case the Tumblr backend is ever changed, or the minimum amount to save network bytes?

Also, note that this relies on the snake_case conversion in apiFetch. Keeping everything as camelCase for as long as possible is the least confusing, IMO.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable tipping on your blog.
- Load XKit Rewritten without this PR.
- Set the tipping status on a test post to the opposite of your blog's "Add tip button to your posts by default" preference.
- Add a tag to the post with Quick Tags. Refresh the page. The tipping status should change to the default.
- Load XKit Rewritten with this PR.
- Repeat the above steps. Quick Tags should function and the tipping status should stay as you set it.

Also, test Trim Reblogs to ensure it functions normally; it should be no different than before.