### PR TITLE
Implement simple load failure warning

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -85,9 +85,13 @@
     const installedScripts = await getInstalledScripts();
     const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
 
-    installedScripts
+    const loaded = installedScripts
       .filter(scriptName => enabledScripts.includes(scriptName))
-      .forEach(runScript);
+      .map(runScript);
+
+    const rootNode = document.getElementById('root');
+    setTimeout(() => rootNode.classList.add('xkit-after-n-seconds'), 5000);
+    Promise.all(loaded).then(() => rootNode.classList.add('xkit-loaded'));
   };
 
   const waitForReactLoaded = () => new Promise(resolve => {

--- a/src/content_scripts/notifications.css
+++ b/src/content_scripts/notifications.css
@@ -47,3 +47,22 @@
 [role="dialog"] #xkit-toasts[data-in-sidebar="false"] {
   position: absolute;
 }
+
+#root.xkit-after-n-seconds:not(.xkit-loaded)::after {
+  content: "Warning: XKit Rewritten scripts are not fully loaded!";
+
+  position: fixed;
+  bottom: 0;
+  z-index: 98;
+
+  width: 100%;
+  padding: 10px;
+  border-top: 1px solid rgba(var(--white-on-dark), .13);
+
+  background-color: rgb(var(--navy));
+  background-image: linear-gradient(rgba(var(--white-on-dark), .07), rgba(var(--white-on-dark), .07));
+  color: rgb(var(--white-on-dark));
+  font-family: var(--font-family);
+  line-height: 1.5;
+  text-align: center;
+}


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

In a few lines of code, this implements a simple warning display when not all scripts have been successfully loaded after an arbitrary delay (5 seconds). It is very difficult to detect this failure state otherwise, as no error occurs.

The warning message vanishes if scripts do eventually load, preventing possible false positives if loading takes an excessive amount of time (reopening a browser with many windows can cause this, for example); the message should be chosen not to definitively imply that the extension is in a permanent error state.

This would make sense to merge along with a fix for the "haunted chromium" bug, to see if the fix worked. (Right now I kind of favor the ```await Promise.all(['css_map', 'language_data', 'user'].map(name => import(getURL(`/util/${name}.js`))));``` oneliner, just so we have something released.)

#756 is a much more convoluted version of this that identifies which script(s) failed to load.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

