### PR TITLE
Tag Tracking+: Support control-click + right-click + use soft nav

### DIFF
--- a/src/content_scripts/sidebar.css
+++ b/src/content_scripts/sidebar.css
@@ -50,7 +50,7 @@
   background-color: rgba(var(--white-on-dark), 0.07);
 }
 
-.xkit-sidebar-item li button {
+.xkit-sidebar-item li a {
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -61,6 +61,7 @@
   cursor: pointer;
   font: inherit;
   text-align: left;
+  text-decoration: none;
 }
 
 .xkit-sidebar-item svg {
@@ -98,7 +99,7 @@ nav .xkit-sidebar-item li:hover {
   background-color: transparent;
 }
 
-nav .xkit-sidebar-item li button {
+nav .xkit-sidebar-item li a {
   box-sizing: border-box;
   min-height: 41px;
   padding-top: 13px;

--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -1,4 +1,4 @@
-import { apiFetch } from '../util/tumblr_helpers.js';
+import { apiFetch, onClickNavigate } from '../util/tumblr_helpers.js';
 import { filterPostElements } from '../util/interface.js';
 import { timelineObject } from '../util/react_props.js';
 import { keyToCss } from '../util/css_map.js';
@@ -144,7 +144,8 @@ export const main = async function () {
       title: 'Tag Tracking+',
       rows: trackedTags.map(tag => ({
         label: `#${tag}`,
-        onclick: () => location.assign(`/tagged/${tag}?sort=recent`),
+        href: `/tagged/${tag}?sort=recent`,
+        onclick: onClickNavigate,
         count: '\u22EF'
       }))
     });

--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -32,9 +32,9 @@ const carrotSvg = dom('svg', {
  * @param {sidebarRowOptions} options - Sidebar row options
  * @returns {HTMLLIElement} The constructed sidebar row
  */
-const buildSidebarRow = ({ label, onclick, count, carrot }) =>
+const buildSidebarRow = ({ label, onclick, href, count, carrot }) =>
   dom('li', null, null, [
-    dom('button', null, { click: onclick }, [
+    dom('a', { role: 'button', ...href ? { href } : {} }, { click: onclick }, [
       dom('span', null, null, [label]),
       count !== undefined
         ? dom('span', { class: 'count', 'data-count-for': label }, null, [count])


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Exactly as described in the linked issue, this changes the DOM element used for clickable sidebar buttons to `<a role="button">`, allowing users to right-click or control-click them to open the ones created by Tag Tracking+ in new tabs. It implements the soft navigation helper we previously created to make regular clicks on these buttons much faster.

Resolves #854, #933

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

