### PR TITLE
Fix Chrome script loading inconsistency

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -85,6 +85,10 @@
     const installedScripts = await getInstalledScripts();
     const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
 
+    for (const scriptName of installedScripts.filter(scriptName => enabledScripts.includes(scriptName))) {
+      await import(getURL(`/scripts/${scriptName}.js`));
+    }
+
     installedScripts
       .filter(scriptName => enabledScripts.includes(scriptName))
       .forEach(runScript);

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -85,6 +85,7 @@
     const installedScripts = await getInstalledScripts();
     const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
 
+    // break up import waterfall to prevent chromium failures on slow computers
     for (const scriptName of installedScripts.filter(scriptName => enabledScripts.includes(scriptName))) {
       await import(getURL(`/scripts/${scriptName}.js`));
     }

--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -15,8 +15,7 @@ const includeFiltered = true;
 const tagLinkSelector = `${keyToCss('searchResult')} h3 ~ a${keyToCss('typeaheadRow')}[href^="/tagged/"]`;
 const tagTextSelector = keyToCss('tagText');
 
-const trackedTagsData = await apiFetch('/v2/user/tags') ?? {};
-const trackedTags = trackedTagsData.response?.tags?.map(({ name }) => name) ?? [];
+let trackedTags;
 const unreadCounts = new Map();
 
 let sidebarItem;
@@ -131,6 +130,9 @@ const processTagLinks = function (tagLinkElements) {
 };
 
 export const main = async function () {
+  const trackedTagsData = await apiFetch('/v2/user/tags') ?? {};
+  trackedTags = trackedTagsData.response?.tags?.map(({ name }) => name) ?? [];
+
   onNewPosts.addListener(processPosts);
   refreshAllCounts(true).then(startRefreshInterval);
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

At the expense of initial extension load speed, this ensures that XKit will not silently fail to load some scripts on slow computers in certain scenarios in chromium-based browsers; see the linked issue for details.

It does so by importing script files one at a time on their initial import instead of all at once, which seems to prevent some problem with large import waterfalls. (Subsequent imports do not trigger this.)

Functionality-wise, this PR is a strictly worse version of #897, which fixes the issue without a load speed drawback using link preloading. That code is, however, significantly more complicated to understand, both in a PR review sense and a "having the code make sense when a future contributor reads it" sense.

Resolves #636.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

I don't expect anyone to be able to consistently replicate the problem this solves, as I didn't find a great method, so testing is probably confined to ensuring that XKit continues to function correctly.

To test the actual fix, merge #756 into master on a slow PC, enable ~all of the scripts, and try to observe a failure. Then, merge #756 into this PR with the same scenario and observe that there are no failures.

