### PR TITLE
Mutual Checker: Fix misaligned reblog icons in mobile view

### DIFF
--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -59,9 +59,7 @@ const addIcons = function (postElements) {
     const isMutual = await mutuals[blogName];
     if (isMutual) {
       postElement.classList.add(mutualsClass);
-      getComputedStyle(postAttribution).getPropertyValue('display') === 'flex'
-        ? postAttribution.prepend(icon.cloneNode(true))
-        : postAttribution.before(icon.cloneNode(true));
+      postAttribution.prepend(icon.cloneNode(true));
     } else if (showOnlyMutuals) {
       postElement.classList.add(hiddenClass);
     }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes mutual checker icons looking weird in the mobile/tablet view by simply reverting the previous fix, which no longer appears necessary.

Resolves #919


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Load posts by a mutual with a narrow viewport. Mutual icons should not appear as they do in the screenshot in the linked issue.
Repeat when loading posts with infinite scrolling, when loading the page with a wide viewport and resizing to narrow, in the blog view modal, in the blog view non-modal, etc.
