### PR TITLE
User util: use redpop's user info

### DIFF
--- a/src/util/user.js
+++ b/src/util/user.js
@@ -1,11 +1,24 @@
-import { apiFetch } from './tumblr_helpers.js';
+import { inject } from './inject.js';
 
-const fetchedUserInfo = await apiFetch('/v2/user/info').catch(() => ({ response: {} }));
+const unburyUserInfo = async () => {
+  const baseContainerElement = document.getElementById('base-container');
+  const reactKey = Object.keys(baseContainerElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = baseContainerElement[reactKey];
+
+  while (fiber !== null) {
+    const { appContext } = fiber.memoizedProps || {};
+    if (appContext !== undefined) {
+      return appContext.getUserInfo();
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
 
 /**
  * {object?} userInfo - The contents of the /v2/user/info API endpoint
  */
-export const userInfo = fetchedUserInfo.response.user;
+export const userInfo = await inject(unburyUserInfo).catch(() => ({}));
 
 /**
  * {object[]} userBlogs - An array of blog objects the current user has post access to

--- a/src/util/user.js
+++ b/src/util/user.js
@@ -1,4 +1,5 @@
 import { inject } from './inject.js';
+import { apiFetch } from './tumblr_helpers.js';
 
 const unburyUserInfo = async () => {
   const baseContainerElement = document.getElementById('base-container');
@@ -18,7 +19,9 @@ const unburyUserInfo = async () => {
 /**
  * {object?} userInfo - The contents of the /v2/user/info API endpoint
  */
-export const userInfo = await inject(unburyUserInfo).catch(() => ({}));
+export const userInfo =
+  (await inject(unburyUserInfo).catch(() => undefined)) ??
+  (await apiFetch('/v2/user/info').catch(() => ({ response: {} })));
 
 /**
  * {object[]} userBlogs - An array of blog objects the current user has post access to

--- a/src/util/user.js
+++ b/src/util/user.js
@@ -21,7 +21,7 @@ const unburyUserInfo = async () => {
  */
 export const userInfo =
   (await inject(unburyUserInfo).catch(() => undefined)) ??
-  (await apiFetch('/v2/user/info').catch(() => ({ response: {} })));
+  (await apiFetch('/v2/user/info').catch(() => ({ response: {} })))?.response?.user;
 
 /**
  * {object[]} userBlogs - An array of blog objects the current user has post access to


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Rather than doing our own API request to get user info right after redpop does a request for the same thing, this steals it from appContext. This improves initial load speed (especially with legacy xkit loaded, for [weird reasons](https://www.tumblr.com/transienturl/710563203197861888/no-idea-if-anyone-would-know-this-but-if-you)) and technically reduces server load by some minute amount.

Worth bothering with? Probably no.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

