### PR TITLE
Mass Unliker: Only show sidebar button on likes page

### DIFF
--- a/src/scripts/mass_unliker.js
+++ b/src/scripts/mass_unliker.js
@@ -101,7 +101,8 @@ const sidebarOptions = {
       onclick: () => showModal(modalPromptOptions),
       carrot: true
     }
-  ]
+  ],
+  visibility: () => /\/likes/.test(location.pathname)
 };
 
 export const main = async function () {

--- a/src/scripts/mass_unliker.js
+++ b/src/scripts/mass_unliker.js
@@ -102,7 +102,7 @@ const sidebarOptions = {
       carrot: true
     }
   ],
-  visibility: () => /\/likes/.test(location.pathname)
+  visibility: () => /^\/likes/.test(location.pathname)
 };
 
 export const main = async function () {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This only shows the Mass Unliker sidebar button on the likes page. It's the kind of thing you use extremely infrequently, and I think it would make sense for a user to look for it here.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Navigate to https://www.tumblr.com/likes. Confirm that Mass Unliker appears.
- Navigate to https://www.tumblr.com/likes/. Confirm that Mass Unliker appears.
- Navigate elsewhere. Mass Unliker should not appear in the sidebar.
