### PR TITLE
Trim Reblogs: always show trim button

### DIFF
--- a/src/content_scripts/control_buttons.css
+++ b/src/content_scripts/control_buttons.css
@@ -28,6 +28,11 @@
   fill: rgba(var(--black), 0.65);
 }
 
+.xkit-control-button:disabled svg {
+  fill: rgba(var(--black), 0.4);
+  cursor: not-allowed;
+}
+
 @media (max-width: 990px) {
   .xkit-control-button-container {
     margin-left: 0;

--- a/src/content_scripts/control_buttons.css
+++ b/src/content_scripts/control_buttons.css
@@ -28,9 +28,12 @@
   fill: rgba(var(--black), 0.65);
 }
 
+.xkit-control-button:disabled {
+  cursor: not-allowed;
+}
+
 .xkit-control-button:disabled svg {
   fill: rgba(var(--black), 0.4);
-  cursor: not-allowed;
 }
 
 @media (max-width: 990px) {

--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -124,13 +124,15 @@ const appendWithoutViewportOverflow = (element, target) => {
   }
 };
 
-const togglePopupDisplay = async function ({ target, currentTarget }) {
+const togglePopupDisplay = async function ({ target, currentTarget: controlButton }) {
   if (target === popupElement || popupElement.contains(target)) { return; }
 
-  if (currentTarget.contains(popupElement)) {
-    currentTarget.removeChild(popupElement);
+  const buttonContainer = controlButton.parentElement;
+
+  if (buttonContainer.contains(popupElement)) {
+    buttonContainer.removeChild(popupElement);
   } else {
-    appendWithoutViewportOverflow(popupElement, currentTarget);
+    appendWithoutViewportOverflow(popupElement, buttonContainer);
   }
 };
 

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -55,11 +55,6 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
   const { response: postData } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}?fields[blogs]=name,avatar`);
   const { blog, content = [], trail = [] } = postData;
 
-  if (!trail?.length) {
-    notify('This post is too short to trim!');
-    return;
-  }
-
   const createPreviewItem = ({ blog, brokenBlog, content, disableCheckbox = false }) => {
     const { avatar, name } = blog ?? brokenBlog ?? blogPlaceholder;
     const { url: src } = avatar[avatar.length - 1];
@@ -153,9 +148,8 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
 
   const { trail = [], content = [] } = await timelineObject(postElement);
   const items = trail.length + (content.length ? 1 : 0);
-  if (items < 2) { return; }
 
-  const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: onButtonClicked });
+  const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: onButtonClicked }, items < 2);
   const controlIcon = editButton.closest(controlIconSelector);
   controlIcon.before(clonedControlButton);
 });

--- a/src/util/control_buttons.js
+++ b/src/util/control_buttons.js
@@ -27,10 +27,13 @@ export const createControlButtonTemplate = function (symbolId, buttonClass) {
  * @param {HTMLDivElement} template - A button template as returned by createControlButtonTemplate()
  * @param {object} events - An object of DOM Event names and handler functions,
  *                          e.g. { click: () => { alert('Hello!'); } }
+ * @param {boolean} disabled - Whether to disable the button clone
  * @returns {HTMLDivElement} A clone of the button template, with the specified event handlers attached
  */
-export const cloneControlButton = function (template, events) {
-  const newButton = template.cloneNode(true);
+export const cloneControlButton = function (template, events, disabled = false) {
+  const newButtonContainer = template.cloneNode(true);
+  const newButton = newButtonContainer.querySelector('button');
   Object.entries(events).forEach(([type, listener]) => newButton.addEventListener(type, listener));
-  return newButton;
+  newButton.disabled = disabled;
+  return newButtonContainer;
 };


### PR DESCRIPTION
Seeing a lot of user reports that Trim Reblogs is broken and I would really like to know if it's a button add failure or a misunderstanding about which posts should be trimmable. Hence:

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As described in the linked issue, this disables the trim button on editable but untrimmable posts, rather than not adding it at all.

This uses the native dom `disabled` attribute on the button element and moves the event handlers on control buttons to the button element itself.

Resolves #958.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that e.g. Quick Tags works as expected.
- Try to press the Trim Reblogs button on an original post, a reblog with no added content and only one trail item, and a post with enough content to trim.
