### PR TITLE
Show Originals: Reverse mode

### DIFF
--- a/src/scripts/show_originals.css
+++ b/src/scripts/show_originals.css
@@ -2,6 +2,10 @@
   display: none;
 }
 
+[data-show-originals="reverse"] ~ :not(.xkit-show-originals-hidden) article {
+  display: none;
+}
+
 .xkit-show-originals-lengthened {
   min-height: 100vh;
 }
@@ -32,6 +36,7 @@
 
 [data-show-originals="on"].xkit-show-originals-controls > a[data-mode="on"],
 [data-show-originals="off"].xkit-show-originals-controls > a[data-mode="off"],
+[data-show-originals="reverse"].xkit-show-originals-controls > a[data-mode="reverse"],
 .xkit-show-originals-controls > a[data-mode="disabled"] {
   box-shadow: inset 0 -3px 0 var(--blog-link-color, rgb(var(--accent)));
   color: var(--blog-link-color, rgb(var(--accent)));

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -17,6 +17,7 @@ let showOwnReblogs;
 let showReblogsWithContributedContent;
 let whitelist;
 let disabledBlogs;
+let showReverse;
 
 const lengthenTimeline = async (timeline) => {
   if (!timeline.querySelector(keyToCss('manualPaginatorButtons'))) {
@@ -49,12 +50,15 @@ const addControls = async (timelineElement, location) => {
 
   const onButton = createButton(translate('Original Posts'), handleClick, 'on');
   const offButton = createButton(translate('All posts'), handleClick, 'off');
+  const reverseButton = createButton(translate('Hidden reblogs'), handleClick, 'reverse');
   const disabledButton = createButton(translate('All posts'), null, 'disabled');
 
   if (location === 'disabled') {
     controls.append(disabledButton);
   } else {
-    controls.append(onButton, offButton);
+    showReverse
+      ? controls.append(onButton, offButton, reverseButton)
+      : controls.append(onButton, offButton);
 
     lengthenTimeline(timelineElement);
     const { [storageKey]: savedModes = {} } = await browser.storage.local.get(storageKey);
@@ -117,7 +121,8 @@ export const main = async function () {
   ({
     showOwnReblogs,
     showReblogsWithContributedContent,
-    whitelistedUsernames
+    whitelistedUsernames,
+    showReverse
   } = await getPreferences('show_originals'));
 
   whitelist = whitelistedUsernames.split(',').map(username => username.trim());

--- a/src/scripts/show_originals.json
+++ b/src/scripts/show_originals.json
@@ -22,6 +22,11 @@
       "type": "textarea",
       "label": "Always show reblogs from these blogs (comma-separated)",
       "default": ""
+    },
+    "showReverse": {
+      "type": "checkbox",
+      "label": "Add a \"reverse\" mode to the controls",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
Honestly, would I add this? Eh.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds an optional mode to Show Originals that filters the timeline to posts it would normally hide.

(This isn't the same as reblogs-only because it might not include your reblogs, reblogs by anyone specifified in the exclusion list in your settings, reblogs with contributed content, etc.)

The translation for the button label doesn't work.
