### PR TITLE
No Recommended: Stop hiding when all posts are recommended

### DIFF
--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -8,7 +8,23 @@ const unHiddenClass = 'xkit-no-recommended-posts-many';
 const timeline = /\/v2\/timeline\/dashboard/;
 const includeFiltered = true;
 
-const styleElement = buildStyle(`.${hiddenClass}:not(.${unHiddenClass}) article { display: none; }`);
+const styleElement = buildStyle(`
+.${hiddenClass}:not(.${unHiddenClass}) article {
+  display: none;
+}
+
+:not(.${unHiddenClass}) + .${unHiddenClass}::before {
+  content: 'Too many recommended posts to hide!';
+
+  display: block;
+  text-align: center;
+  padding: 25px 20px;
+  border-radius: 3px;
+  background-color: rgba(var(--white-on-dark), 0.13);
+  color: rgba(var(--white-on-dark), 0.6);
+  font-weight: 700;
+}
+`);
 
 const precedingHiddenPosts = ({ previousElementSibling: previousElement }, count = 0) => {
   if (!previousElement) return count;

--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -1,13 +1,22 @@
-import { buildStyle, filterPostElements } from '../../util/interface.js';
+import { buildStyle, filterPostElements, postSelector } from '../../util/interface.js';
 import { onNewPosts } from '../../util/mutations.js';
 import { timelineObject } from '../../util/react_props.js';
 
 const excludeClass = 'xkit-no-recommended-posts-done';
 const hiddenClass = 'xkit-no-recommended-posts-hidden';
+const unHiddenClass = 'xkit-no-recommended-posts-many';
 const timeline = /\/v2\/timeline\/dashboard/;
 const includeFiltered = true;
 
-const styleElement = buildStyle(`.${hiddenClass} article { display: none; }`);
+// const styleElement = buildStyle(`.${hiddenClass}:not(.${unHiddenClass}) article { display: none; }`);
+const styleElement = buildStyle(`.${hiddenClass}:not(.${unHiddenClass}) { outline: 4px solid red }`);
+
+const precedingHiddenPosts = ({ previousElementSibling: previousElement }, count = 0) => {
+  if (!previousElement) return count;
+  if (!previousElement.matches(postSelector)) return precedingHiddenPosts(previousElement, count);
+  if (previousElement.classList.contains(hiddenClass)) return precedingHiddenPosts(previousElement, count + 1);
+  return count;
+};
 
 const processPosts = async function (postElements) {
   filterPostElements(postElements, { excludeClass, timeline, includeFiltered }).forEach(async postElement => {
@@ -22,6 +31,13 @@ const processPosts = async function (postElements) {
     if (loggingReason === 'orbitznews') return;
 
     postElement.classList.add(hiddenClass);
+
+    // test
+    postElement.dataset.previousHidden = precedingHiddenPosts(postElement);
+
+    if (precedingHiddenPosts(postElement) >= 10) {
+      postElement.classList.add(unHiddenClass);
+    }
   });
 };
 

--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -31,9 +31,13 @@ const styleElement = buildStyle(`
 `);
 
 const precedingHiddenPosts = ({ previousElementSibling: previousElement }, count = 0) => {
+  // If there is no previous sibling, stop counting
   if (!previousElement) return count;
+  // If the previous sibling is not a post, skip over it
   if (!previousElement.matches(postSelector)) return precedingHiddenPosts(previousElement, count);
+  // If the previous sibling is hidden, count it and continue
   if (previousElement.classList.contains(hiddenClass)) return precedingHiddenPosts(previousElement, count + 1);
+  // Otherwise, we've hit a non-hidden post; stop counting
   return count;
 };
 

--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -17,12 +17,16 @@ const styleElement = buildStyle(`
   content: 'Too many recommended posts to hide!';
 
   display: block;
-  text-align: center;
   padding: 25px 20px;
   border-radius: 3px;
+  margin-bottom: var(--post-padding);
+
   background-color: rgba(var(--white-on-dark), 0.13);
   color: rgba(var(--white-on-dark), 0.6);
+
   font-weight: 700;
+  text-align: center;
+  line-height: 1.5em;
 }
 `);
 

--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -22,7 +22,7 @@ const styleElement = buildStyle(`
   margin-bottom: var(--post-padding);
 
   background-color: rgba(var(--white-on-dark), 0.13);
-  color: rgba(var(--white-on-dark), 0.6);
+  color: rgba(var(--white-on-dark), 0.65);
 
   font-weight: 700;
   text-align: center;

--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -8,8 +8,7 @@ const unHiddenClass = 'xkit-no-recommended-posts-many';
 const timeline = /\/v2\/timeline\/dashboard/;
 const includeFiltered = true;
 
-// const styleElement = buildStyle(`.${hiddenClass}:not(.${unHiddenClass}) article { display: none; }`);
-const styleElement = buildStyle(`.${hiddenClass}:not(.${unHiddenClass}) { outline: 4px solid red }`);
+const styleElement = buildStyle(`.${hiddenClass}:not(.${unHiddenClass}) article { display: none; }`);
 
 const precedingHiddenPosts = ({ previousElementSibling: previousElement }, count = 0) => {
   if (!previousElement) return count;
@@ -31,9 +30,6 @@ const processPosts = async function (postElements) {
     if (loggingReason === 'orbitznews') return;
 
     postElement.classList.add(hiddenClass);
-
-    // test
-    postElement.dataset.previousHidden = precedingHiddenPosts(postElement);
 
     if (precedingHiddenPosts(postElement) >= 10) {
       postElement.classList.add(unHiddenClass);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This turns No Recommended's hide recommended posts tweak off once more than (an arbitrary) 10 posts in a row are recommendations.

This prevents the endless-scrolling-enabled dashboard from continually loading new content if part of one's dash is entirely recommended posts, which appears to be happening on my account if I scroll back enough (and might be true on a new user's dash as well). This saves server load and memory, of course.

~~I think this is fine to do without any UI copy updates. A fancier version could apply a CSS style to the element with `precedingHiddenPosts(postElement) === 10` that gives it a `before` with a message about too many recommended posts to hide.~~ actually you know what here

<img width="1517"  src="https://user-images.githubusercontent.com/8336245/221431215-899e7739-e258-47aa-b1fb-73f7d15f773d.png">


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
If your dash does the same thing as mine: scroll far enough down your dashboard that all of the posts are recommended and confirm that the UI appears as shown.
