### PR TITLE
fast startup experiments

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -90,6 +90,11 @@
 
     browser.storage.onChanged.addListener(onStorageChanged);
 
+    // load scripts sequentially to avoid chromium load failures
+    // for (const name of installedScripts.filter(name => enabledScripts.includes(name))) {
+    //   await import(getURL(`/scripts/${name}.js`));
+    // }
+
     installedScripts
       .filter(scriptName => enabledScripts.includes(scriptName))
       .forEach(runScript);

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -104,13 +104,13 @@
       browser.storage.local.get('enabledScripts')
     ]);
 
-    const scriptPreloadLinks = installedScripts
-      .filter(name => enabledScripts.includes(name))
-      .map(name => createPreloadLinkElement(name, 'scripts'));
+    const installedEnabledScripts = installedScripts
+      .filter(name => enabledScripts.includes(name));
 
-    const utilPreloadLinks = installedUtils.map(name => createPreloadLinkElement(name, 'util'));
-
-    document.head.append(...scriptPreloadLinks, ...utilPreloadLinks);
+    document.head.append(
+      ...installedEnabledScripts.map(name => createPreloadLinkElement(name, 'scripts')),
+      ...installedUtils.map(name => createPreloadLinkElement(name, 'util'))
+    );
 
     await waitForDocumentReady();
     if (!isRedpop()) return;
@@ -121,14 +121,7 @@
 
     browser.storage.onChanged.addListener(onStorageChanged);
 
-    // load scripts sequentially to avoid chromium load failures
-    // for (const name of installedScripts.filter(name => enabledScripts.includes(name))) {
-    //   await import(getURL(`/scripts/${name}.js`));
-    // }
-
-    installedScripts
-      .filter(scriptName => enabledScripts.includes(scriptName))
-      .forEach(runScript);
+    installedEnabledScripts.forEach(runScript);
   };
 
   const waitForReactLoaded = () => new Promise(resolve => {

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -90,6 +90,11 @@
 
     browser.storage.onChanged.addListener(onStorageChanged);
 
+    // preload user and css map fetches
+    ['dom', 'inject', 'tumblr_helpers', 'css_map', 'user'].forEach(utilname =>
+      import(getURL(`/util/${utilname}.js`))
+    );
+
     // load scripts sequentially to avoid chromium load failures
     // for (const name of installedScripts.filter(name => enabledScripts.includes(name))) {
     //   await import(getURL(`/scripts/${name}.js`));

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -85,9 +85,9 @@
     return installedUtils;
   };
 
-  const createPreloadLinkElement = (name, directory) =>
+  const createPreloadLinkElement = path =>
     Object.assign(document.createElement('link'), {
-      href: getURL(`/${directory}/${name}.js`),
+      href: getURL(path),
       rel: 'preload',
       as: 'script',
       crossOrigin: 'anonymous'
@@ -108,8 +108,8 @@
       .filter(name => enabledScripts.includes(name));
 
     document.head.append(
-      ...installedEnabledScripts.map(name => createPreloadLinkElement(name, 'scripts')),
-      ...installedUtils.map(name => createPreloadLinkElement(name, 'util'))
+      ...installedEnabledScripts.map(name => createPreloadLinkElement(`/scripts/${name}.js`)),
+      ...installedUtils.map(name => createPreloadLinkElement(`/util/${name}.js`))
     );
 
     await waitForDocumentReady();

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -115,7 +115,7 @@
     await waitForDocumentReady();
     if (!isRedpop()) return;
 
-    if (!isReactLoaded()) await waitForReactLoaded();
+    await waitForReactLoaded();
 
     $('style.xkit').remove();
 
@@ -124,9 +124,11 @@
     installedEnabledScripts.forEach(runScript);
   };
 
-  const waitForReactLoaded = () => new Promise(resolve => {
-    window.requestAnimationFrame(() => isReactLoaded() ? resolve() : waitForReactLoaded().then(resolve));
-  });
+  const waitForReactLoaded = async () => {
+    while (!isReactLoaded()) {
+      await new Promise(window.requestAnimationFrame);
+    }
+  };
 
   const waitForDocumentReady = () =>
     document.readyState === 'loading' &&

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -48,7 +48,7 @@
         "*://www.tumblr.com/register?*",
         "*://www.tumblr.com/privacy/*"
       ],
-      "run_at": "document_end",
+      "run_at": "document_start",
       "js": [
         "lib/browser-polyfill.min.js",
         "lib/jquery.min.js",

--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -15,8 +15,7 @@ const includeFiltered = true;
 const tagLinkSelector = `${keyToCss('searchResult')} h3 ~ a${keyToCss('typeaheadRow')}[href^="/tagged/"]`;
 const tagTextSelector = keyToCss('tagText');
 
-const trackedTagsData = await apiFetch('/v2/user/tags') ?? {};
-const trackedTags = trackedTagsData.response?.tags?.map(({ name }) => name) ?? [];
+let trackedTags;
 const unreadCounts = new Map();
 
 let sidebarItem;
@@ -131,6 +130,9 @@ const processTagLinks = function (tagLinkElements) {
 };
 
 export const main = async function () {
+  const trackedTagsData = await apiFetch('/v2/user/tags') ?? {};
+  trackedTags = trackedTagsData.response?.tags?.map(({ name }) => name) ?? [];
+
   onNewPosts.addListener(processPosts);
   refreshAllCounts(true).then(startRefreshInterval);
 

--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -15,7 +15,8 @@ const includeFiltered = true;
 const tagLinkSelector = `${keyToCss('searchResult')} h3 ~ a${keyToCss('typeaheadRow')}[href^="/tagged/"]`;
 const tagTextSelector = keyToCss('tagText');
 
-let trackedTags;
+const trackedTagsData = await apiFetch('/v2/user/tags') ?? {};
+const trackedTags = trackedTagsData.response?.tags?.map(({ name }) => name) ?? [];
 const unreadCounts = new Map();
 
 let sidebarItem;
@@ -130,9 +131,6 @@ const processTagLinks = function (tagLinkElements) {
 };
 
 export const main = async function () {
-  const trackedTagsData = await apiFetch('/v2/user/tags') ?? {};
-  trackedTags = trackedTagsData.response?.tags?.map(({ name }) => name) ?? [];
-
   onNewPosts.addListener(processPosts);
   refreshAllCounts(true).then(startRefreshInterval);
 

--- a/src/util/_index.json
+++ b/src/util/_index.json
@@ -1,0 +1,21 @@
+[
+  "control_buttons",
+  "crypto",
+  "css_map",
+  "dom",
+  "inject",
+  "interface",
+  "language_data",
+  "meatballs",
+  "mega_editor",
+  "modals",
+  "mutations",
+  "notifications",
+  "post_actions",
+  "preferences",
+  "react_props",
+  "remixicon",
+  "sidebar",
+  "tumblr_helpers",
+  "user"
+]

--- a/src/util/remixicon.js
+++ b/src/util/remixicon.js
@@ -2,16 +2,20 @@ import { dom } from './dom.js';
 
 const symbolsUrl = browser.runtime.getURL('/lib/remixicon/remixicon.symbol.svg');
 
-if (document.querySelector(`svg[data-src="${symbolsUrl}"]`) === null) {
-  fetch(symbolsUrl)
-    .then(response => response.text())
-    .then(responseText => {
-      const responseDocument = (new DOMParser()).parseFromString(responseText, 'image/svg+xml');
-      const symbols = responseDocument.firstElementChild;
-      symbols.dataset.src = symbolsUrl;
-      document.head.appendChild(symbols);
-    });
-}
+const requestIdleCallback = window.requestIdleCallback ?? window.requestAnimationFrame;
+
+requestIdleCallback(() => {
+  if (document.querySelector(`svg[data-src="${symbolsUrl}"]`) === null) {
+    fetch(symbolsUrl)
+      .then(response => response.text())
+      .then(responseText => {
+        const responseDocument = (new DOMParser()).parseFromString(responseText, 'image/svg+xml');
+        const symbols = responseDocument.firstElementChild;
+        symbols.dataset.src = symbolsUrl;
+        document.head.appendChild(symbols);
+      });
+  }
+});
 
 export const buildSvg = symbolId => dom('svg', { xmlns: 'http://www.w3.org/2000/svg' }, null, [
   dom('use', { xmlns: 'http://www.w3.org/2000/svg', href: `#${symbolId}` })


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Committing some attempts to get XKit Rewritten to load more quickly on startup (partially to mitigate the impacts of a potential fix for #636). I don't think these made a perceptible difference, so so far I think this is a failure(?), but I haven't, like, screen recorded or anything yet.

Fundamentally, I don't think you can force a big import waterfall with a bunch of top level awaits to run much earlier. I do manage to run the main waterfall of script imports right after hydration finishes by fetching the list of scripts to run beforehand, but I can't get the API fetches for the user and css map utilities to run that early, so they're still limiting factors.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

