### PR TITLE
Exclude settings page from sidebar insertion

### DIFF
--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -89,6 +89,8 @@ const sidebarItemSelector = keyToCss('sidebarItem', 'sidebarContent');
 const navSubHeaderSelector = keyToCss('navSubHeader');
 
 const addSidebarToPage = (siblingCandidates) => {
+  if (/^\/settings/.test(location.pathname)) { return; }
+
   [...sidebarItems.children]
     .filter(sidebarItem => conditions.has(sidebarItem))
     .forEach(sidebarItem => { sidebarItem.hidden = !conditions.get(sidebarItem)(); });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This prevents sidebar items from being added to the settings page.

There is nothing fundamentally wrong with the idea of XKit adding stuff to settings, I guess, but it's a) seemingly not intended for any script so far, b) kind of weird, and c) at the very least, in the wrong place, taking up space above the blogs selector.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Enable Tag Tracking+/Tag Replacer. Navigate to the settings page and confirm that neither appears. Navigate elsewhere and confirm that they do.

