### PR TITLE
Quote Replies: Activate in notification dropdown

### DIFF
--- a/src/scripts/quote_replies.css
+++ b/src/scripts/quote_replies.css
@@ -29,7 +29,7 @@ button.xkit-quote-replies-dropdown {
 }
 
 @media (hover: hover) {
-  button.xkit-quote-replies:not(.xkit-quote-replies-dropdown) svg {
+  button.xkit-quote-replies svg {
     opacity: 0;
     transform: scale(0);
   }

--- a/src/scripts/quote_replies.css
+++ b/src/scripts/quote_replies.css
@@ -23,24 +23,19 @@ button.xkit-quote-replies:disabled svg {
   transition-property: none;
 }
 
+button.xkit-quote-replies-dropdown {
+  align-self: flex-start;
+  margin: 10px 0 0;
+}
+
 @media (hover: hover) {
-  button.xkit-quote-replies-activity svg {
+  button.xkit-quote-replies:not(.xkit-quote-replies-dropdown) svg {
     opacity: 0;
     transform: scale(0);
   }
 
-  :is(:hover, :focus-within) > button.xkit-quote-replies-activity svg {
+  :is(:hover, :focus-within) > button.xkit-quote-replies svg {
     opacity: 1;
     transform: scale(1);
-  }
-
-  :is(:hover, :focus-within) > button.xkit-quote-replies-dropdown + div,
-  :not(:hover, :focus-within) > button.xkit-quote-replies-dropdown {
-    display: none;
-  }
-
-  button.xkit-quote-replies-dropdown {
-    padding: 7px;
-    margin: 0 12px;
   }
 }

--- a/src/scripts/quote_replies.css
+++ b/src/scripts/quote_replies.css
@@ -24,13 +24,23 @@ button.xkit-quote-replies:disabled svg {
 }
 
 @media (hover: hover) {
-  button.xkit-quote-replies svg {
+  button.xkit-quote-replies-activity svg {
     opacity: 0;
     transform: scale(0);
   }
 
-  :is(:hover, :focus-within) > button.xkit-quote-replies svg {
+  :is(:hover, :focus-within) > button.xkit-quote-replies-activity svg {
     opacity: 1;
     transform: scale(1);
+  }
+
+  :is(:hover, :focus-within) > button.xkit-quote-replies-dropdown + div,
+  :not(:hover, :focus-within) > button.xkit-quote-replies-dropdown {
+    display: none;
+  }
+
+  button.xkit-quote-replies-dropdown {
+    padding: 7px;
+    margin: 0 12px;
   }
 }

--- a/src/scripts/quote_replies.js
+++ b/src/scripts/quote_replies.js
@@ -10,7 +10,6 @@ import { userBlogs } from '../util/user.js';
 
 const storageKey = 'quote_replies.currentResponseId';
 const buttonClass = 'xkit-quote-replies';
-const activityPageButtonClass = 'xkit-quote-replies-activity';
 const dropdownButtonClass = 'xkit-quote-replies-dropdown';
 
 const originalPostTagStorageKey = 'quick_tags.preferences.originalPostTag';
@@ -49,11 +48,7 @@ const processNotifications = notifications => notifications.forEach(async notifi
   activityElement.after(dom(
     'button',
     {
-      class: `${buttonClass} ${
-        notification.matches(dropdownSelector)
-          ? dropdownButtonClass
-          : activityPageButtonClass
-      }`,
+      class: `${buttonClass} ${notification.matches(dropdownSelector) ? dropdownButtonClass : ''}`,
       title: 'Quote this reply'
     },
     {

--- a/src/scripts/quote_replies.js
+++ b/src/scripts/quote_replies.js
@@ -18,7 +18,7 @@ const originalPostTagStorageKey = 'quick_tags.preferences.originalPostTag';
 const activitySelector = `${keyToCss('notification')} > ${keyToCss('activity')}`;
 
 const activityPageSelector = `section${keyToCss('notifications')} > ${keyToCss('notification')}`;
-const dropdownSelector = `${keyToCss('activityPopover')} ${keyToCss('notification')}`;
+const dropdownSelector = `${keyToCss('activityPopover')} > [role="tabpanel"] > ${keyToCss('notification')}`;
 
 let originalPostTag;
 let tagReplyingBlog;

--- a/src/scripts/quote_replies.js
+++ b/src/scripts/quote_replies.js
@@ -10,10 +10,15 @@ import { userBlogs } from '../util/user.js';
 
 const storageKey = 'quote_replies.currentResponseId';
 const buttonClass = 'xkit-quote-replies';
+const activityPageButtonClass = 'xkit-quote-replies-activity';
+const dropdownButtonClass = 'xkit-quote-replies-dropdown';
 
 const originalPostTagStorageKey = 'quick_tags.preferences.originalPostTag';
 
 const activitySelector = `${keyToCss('notification')} > ${keyToCss('activity')}`;
+
+const activityPageSelector = `section${keyToCss('notifications')} > ${keyToCss('notification')}`;
+const dropdownSelector = `${keyToCss('activityPopover')} ${keyToCss('notification')}`;
 
 let originalPostTag;
 let tagReplyingBlog;
@@ -43,7 +48,14 @@ const processNotifications = notifications => notifications.forEach(async notifi
 
   activityElement.after(dom(
     'button',
-    { class: buttonClass, title: 'Quote this reply' },
+    {
+      class: `${buttonClass} ${
+        notification.matches(dropdownSelector)
+          ? dropdownButtonClass
+          : activityPageButtonClass
+      }`,
+      title: 'Quote this reply'
+    },
     {
       click () {
         this.disabled = true;
@@ -105,7 +117,7 @@ export const main = async function () {
   ({ [originalPostTagStorageKey]: originalPostTag } = await browser.storage.local.get(originalPostTagStorageKey));
   ({ tagReplyingBlog } = await getPreferences('quote_replies'));
 
-  const notificationSelector = `section${keyToCss('notifications')} > ${keyToCss('notification')}`;
+  const notificationSelector = `${activityPageSelector}, ${dropdownSelector}`;
   pageModifications.register(notificationSelector, processNotifications);
 
   const { [storageKey]: responseId } = await browser.storage.local.get(storageKey);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds Quote Replies buttons to the activity dropdown.

idk man. css or whatever. there's not a lot of space in there

Resolves #862.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Use Quote Replies on the activity page. Confirm that it still works as expected.
Use Quote Replies from the notification dropdown. Confirm that it works as expected.
Comment the `@media (hover: hover)` CSS rule section or use a touchscreen and confirm that nothing explodes and the Quote Replies buttons are still visible.

