### PR TITLE
Trim Reblogs: Mention legacy edits + legacy XKit in legacy post warning

### DIFF
--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -38,7 +38,7 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
       showModal({
         title: 'Note: Legacy post',
         message: [
-          'The root post of this thread was originally created with, or a post in it was edited with, the ',
+          'This thread was originally created, or at some point edited, using the ',
           dom('strong', null, null, 'legacy post editor'),
           ' or a previous XKit version.',
           '\n\n',

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -38,7 +38,10 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
       showModal({
         title: 'Note: Legacy post',
         message: [
-          'The root post of this thread was originally created with the legacy post editor.',
+          'The root post of this thread was originally created with the ',
+          dom('strong', null, null, 'legacy post editor'),
+          ' ',
+          dom('small', null, null, '(or it was edited with a previous XKit version.)'),
           '\n\n',
           'On these threads, Trim Reblogs may work normally, have no effect, or require a repeat of the trim action to completely remove the desired trail items.'
         ],

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -38,7 +38,7 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
       showModal({
         title: 'Note: Legacy post',
         message: [
-          'This thread was originally created, or at some point edited, using the ',
+          'This thread was originally created, or at some point was edited, using the ',
           dom('strong', null, null, 'legacy post editor'),
           ' or a previous XKit version.',
           '\n\n',

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -38,10 +38,9 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
       showModal({
         title: 'Note: Legacy post',
         message: [
-          'The root post of this thread was originally created with the ',
+          'The root post of this thread was originally created with, or a post in it was edited with, the ',
           dom('strong', null, null, 'legacy post editor'),
-          ' ',
-          dom('small', null, null, '(or it was edited with a previous XKit version.)'),
+          ' or a previous XKit version.',
           '\n\n',
           'On these threads, Trim Reblogs may work normally, have no effect, or require a repeat of the trim action to completely remove the desired trail items.'
         ],


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This mentions an edit with the _legacy post editor or the_ previous XKit version as a blanket possible reason for a post appearing as legacy in the Trim Reblogs warning popup.

Resolves #957.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Draft a reblog of  https://www.tumblr.com/transienttest/708567905092157440/beta-reblog-2. Try trimming it. Verify that the UI copy makes sense and looks good.

