### PR TITLE
Tweaks: Fix live carousel tweak

### DIFF
--- a/src/scripts/tweaks/no_live.js
+++ b/src/scripts/tweaks/no_live.js
@@ -7,12 +7,12 @@ const styleElement = buildStyle(`.${hiddenClass} { display: none; }`);
 
 const processFrames = frames =>
   frames.forEach(frame =>
-    frame.closest(keyToCss('listTimelineObjectInner')).classList.add(hiddenClass)
+    frame.closest(keyToCss('listTimelineObjectInner'))?.classList?.add(hiddenClass)
   );
 
 export const main = async function () {
   pageModifications.register(
-    'iframe[src^="https://api.gateway.tumblr-live.com/"]',
+    `[data-timeline="/v2/timeline/dashboard"] iframe[src^="https://api.gateway.tumblr-live.com/"]`,
     processFrames
   );
   document.documentElement.append(styleElement);

--- a/src/scripts/tweaks/no_live.js
+++ b/src/scripts/tweaks/no_live.js
@@ -12,7 +12,7 @@ const processFrames = frames =>
 
 export const main = async function () {
   pageModifications.register(
-    `[data-timeline="/v2/timeline/dashboard"] iframe[src^="https://api.gateway.tumblr-live.com/"]`,
+    '[data-timeline="/v2/timeline/dashboard"] iframe[src^="https://api.gateway.tumblr-live.com/"]',
     processFrames
   );
   document.documentElement.append(styleElement);


### PR DESCRIPTION
And this is why we don't just paste the first draft code and PR it. I have brought shame upon my household.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes a crash when one hard-loads tumblr.com/live that occurs since I didn't exclude other Live iframes from processing or handle their existence in the processing code.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
n/a, I am _very_ trustworthy this time

