### PR TITLE
New tweak: Hide Tumblr Live carousel

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -84,6 +84,11 @@
       "type": "checkbox",
       "label": "Hide the \"Now, where were we?\" button",
       "default": false
+    },
+    "no_live": {
+      "type": "checkbox",
+      "label": "Hide the Tumblr Live carousel",
+      "default": false
     }
   }
 }

--- a/src/scripts/tweaks/no_live.js
+++ b/src/scripts/tweaks/no_live.js
@@ -1,0 +1,26 @@
+import { pageModifications } from '../../util/mutations.js';
+import { buildStyle } from '../../util/interface.js';
+import { keyToCss } from '../../util/css_map.js';
+
+const hiddenClass = 'xkit-tweaks-no-live-hidden';
+const styleElement = buildStyle(`.${hiddenClass} { display: none; }`);
+
+const processFrames = frames =>
+  frames.forEach(frame =>
+    frame.closest(keyToCss('listTimelineObjectInner')).classList.add(hiddenClass)
+  );
+
+export const main = async function () {
+  pageModifications.register(
+    'iframe[src^="https://api.gateway.tumblr-live.com/"]',
+    processFrames
+  );
+  document.documentElement.append(styleElement);
+};
+
+export const clean = async function () {
+  pageModifications.unregister(processFrames);
+  styleElement.remove();
+
+  $(`.${hiddenClass}`).removeClass(hiddenClass);
+};


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Yeah, alright.

Adds a tweak that hides the Tumblr Live carousel at the top of the dashboard.

(No, we will not hide the Tumblr Live button and make the feature entirely inaccessible.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
~~n/a; no maintainer has this element right now~~ decide where in the tweaks list this goes
