### PR TITLE
Tag Tracking+ Fix crash when tags contain special characters

### DIFF
--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -58,7 +58,11 @@ const refreshCount = async function (tag) {
   const unreadCountString = `${unreadCount}${showPlus ? '+' : ''}`;
 
   [document, ...(!sidebarItem || document.contains(sidebarItem) ? [] : [sidebarItem])]
-    .flatMap(node => [...node.querySelectorAll(`[data-count-for="#${tag}"]`)])
+    .flatMap(node =>
+      [...node.querySelectorAll('[data-count-for]')].filter(
+        ({ dataset: { countFor } }) => countFor === `#${tag}`
+      )
+    )
     .filter((value, index, array) => array.indexOf(value) === index)
     .forEach(unreadCountElement => {
       unreadCountElement.textContent = unreadCountString;

--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -34,7 +34,7 @@ const refreshCount = async function (tag) {
       }
     }
   } = await apiFetch(
-    `/v2/hubs/${tag}/timeline`,
+    `/v2/hubs/${encodeURIComponent(tag)}/timeline`,
     { queryParams: { limit: 20, sort: 'recent' } }
   );
 
@@ -149,7 +149,7 @@ export const main = async function () {
       title: 'Tag Tracking+',
       rows: trackedTags.map(tag => ({
         label: `#${tag}`,
-        href: `/tagged/${tag}?sort=recent`,
+        href: `/tagged/${encodeURIComponent(tag)}?sort=recent`,
         onclick: onClickNavigate,
         count: '\u22EF'
       }))


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This prevents Tag Tracking+ from crashing or linking to invalid URLs when a user's tracked tags contain special characters that are not automatically encoded.

Resolves #850; resolves #1007

Notably does not address #847.

Notably does not fix issues resulting from Tumblr's deduplication of similar tags; see https://github.com/AprilSylph/XKit-Rewritten/issues/850#issuecomment-1457506044. Would also like to fix this, of course.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Track e.g. `a/b` and `what?` and confirm that Tag Tracking+ loads, refreshes tag counts upon navigation, and creates sidebar links that correctly soft navigate when clicked and that correctly hard navigate when control-clicked and right clicked to open in a new tab.

Track e.g. `"hello"` and confirm that, while counts will not ever be set to 0 if the first post in the tag is actually tagged `hello`, the rest of the script works as expected.
