### PR TITLE
Fix Chromium/Safari script loading inconsistency

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -85,6 +85,13 @@
     const installedScripts = await getInstalledScripts();
     const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
 
+    /**
+     * fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await
+     *
+     * @see https://github.com/sveltejs/kit/issues/7805#issuecomment-1330078207
+     */
+    await Promise.all(['css_map', 'language_data', 'user'].map(name => import(getURL(`/util/${name}.js`))));
+
     installedScripts
       .filter(scriptName => enabledScripts.includes(scriptName))
       .forEach(runScript);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This prevents XKit from silently failing to load some scripts on slow computers in certain scenarios in Chromium-based browsers or Safari; see the linked issue, https://github.com/AprilSylph/XKit-Rewritten/pull/945#issuecomment-1439428253, and https://github.com/sveltejs/kit/issues/7805#issuecomment-1330078207 for background.

The bug appears to be that it is possible for dynamic imports to fail when multiple dynamic imports attempt to load the same module file simultaneously during the import waterfall when that module is waiting on a top level await statement.

Ensuring that the modules in question have resolved already appears to be the minimum change necessary to fix this.

We have discussed other solutions (completely removing top level await from imported utils, #1017) and improvements that mitigate the load speed reduction resulting from this (#945, #897) in various other locations.

I have also shown a way to enforce top level await only occurring in the utility files that this patch affects using eslint (#1017); I can merge that in if desired, or we can pursue more elegant solutions and just keep this as a hotfix.

Resolves #636.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Merge #756 or #1014 into master (preferably on a slow PC and/or with XKit 7 enabled), enable ~all of the scripts, and try to observe a failure. Then, merge #756 or #1014 into this PR with the same scenario and observe that there are no failures.

