### PR TITLE
Seen Posts: Hide seen posts completely

### DIFF
--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -2,3 +2,7 @@ body:not(.xkit-seen-posts-only-dim-avatar) .xkit-seen-posts-seen:not(:hover),
 body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article > :first-child img {
   opacity: 0.5;
 }
+
+body.xkit-seen-posts-hide .xkit-seen-posts-seen {
+  display: none;
+}

--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -6,3 +6,7 @@ body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article >
 body.xkit-seen-posts-hide .xkit-seen-posts-seen article {
   display: none;
 }
+
+body.xkit-seen-posts-hide .xkit-seen-posts-lengthened {
+  min-height: 100vh;
+}

--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -3,6 +3,6 @@ body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article >
   opacity: 0.5;
 }
 
-body.xkit-seen-posts-hide .xkit-seen-posts-seen {
+body.xkit-seen-posts-hide .xkit-seen-posts-seen article {
   display: none;
 }

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -1,14 +1,16 @@
 import { filterPostElements, postSelector } from '../util/interface.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
+import { keyToCss } from '../util/css_map.js';
 
 const excludeClass = 'xkit-seen-posts-done';
-const timeline = /\/v2\/timeline\/dashboard/;
+const timeline = '/v2/timeline/dashboard';
 const includeFiltered = true;
 
 const dimClass = 'xkit-seen-posts-seen';
 const onlyDimAvatarsClass = 'xkit-seen-posts-only-dim-avatar';
 const hideClass = 'xkit-seen-posts-hide';
+const lengthenedClass = 'xkit-seen-posts-lengthened';
 
 const storageKey = 'seen_posts.seenPosts';
 let seenPosts = [];
@@ -40,7 +42,16 @@ const markAsSeen = (articleElement) => {
   browser.storage.local.set({ [storageKey]: seenPosts });
 };
 
+const lengthenTimelines = () =>
+  [...document.querySelectorAll(`[data-timeline="${timeline}"]`)].forEach(timelineElement => {
+    if (!timelineElement.querySelector(keyToCss('manualPaginatorButtons'))) {
+      timelineElement.classList.add(lengthenedClass);
+    }
+  });
+
 const dimPosts = function (postElements) {
+  lengthenTimelines();
+
   for (const postElement of filterPostElements(postElements, { excludeClass, timeline, includeFiltered })) {
     const { id } = postElement.dataset;
 
@@ -101,6 +112,7 @@ export const clean = async function () {
   $(`.${hideClass}`).removeClass(hideClass);
   $(`.${dimClass}`).removeClass(dimClass);
   $(`.${onlyDimAvatarsClass}`).removeClass(onlyDimAvatarsClass);
+  $(`.${lengthenedClass}`).removeClass(lengthenedClass);
 };
 
 export const stylesheet = true;

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -8,6 +8,7 @@ const includeFiltered = true;
 
 const dimClass = 'xkit-seen-posts-seen';
 const onlyDimAvatarsClass = 'xkit-seen-posts-only-dim-avatar';
+const hideClass = 'xkit-seen-posts-hide';
 
 const storageKey = 'seen_posts.seenPosts';
 let seenPosts = [];
@@ -53,9 +54,16 @@ const dimPosts = function (postElements) {
 
 export const onStorageChanged = async function (changes, areaName) {
   const {
+    'seen_posts.preferences.hideSeenPosts': hideSeenPostsChanges,
     'seen_posts.preferences.onlyDimAvatars': onlyDimAvatarsChanges,
     [storageKey]: seenPostsChanges
   } = changes;
+
+  if (hideSeenPostsChanges && hideSeenPostsChanges.oldValue !== undefined) {
+    const { newValue: hideSeenPosts } = hideSeenPostsChanges;
+    const addOrRemoveHide = hideSeenPosts ? 'add' : 'remove';
+    document.body.classList[addOrRemoveHide](hideClass);
+  }
 
   if (onlyDimAvatarsChanges && onlyDimAvatarsChanges.oldValue !== undefined) {
     const { newValue: onlyDimAvatars } = onlyDimAvatarsChanges;
@@ -71,7 +79,10 @@ export const onStorageChanged = async function (changes, areaName) {
 export const main = async function () {
   ({ [storageKey]: seenPosts = [] } = await browser.storage.local.get(storageKey));
 
-  const { onlyDimAvatars } = await getPreferences('seen_posts');
+  const { hideSeenPosts, onlyDimAvatars } = await getPreferences('seen_posts');
+  if (hideSeenPosts) {
+    document.body.classList.add(hideClass);
+  }
   if (onlyDimAvatars) {
     document.body.classList.add(onlyDimAvatarsClass);
   }
@@ -87,6 +98,7 @@ export const clean = async function () {
   timers.clear();
 
   $(`.${excludeClass}`).removeClass(excludeClass);
+  $(`.${hideClass}`).removeClass(hideClass);
   $(`.${dimClass}`).removeClass(dimClass);
   $(`.${onlyDimAvatarsClass}`).removeClass(onlyDimAvatarsClass);
 };

--- a/src/scripts/seen_posts.json
+++ b/src/scripts/seen_posts.json
@@ -9,14 +9,14 @@
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#seen-posts",
   "relatedTerms": [ "Read Posts" ],
   "preferences": {
-    "hideSeenPosts": {
-      "type": "checkbox",
-      "label": "Hide seen posts from dashboard",
-      "default": false
-    },
     "onlyDimAvatars": {
       "type": "checkbox",
       "label": "Only dim avatars on seen posts",
+      "default": false
+    },
+    "hideSeenPosts": {
+      "type": "checkbox",
+      "label": "Hide seen posts from the dashboard",
       "default": false
     }
   }

--- a/src/scripts/seen_posts.json
+++ b/src/scripts/seen_posts.json
@@ -9,6 +9,11 @@
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#seen-posts",
   "relatedTerms": [ "Read Posts" ],
   "preferences": {
+    "hideSeenPosts": {
+      "type": "checkbox",
+      "label": "Hide seen posts from dashboard",
+      "default": false
+    },
     "onlyDimAvatars": {
       "type": "checkbox",
       "label": "Only dim avatars on seen posts",


### PR DESCRIPTION
I'm stealing this branch (#870) from @char-lock to add a `lengthenTimelines` function!

(This includes a rebase off of master to take advantage of #891, allowing the `timeline` variable to be a string.)

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As per the linked issue, adds a preference to the Seen Posts script to allow users to hide seen posts on the dashboard using a CSS style.

Resolves #869.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

User should be able to browse as usual, but when their dashboard updates with new posts, any posts they have viewed will be hidden, leaving only new posts and old ones that have not been viewed.

