### PR TITLE
New Tweak: Respect user's theme when in blog-view.

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -7,7 +7,7 @@
     "background_color": "#ecc84b"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#tweaks",
-  "relatedTerms": [ "Blacklist", "Separator" ],
+  "relatedTerms": ["Blacklist", "Separator"],
   "preferences": {
     "slim_filtered_screens": {
       "type": "checkbox",
@@ -88,6 +88,11 @@
     "no_where_were_we": {
       "type": "checkbox",
       "label": "Hide the \"Now, where were we?\" button",
+      "default": false
+    },
+    "respect_theme": {
+      "type": "checkbox",
+      "label": "Respect the user's theme on blog pages",
       "default": false
     }
   }

--- a/src/scripts/tweaks/respect_theme.js
+++ b/src/scripts/tweaks/respect_theme.js
@@ -1,0 +1,32 @@
+import { keyToCss } from '../../util/css_map.js';
+import { buildStyle } from '../../util/interface.js';
+
+const BLOG_POST_BODY_SELECTOR = keyToCss('scrollContainer', 'isModal');
+
+const styleElement = buildStyle(`
+ ${BLOG_POST_BODY_SELECTOR} {
+    --black: inherit !important;
+    --white: inherit !important;
+    --white-on-dark: inherit !important;
+    --navy: inherit !important;
+    --red: inherit !important;
+    --orange: inherit !important;
+    --yellow: inherit !important;
+    --green: inherit !important;
+    --blue: inherit !important;
+    --purple: inherit !important;
+    --pink: inherit !important;
+    --accent: inherit !important;
+    --secondary-accent: inherit !important;
+    --follow: inherit !important;
+    --override-posts--color-primary-link: inherit !important;
+  }
+`);
+
+export const main = async function () {
+  document.head.append(styleElement);
+};
+
+export const clean = async function () {
+  styleElement.remove();
+};


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
This tweak is great for users with dark color pallets that wish to not have blinding light when viewing other user's blogs with lighter themes. 

I got the idea from this Suggestion Box comment [here](https://github.com/AprilSylph/XKit-Rewritten/discussions/646#discussioncomment-3087855) on how they'd like to still see the theme while keeping posts readable.

This allows for more comfortable post viewing while still seeing the splash of flair from 

Note: this is only for the posts themselves. The surrounding theme of the blog is preserved. 

Additional note: this respects all the color pallets (True Blue, Goth Rave, Cybernetic, etc.)

### Inquiry

Since this doesn't truly affect the dashboard, simply the **blog-view**, is it appropriate to be included in Tweaks? Tweaks is defined to the users as "Miscellaneous **dashboard** options". 

Would it be more appropriate for this to be a stand-alone script?

Note: this is not the same behavior as Themed Posts, as this is the user's pallet and not the target blog's theme.

Note: this is not the same behavior as disabling "Use blog colors when viewing blogs" as mentioned [here](https://github.com/AprilSylph/XKit-Rewritten/discussions/646#discussioncomment-3055765). It preserves the surrounding theme. 

![firefox_BU0WVMVOcm](https://user-images.githubusercontent.com/118627996/204651858-48f72479-1673-48a0-b566-cdb714792001.png)

### Technical Explanation
All this does is prevent the CSS variables of the blog from overriding the user's color pallet on posts by setting the color variables to `inherit !important;` and appends the style to the document head. 

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Just enable "Respect the user's theme on blog pages" under Tweaks! 

It should only change the theme of **posts** in blog-view. 
