### PR TITLE
Mutual Checker: Tooltip on mutuals icon

### DIFF
--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -83,6 +83,7 @@ export const main = async function () {
     viewBox: '0 0 1000 1000',
     fill: aprilFools ? '#00b8ff' : 'rgb(var(--black))'
   }, null, [
+    dom('title', { xmlns: 'http://www.w3.org/2000/svg' }, null, ['Following each other']),
     dom('path', { xmlns: 'http://www.w3.org/2000/svg', d: aprilFools ? aprilFoolsPath : regularPath })
   ]);
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds an on-hover tooltip to the mutual checker icon. (The text is based on that of Tumblr's built-in one.)

Not sure why the duplicated xmlns attribute is needed?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Hover the mouse over the mutual checker icon. A tooltip should appear.
