### PR TITLE
Quick Reblog: Increase default remembered post storage

### DIFF
--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -67,7 +67,7 @@
       "label": "Remember the last ",
       "options": [
         { "value": "100", "label": "100 posts" },
-        { "value": "1000", "label": "1000 posts" },
+        { "value": "1000", "label": "1,000 posts" },
         { "value": "10000", "label": "10,000 posts" }
       ],
       "default": "10000"

--- a/src/scripts/quick_reblog.json
+++ b/src/scripts/quick_reblog.json
@@ -70,7 +70,7 @@
         { "value": "1000", "label": "1000 posts" },
         { "value": "10000", "label": "10,000 posts" }
       ],
-      "default": "100"
+      "default": "10000"
     }
   }
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

> the 100 default is probably just for the sake of browser.storage.sync, which we do not use anymore, so yes please set it higher


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

