### PR TITLE
Tweaks: Fix "your tags" dropdown visual issue of Unsticky Tab Bar

### DIFF
--- a/src/scripts/tweaks/unsticky_tab_bar.js
+++ b/src/scripts/tweaks/unsticky_tab_bar.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
-  ${keyToCss('tabsHeader')} { position: static !important; }
+  ${keyToCss('tabsHeader')} { position: relative !important; top: 0 !important;}
   ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} { top: 69px !important; }
 `);
 

--- a/src/scripts/tweaks/unsticky_tab_bar.js
+++ b/src/scripts/tweaks/unsticky_tab_bar.js
@@ -2,7 +2,11 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
-  ${keyToCss('tabsHeader')} { position: relative !important; top: 0 !important;}
+  ${keyToCss('tabsHeader')} {
+    position: relative !important;
+    top: 0 !important;
+    transition: none !important;
+  }
   ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} { top: 69px !important; }
 `);
 


### PR DESCRIPTION
### Description

Goal is to provide a fix in #968 by changing `position: static !important;` to `position: relative !important; top: 0 !important;`. 

### Testing steps

- Change `position: static !important;` to `position: relative !important; top: 0 !important;`.  https://github.com/AprilSylph/XKit-Rewritten/blob/c4a0a29d3aad83ab4dd49279fd0a9672f12907c2/src/scripts/tweaks/unsticky_tab_bar.js#L5
- Enable Unsticky Tab Bar tweak
- Go to your dashboard > your tags
- Click "filter by tags"

Confirm the fix works if it shows:

![image](https://user-images.githubusercontent.com/17378596/226088430-628363f2-1898-45dd-985b-ba2cb334a8bf.png)
