### PR TITLE
Quick Reblog: Add dialog height option for Quick Tags Integration.

### DIFF
--- a/src/scripts/quick_reblog.css
+++ b/src/scripts/quick_reblog.css
@@ -126,7 +126,7 @@ div:first-child + span + #quick-reblog,
   display: flex;
   flex-direction: column;
   align-items: stretch;
-  max-height: calc(var(--button-height) * 4);
+  max-height: calc(var(--button-height) * var(--quick-tags-size));
   overflow-y: auto;
 }
 

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -48,6 +48,7 @@ let showBlogSelector;
 let rememberLastBlog;
 let showCommentInput;
 let quickTagsIntegration;
+let quickTagsIntegrationSize;
 let showTagsInput;
 let showTagSuggestions;
 let reblogTag;
@@ -274,6 +275,21 @@ const renderQuickTags = async function () {
   });
 };
 
+const parseQuickTagsSize = (size) => {
+  if (!Number.isInteger(size)) {
+    return 4;
+  }
+
+  return Math.min(20, Math.max(1, size));
+};
+
+const setQuickTagsSize = (size) => {
+  quickTagsList.style.setProperty(
+    '--quick-tags-size',
+    parseQuickTagsSize(size)
+  );
+};
+
 const updateQuickTags = (changes, areaName) => {
   if (areaName === 'local' && Object.keys(changes).includes(quickTagsStorageKey)) {
     renderQuickTags();
@@ -298,6 +314,7 @@ export const main = async function () {
     rememberLastBlog,
     showCommentInput,
     quickTagsIntegration,
+    quickTagsIntegrationSize,
     showTagsInput,
     showTagSuggestions,
     reblogTag,
@@ -340,6 +357,7 @@ export const main = async function () {
   $(document.body).on('mouseenter', reblogButtonSelector, showPopupOnHover);
 
   if (quickTagsIntegration) {
+    setQuickTagsSize(Number.parseInt(quickTagsIntegrationSize));
     browser.storage.onChanged.addListener(updateQuickTags);
     renderQuickTags();
   }

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -37,6 +37,11 @@
       "label": "Enable integration with Quick Tags",
       "default": true
     },
+    "quickTagsIntegrationSize": {
+      "type": "text",
+      "label": "Quick Tags size (1-20)",
+      "default": 4
+    },
     "showTagsInput": {
       "type": "checkbox",
       "label": "Show the tags field",

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -34,8 +34,12 @@
     },
     "quickTagsIntegration": {
       "type": "checkbox",
-      "label": "Enable integration with Quick Tags",
-      "default": true
+      "label": "Enable integration with Quick Tags"
+    },
+    "quickTagsIntegrationSize": {
+      "type": "text",
+      "label": "Quick Tags size (1-20)",
+      "default": 4
     },
     "showTagsInput": {
       "type": "checkbox",

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -34,12 +34,8 @@
     },
     "quickTagsIntegration": {
       "type": "checkbox",
-      "label": "Enable integration with Quick Tags"
-    },
-    "quickTagsIntegrationSize": {
-      "type": "text",
-      "label": "Quick Tags size (1-20)",
-      "default": 4
+      "label": "Enable integration with Quick Tags",
+      "default": true
     },
     "showTagsInput": {
       "type": "checkbox",


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
This adds an option in Quick Reblog's preferences to increase or decrease the height of the Quick Tags Integration dialog. 

This addresses the issue raised in #867.

It parses the the preference from Quick Reblog and sets it as a CSS variable in `quickTagsList` component. This makes it available on every subsequent render of the Quick Reblog popup dialog without having to check every single time. 

The variable changes the height of the dialog from 1 to 20 units, each unit being the height of the button which is the same height as each tag element.

Default (4):
![default size](https://user-images.githubusercontent.com/118627996/210111080-e2c4ec46-e42d-4815-848e-bef6aace09cb.png)

Size 10:
![size 10](https://user-images.githubusercontent.com/118627996/210111110-0c38b402-9f14-41d4-b224-4f58756ebf32.png)

Size 1:
![size 1](https://user-images.githubusercontent.com/118627996/210111124-668d5ea3-cc78-4b06-a58d-79c882576d64.png)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
 
To test, go to the Quick Reblog preferences and set a height different than the default of 4. The change should be reflected immediately.
