### PR TITLE
Scroll to bottom: Don't deactivate on "embedded blog view"

### DIFF
--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -1,7 +1,7 @@
 import { keyToClasses, keyToCss } from '../util/css_map.js';
 import { translate } from '../util/language_data.js';
 import { pageModifications } from '../util/mutations.js';
-import { blogViewSelector, buildStyle } from '../util/interface.js';
+import { buildStyle } from '../util/interface.js';
 
 const scrollToBottomButtonId = 'xkit-scroll-to-bottom-button';
 $(`[id="${scrollToBottomButtonId}"]`).remove();
@@ -17,11 +17,6 @@ let scrollToBottomButton;
 let active = false;
 
 const styleElement = buildStyle(`
-${keyToCss('isPeeprShowing')} #${scrollToBottomButtonId} {
-  opacity: 0;
-  pointer-events: none;
-}
-
 .${activeClass} svg use {
   --icon-color-primary: rgb(var(--yellow));
 }
@@ -29,8 +24,7 @@ ${keyToCss('isPeeprShowing')} #${scrollToBottomButtonId} {
 
 const scrollToBottom = () => {
   window.scrollTo({ top: document.documentElement.scrollHeight });
-  const loaders = [...document.querySelectorAll(knightRiderLoaderSelector)]
-    .filter(element => element.matches(blogViewSelector) === false);
+  const loaders = [...document.querySelectorAll(knightRiderLoaderSelector)];
 
   if (loaders.length === 0) {
     stopScrolling();


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As discussed in #975, this allows Scroll to Bottom to function on the non-modal form of the blog view that can be opened by directly navigating to e.g. https://www.tumblr.com/april. (It already did besides that we locked it out for consistency and out of a concern for being rate limited when doing so; this just removes the lockout.)

It doesn't add functionality to work in the modal blog view; that's more complicated.

Resolves #975, since the lockout can't malfunction if it's gone... except that now the reverse actually happens: the scroll to top and scroll to bottom buttons appear erroneously in the modal form of the blog view and will action on the background page. This is, of course, still a redpop bug.

Resolves #731.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Navigate to https://www.tumblr.com/april. Ensure scroll to bottom works as expected.
Navigate to https://www.tumblr.com/transienttest2. Ensure scroll to bottom works as expected, stopping when it runs out of posts.
