### PR TITLE
CleanFeed: Always process mature-labeled posts

### DIFF
--- a/src/scripts/cleanfeed.js
+++ b/src/scripts/cleanfeed.js
@@ -19,9 +19,9 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
     return;
   }
 
-  const { blog: { name, isAdult }, trail } = await timelineObject(postElement);
+  const { blog: { name, isAdult }, communityLabels, trail } = await timelineObject(postElement);
 
-  if (isAdult || localFlaggedBlogs.includes(name)) {
+  if (isAdult || communityLabels.hasCommunityLabel || localFlaggedBlogs.includes(name)) {
     postElement.classList.add(hiddenClass);
     return;
   }

--- a/src/scripts/cleanfeed.json
+++ b/src/scripts/cleanfeed.json
@@ -19,7 +19,7 @@
       "default": "smart"
     },
     "localFlagging": {
-      "label": "Treat these blogs as flagged (comma-separated)",
+      "label": "Treat these blogs as mature (comma-separated)",
       "type": "textarea",
       "default": ""
     }

--- a/src/scripts/cleanfeed.json
+++ b/src/scripts/cleanfeed.json
@@ -10,11 +10,11 @@
   "relatedTerms": [ "nsfw" ],
   "preferences": {
     "blockingMode": {
-      "label": "Hide media from",
+      "label": "Hide:",
       "type": "select",
       "options": [
-        { "value": "smart", "label": "flagged blogs only" },
-        { "value": "all", "label": "all blogs" }
+        { "value": "smart", "label": "flagged/mature media only" },
+        { "value": "all", "label": "all media" }
       ],
       "default": "smart"
     },

--- a/src/scripts/cleanfeed.json
+++ b/src/scripts/cleanfeed.json
@@ -7,7 +7,7 @@
     "background_color": "#ff567e"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#cleanfeed",
-  "relatedTerms": [ "nsfw" ],
+  "relatedTerms": [ "NSFW", "Mature", "Adult", "Sensitive", "Community Label" ],
   "preferences": {
     "blockingMode": {
       "label": "Hide:",

--- a/src/scripts/cleanfeed.json
+++ b/src/scripts/cleanfeed.json
@@ -10,11 +10,11 @@
   "relatedTerms": [ "NSFW", "Mature", "Adult", "Sensitive", "Community Label" ],
   "preferences": {
     "blockingMode": {
-      "label": "Hide:",
+      "label": "Hide media from:",
       "type": "select",
       "options": [
-        { "value": "smart", "label": "flagged/mature media only" },
-        { "value": "all", "label": "all media" }
+        { "value": "smart", "label": "mature posts & blogs" },
+        { "value": "all", "label": "all posts" }
       ],
       "default": "smart"
     },


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This includes mature-labeled posts along with posts by "flagged" blogs in CleanFeed. It doesn't add any additional options or process nudity/violence/alcohol flags separately, opting for the simplest solution.

Resolves #947.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

