### PR TITLE
remove unused awaits from notification util

### DIFF
--- a/src/util/notifications.js
+++ b/src/util/notifications.js
@@ -3,13 +3,10 @@ import { dom } from './dom.js';
 
 const toastContainer = dom('div', { id: 'xkit-toasts' });
 
-const drawerContentSelectorPromise = keyToCss('drawerContent');
-const sidebarSelectorPromise = keyToCss('sidebar');
+const drawerContentSelector = keyToCss('drawerContent');
+const sidebarSelector = keyToCss('sidebar');
 
-const addToastContainerToPage = async () => {
-  const drawerContentSelector = await drawerContentSelectorPromise;
-  const sidebarSelector = await sidebarSelectorPromise;
-
+const addToastContainerToPage = () => {
   const targetNode = [
     document.body.querySelector(`${drawerContentSelector} ${sidebarSelector}`),
     document.body.querySelector(drawerContentSelector),
@@ -29,7 +26,7 @@ const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
  * @param {string} textContent - Text to display to the user as a notification
  */
 export const notify = async textContent => {
-  await addToastContainerToPage();
+  addToastContainerToPage();
 
   const toast = dom('div', { class: 'visible' }, null, [textContent]);
   toastContainer.append(toast);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Minor refactor we forgot to do once keyToCss was synchronous: this removes some unused `await`s in notifications.js.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Confirm that notifications still work, e.g. by drafting a reblog with quick reblog.
