### PR TITLE
Mega-Editor Utility: Pass errors correctly

### DIFF
--- a/src/util/mega_editor.js
+++ b/src/util/mega_editor.js
@@ -44,9 +44,15 @@ export const megaEdit = async function (postIds, options) {
     delete requestBody.tags;
   }
 
-  return inject(async (resource, body) => fetch(resource, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
-    body
-  }), [`https://www.tumblr.com/${pathname}`, $.param(requestBody)]);
+  return inject(
+    async (resource, body) =>
+      fetch(resource, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+        body
+      }).then(async response =>
+        response.ok ? response.json() : Promise.reject(await response.json())
+      ),
+    [`https://www.tumblr.com/${pathname}`, $.param(requestBody)]
+  );
 };


### PR DESCRIPTION
I don't think I'm doing this right.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This ensures that a non-201 response to the mega editor endpoint actually triggers catch handlers in scripts with some useful information. Without this change, `inject()` serializes the non-201 `Response` object to `{}` and resolves, so scripts think their edits succeeded when they actually did not.

I'm not at all familiar with how the inject error code works or how javascript errors work in general. But the inject code clearly expects a rejected promise containing an error, which `fetch` doesn't natively create, so, this is a manual way to do that? Is there a better way?

The other thing I considered was, can you coerce a `Response` to be serializable (e.g. via `Object.fromEntries(Object.entries(response))` and then always resolve through the inject with that? Then scripts could check `response.ok` and action based on that. They would lose the actual response body in that case, though, I guess.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
I can post proper test code later; just copypasting atm.
```js
    console.log('...');

    try {
      console.log('a', await megaEdit(postIds, { mode: 'remove', tags: ['sdkfjndsknsdkjfbsbkjsdfbkjsbf'] }));
    } catch (e) {
      console.log('error a', e);
    }

    try {
      console.log('b', await megaEdit([1], { mode: 'remove', tags: ['sdkfjndsknsdkjfbsbkjsdfbkjsbf'] }));
    } catch (e) {
      console.log('error b', e);
    }

    console.log('...');
```
