### PR TITLE
Tweaks: Fix "where were we" tweak consistency

### DIFF
--- a/src/scripts/tweaks/no_where_were_we.js
+++ b/src/scripts/tweaks/no_where_were_we.js
@@ -1,7 +1,7 @@
 import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
-const styleElement = buildStyle(`${keyToCss('wrapper')} ${keyToCss('newPostIndicator')} { display: none; }`);
+const styleElement = buildStyle(`${keyToCss('wrapper')} ${keyToCss('newPostIndicator')} { display: none !important; }`);
 
 export const main = async () => document.head.append(styleElement);
 export const clean = async () => styleElement.remove();


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Uses !important to ensure race conditions do not break the "where were we" hiding tweak when soft navigating to the dashboard.

Resolves #961.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

