### PR TITLE
Ensure style elements override Tumblr styles

### DIFF
--- a/src/scripts/accesskit/disable_animations.js
+++ b/src/scripts/accesskit/disable_animations.js
@@ -22,5 +22,5 @@ canvas#fire-everywhere {
 }
 `);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/accesskit/no_user_fonts.js
+++ b/src/scripts/accesskit/no_user_fonts.js
@@ -4,5 +4,5 @@ import { buildStyle } from '../../util/interface.js';
 const selector = `${keyToCss('textBlock')} ${keyToCss('quote', 'chat', 'quirky')}`;
 const styleElement = buildStyle(`${selector} { font-family: var(--font-family); }`);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -62,7 +62,7 @@ const onStorageChanged = async function (changes, areaName) {
 export const main = async function () {
   ({ visible_alt_text_mode: mode } = await getPreferences('accesskit'));
 
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
   pageModifications.register(`article ${imageBlockSelector} img[alt]`, processImages);
   browser.storage.onChanged.addListener(onStorageChanged);
 };

--- a/src/scripts/anti_capitalism.js
+++ b/src/scripts/anti_capitalism.js
@@ -19,7 +19,7 @@ const processVideoCTAs = videoCTAs => videoCTAs
   .forEach(({ classList }) => classList.add(hiddenClass));
 
 export const main = async () => {
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
   pageModifications.register(`${listTimelineObjectInnerSelector}:first-child ${keyToCss('videoCTA', 'videoImageCTA')}`, processVideoCTAs);
 };
 

--- a/src/scripts/cleanfeed.js
+++ b/src/scripts/cleanfeed.js
@@ -41,7 +41,7 @@ export const main = async function () {
   styleElement.textContent = localFlaggedBlogs
     .map(username => `[title="${username}"] img[alt="${translate('Avatar')}"] { filter: blur(20px); }`)
     .join('');
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
   onNewPosts.addListener(processPosts);
 };
 

--- a/src/scripts/hide_avatars.js
+++ b/src/scripts/hide_avatars.js
@@ -12,7 +12,7 @@ export const main = async function () {
     .map(username => `[title="${username.trim()}"] img[alt="${translate('Avatar')}"] { display: none; }`)
     .join('\n');
 
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 };
 
 export const clean = async function () {

--- a/src/scripts/no_recommended/hide_answertime.js
+++ b/src/scripts/no_recommended/hide_answertime.js
@@ -3,5 +3,5 @@ import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`${keyToCss('answerTimeBanner')} { display: none; }`);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -21,7 +21,7 @@ const hideBlogCarousels = blogCarousels => blogCarousels
   });
 
 export const main = async function () {
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
   pageModifications.register(blogCarouselSelector, hideBlogCarousels);
 };
 

--- a/src/scripts/no_recommended/hide_lightbox_related.js
+++ b/src/scripts/no_recommended/hide_lightbox_related.js
@@ -11,5 +11,5 @@ ${mainSectionSelector} { height: unset; margin: auto; }
 ${relatedPostsSectionSelector} { display: none; }
 `);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/no_recommended/hide_radar.js
+++ b/src/scripts/no_recommended/hide_radar.js
@@ -14,7 +14,7 @@ const checkForRadar = function (sidebarTitles) {
 
 export const main = async function () {
   pageModifications.register('aside > div > h1', checkForRadar);
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 };
 
 export const clean = async function () {

--- a/src/scripts/no_recommended/hide_recommended_blogs.js
+++ b/src/scripts/no_recommended/hide_recommended_blogs.js
@@ -21,7 +21,7 @@ export const main = async function () {
   const topBlogsSelector = `${keyToCss('desktopContainer')} > ${keyToCss('recommendedBlogs')}`;
   pageModifications.register(topBlogsSelector, hideTagPageRecommended);
 
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 };
 
 export const clean = async function () {

--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -27,7 +27,7 @@ const processPosts = async function (postElements) {
 
 export const main = async function () {
   onNewPosts.addListener(processPosts);
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 };
 
 export const clean = async function () {

--- a/src/scripts/no_recommended/hide_tag_carousels.js
+++ b/src/scripts/no_recommended/hide_tag_carousels.js
@@ -23,7 +23,7 @@ const hideTagCarousels = carouselWrappers => carouselWrappers
   });
 
 export const main = async function () {
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
   pageModifications.register(carouselWrapperSelector, hideTagCarousels);
 };
 

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -104,7 +104,7 @@ export const onStorageChanged = (changes, areaName) => {
 export const main = async function () {
   ({ [storageKey]: blockedPostTargetIDs = [] } = await browser.storage.local.get(storageKey));
   styleElement.textContent = buildCss();
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 
   pageModifications.register(notificationSelector, processNotifications);
 

--- a/src/scripts/panorama.js
+++ b/src/scripts/panorama.js
@@ -35,5 +35,5 @@ ${queueSettings} {
 `);
 styleElement.media = '(min-width: 990px)';
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -85,7 +85,7 @@ const addButtonToPage = async function ([scrollToTopButton]) {
 
 export const main = async function () {
   pageModifications.register(`button[aria-label="${translate('Scroll to top')}"]`, addButtonToPage);
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 };
 
 export const clean = async function () {

--- a/src/scripts/shorten_posts.js
+++ b/src/scripts/shorten_posts.js
@@ -59,7 +59,7 @@ export const main = async function () {
   ({ showTags, maxHeight } = await getPreferences('shorten_posts'));
 
   styleElement.textContent = `body { --xkit-shorten-posts-max-height: ${maxHeight}; }`;
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 
   onNewPosts.addListener(shortenPosts);
 };

--- a/src/scripts/themed_posts.js
+++ b/src/scripts/themed_posts.js
@@ -89,7 +89,7 @@ export const main = async function () {
     `;
   }
 
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
   onNewPosts.addListener(processPosts);
 };
 

--- a/src/scripts/tweaks/caught_up_line.js
+++ b/src/scripts/tweaks/caught_up_line.js
@@ -27,7 +27,7 @@ const createCaughtUpLine = tagChicletCarouselItems => tagChicletCarouselItems
   });
 
 export const main = async function () {
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
   pageModifications.register(tagChicletCarouselItemSelector, createCaughtUpLine);
 };
 

--- a/src/scripts/tweaks/hide_activity_notification_badge.js
+++ b/src/scripts/tweaks/hide_activity_notification_badge.js
@@ -8,5 +8,5 @@ button[aria-label="${translate('Activity')}"] ${keyToCss('notificationBadge')} {
 }
 `);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/hide_filtered_posts.js
+++ b/src/scripts/tweaks/hide_filtered_posts.js
@@ -12,7 +12,7 @@ const hideFilteredPosts = filteredScreens => filteredScreens
 export const main = async function () {
   const filteredScreenSelector = `article ${keyToCss('filteredScreen')}`;
   pageModifications.register(filteredScreenSelector, hideFilteredPosts);
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 };
 
 export const clean = async function () {

--- a/src/scripts/tweaks/hide_follower_counts.js
+++ b/src/scripts/tweaks/hide_follower_counts.js
@@ -4,5 +4,5 @@ import { buildStyle } from '../../util/interface.js';
 const countSelector = keyToClasses('count').map(className => `a[href$="/followers"] .${className}`).join(',');
 const styleElement = buildStyle(`${countSelector} { visibility: hidden; } a[href$="/activity/total"] { display: none; }`);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/hide_footer_tooltips.js
+++ b/src/scripts/tweaks/hide_footer_tooltips.js
@@ -8,5 +8,5 @@ article footer ${keyToCss('controlIcon')} ${keyToCss('tooltip')} ~ * {
 }
 `);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/hide_liked_posts.js
+++ b/src/scripts/tweaks/hide_liked_posts.js
@@ -18,7 +18,7 @@ const processPosts = async function (postElements) {
 
 export const main = async function () {
   onNewPosts.addListener(processPosts);
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 };
 
 export const clean = async function () {

--- a/src/scripts/tweaks/hide_mini_follow.js
+++ b/src/scripts/tweaks/hide_mini_follow.js
@@ -3,5 +3,5 @@ import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`article ${keyToCss('followButton')} { display: none; }`);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/hide_my_posts.js
+++ b/src/scripts/tweaks/hide_my_posts.js
@@ -20,7 +20,7 @@ const processPosts = async function (postElements) {
 
 export const main = async function () {
   onNewPosts.addListener(processPosts);
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 };
 
 export const clean = async function () {

--- a/src/scripts/tweaks/highlight_contributed_content.js
+++ b/src/scripts/tweaks/highlight_contributed_content.js
@@ -2,5 +2,5 @@ import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle('[data-is-contributed-content="true"] { display: flow-root; background-color: rgb(var(--follow)); }');
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/no_focus_shadow.js
+++ b/src/scripts/tweaks/no_focus_shadow.js
@@ -4,5 +4,5 @@ import { buildStyle } from '../../util/interface.js';
 const selector = keyToClasses('listTimelineObject').map(className => `.${className}:focus > div`).join(',');
 const styleElement = buildStyle(`${selector} { box-shadow: none !important; }`);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/no_where_were_we.js
+++ b/src/scripts/tweaks/no_where_were_we.js
@@ -3,5 +3,5 @@ import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`${keyToCss('wrapper')} ${keyToCss('newPostIndicator')} { display: none; }`);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/show_all_tags.js
+++ b/src/scripts/tweaks/show_all_tags.js
@@ -11,7 +11,7 @@ ${keyToCss('seeAll')} {
 `);
 
 export const main = async function () {
-  document.head.append(styleElement);
+  document.documentElement.append(styleElement);
 };
 
 export const clean = async function () {

--- a/src/scripts/tweaks/slim_filtered_screens.js
+++ b/src/scripts/tweaks/slim_filtered_screens.js
@@ -31,5 +31,5 @@ ${filteredScreenSelector} ${keyToCss('viewPostLinkWrapper')} {
 }
 `);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/unsticky_post_avatars.js
+++ b/src/scripts/tweaks/unsticky_post_avatars.js
@@ -3,5 +3,5 @@ import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`${keyToCss('stickyContainer')} { height: auto !important; }`);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/unsticky_tab_bar.js
+++ b/src/scripts/tweaks/unsticky_tab_bar.js
@@ -2,8 +2,8 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
-  ${keyToCss('tabsHeader')} { position: static; }
-  ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} { top: 69px; }
+  ${keyToCss('tabsHeader')} { position: static !important; }
+  ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} { top: 69px !important; }
 `);
 
 export const main = async () => document.documentElement.append(styleElement);

--- a/src/scripts/tweaks/unsticky_tab_bar.js
+++ b/src/scripts/tweaks/unsticky_tab_bar.js
@@ -6,5 +6,5 @@ const styleElement = buildStyle(`
   ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} { top: 69px !important; }
 `);
 
-export const main = async () => document.head.append(styleElement);
+export const main = async () => document.documentElement.append(styleElement);
 export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/unsticky_tab_bar.js
+++ b/src/scripts/tweaks/unsticky_tab_bar.js
@@ -2,8 +2,8 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
-  ${keyToCss('tabsHeader')} { position: static !important; }
-  ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} { top: 69px !important; }
+  ${keyToCss('tabsHeader')} { position: static; }
+  ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} { top: 69px; }
 `);
 
 export const main = async () => document.documentElement.append(styleElement);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This changes the location where dynamic style elements are inserted to the end of the `document.documentElement` (`<html>` element) instead of inside `<head>`, such that `!important` declarations should not be required to reliably resolve race conditions between Tumblr's styles and ours.

Resolves #961. Obsoletes #962.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

