### PR TITLE
New Script: Indicate legacy-stored threads

### DIFF
--- a/src/scripts/_index.json
+++ b/src/scripts/_index.json
@@ -5,6 +5,7 @@
   "cleanfeed",
   "collapsed_queue",
   "hide_avatars",
+  "legacy_post_indicators",
   "limit_checker",
   "mass_deleter",
   "mass_unliker",

--- a/src/scripts/legacy_post_indicators.js
+++ b/src/scripts/legacy_post_indicators.js
@@ -1,0 +1,63 @@
+import { keyToCss } from '../util/css_map.js';
+import { dom } from '../util/dom.js';
+import { buildStyle, filterPostElements } from '../util/interface.js';
+import { onNewPosts } from '../util/mutations.js';
+import { timelineObject } from '../util/react_props.js';
+import { buildSvg } from '../util/remixicon.js';
+
+const indicatorClass = 'xkit-legacy-post-indicator';
+const excludeClass = 'xkit-legacy-post-done';
+const includeFiltered = true;
+
+const symbolId = 'ri-archive-fill';
+
+const styleElement = buildStyle(`
+.xkit-legacy-post-indicator {
+  display: flex;
+  align-items: center;
+
+  cursor: help;
+}
+
+.xkit-legacy-post-indicator > svg {
+  width: 24px;
+  height: 24px;
+
+  fill: rgba(var(--black), 0.4);
+}
+`);
+
+let indicatorTemplate;
+
+const processPosts = postElements =>
+  filterPostElements(postElements, { excludeClass, includeFiltered }).forEach(
+    async postElement => {
+      const { isBlocksPostFormat } = await timelineObject(postElement);
+
+      if (isBlocksPostFormat === false) {
+        const rightContent = postElement.querySelector(`header ${keyToCss('rightContent')}`);
+        if (!rightContent || rightContent.querySelector(keyToCss('sponsoredContainer'))) {
+          return;
+        }
+
+        rightContent.before(indicatorTemplate.cloneNode(true));
+      }
+    }
+  );
+
+export const main = async function () {
+  document.head.append(styleElement);
+  indicatorTemplate = dom(
+    'div',
+    { class: indicatorClass, title: 'Stored in the legacy post format.' },
+    null,
+    [buildSvg(symbolId)]
+  );
+  onNewPosts.addListener(processPosts);
+};
+
+export const clean = async function () {
+  onNewPosts.removeListener(processPosts);
+  styleElement.remove();
+  $(`.${indicatorClass}`).remove();
+};

--- a/src/scripts/legacy_post_indicators.js
+++ b/src/scripts/legacy_post_indicators.js
@@ -6,7 +6,6 @@ import { timelineObject } from '../util/react_props.js';
 import { buildSvg } from '../util/remixicon.js';
 
 const indicatorClass = 'xkit-legacy-post-indicator';
-const excludeClass = 'xkit-legacy-post-done';
 const includeFiltered = true;
 
 const symbolId = 'ri-archive-fill';
@@ -35,7 +34,7 @@ const indicatorTemplate = dom(
 );
 
 const processPosts = postElements =>
-  filterPostElements(postElements, { excludeClass, includeFiltered }).forEach(
+  filterPostElements(postElements, { includeFiltered }).forEach(
     async postElement => {
       const { isBlocksPostFormat } = await timelineObject(postElement);
 

--- a/src/scripts/legacy_post_indicators.js
+++ b/src/scripts/legacy_post_indicators.js
@@ -12,14 +12,14 @@ const includeFiltered = true;
 const symbolId = 'ri-archive-fill';
 
 const styleElement = buildStyle(`
-.xkit-legacy-post-indicator {
+.${indicatorClass} {
   display: flex;
   align-items: center;
 
   cursor: help;
 }
 
-.xkit-legacy-post-indicator > svg {
+.${indicatorClass} > svg {
   width: 24px;
   height: 24px;
 
@@ -27,7 +27,12 @@ const styleElement = buildStyle(`
 }
 `);
 
-let indicatorTemplate;
+const indicatorTemplate = dom(
+  'div',
+  { class: indicatorClass, title: 'Stored in the legacy post format.' },
+  null,
+  [buildSvg(symbolId)]
+);
 
 const processPosts = postElements =>
   filterPostElements(postElements, { excludeClass, includeFiltered }).forEach(
@@ -46,13 +51,7 @@ const processPosts = postElements =>
   );
 
 export const main = async function () {
-  document.head.append(styleElement);
-  indicatorTemplate = dom(
-    'div',
-    { class: indicatorClass, title: 'Stored in the legacy post format.' },
-    null,
-    [buildSvg(symbolId)]
-  );
+  document.documentElement.append(styleElement);
   onNewPosts.addListener(processPosts);
 };
 

--- a/src/scripts/legacy_post_indicators.json
+++ b/src/scripts/legacy_post_indicators.json
@@ -6,6 +6,5 @@
     "color": "white",
     "background_color": "#000000"
   },
-  "preferences": {
-  }
+  "relatedTerms": [ "Editable", "Trim", "Beta", "New", "NPF" ]
 }

--- a/src/scripts/legacy_post_indicators.json
+++ b/src/scripts/legacy_post_indicators.json
@@ -1,0 +1,11 @@
+{
+  "title": "Legacy Post Indicators",
+  "description": "",
+  "icon": {
+    "class_name": "ri-archive-line",
+    "color": "white",
+    "background_color": "#000000"
+  },
+  "preferences": {
+  }
+}

--- a/src/scripts/legacy_post_indicators.json
+++ b/src/scripts/legacy_post_indicators.json
@@ -4,7 +4,7 @@
   "icon": {
     "class_name": "ri-archive-line",
     "color": "white",
-    "background_color": "#000000"
+    "background_color": "#853779"
   },
   "relatedTerms": [ "Editable", "Trim", "Beta", "New", "NPF" ]
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Implements a script that displays the `isBlocksPostFormat` status of a thread using an icon in the header, so that heavy editable/trim reblogs users can see what threads are still legacy at a glance/in advance.

<img width="781" src="https://user-images.githubusercontent.com/8336245/218334293-d0b6f873-a569-423b-9609-1ece604df358.png">

I also tried some other things; see #916.

Resolves #896 (well, is one way to do so).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

