### PR TITLE
Open in Tabs: Fix in blog card modals/blog view modals

### DIFF
--- a/src/scripts/open_in_tabs.js
+++ b/src/scripts/open_in_tabs.js
@@ -1,10 +1,10 @@
-import { pageModifications } from '../util/mutations.js';
-
 const linkSelector = 'a[role="link"][target="_blank"]';
 
-const onClickExternalLink = event => event.stopPropagation();
-
-const processLinks = links => links.forEach(link => link.addEventListener('click', onClickExternalLink));
+const onDocumentClick = event => {
+  if (event.target.matches(`${linkSelector}, ${linkSelector} *`)) {
+    event.stopPropagation();
+  }
+};
 
 const onClickBlogViewLink = event => {
   event.stopPropagation();
@@ -17,12 +17,11 @@ const onClickBlogViewLink = event => {
 };
 
 export const main = async function () {
-  pageModifications.register(linkSelector, processLinks);
+  document.documentElement.addEventListener('click', onDocumentClick, { capture: true });
   $('#base-container').on('click', 'a[href^="/blog/view/"]', onClickBlogViewLink);
 };
 
 export const clean = async function () {
-  pageModifications.unregister(processLinks);
-  [...document.querySelectorAll(linkSelector)].forEach(link => link.removeEventListener('click', onClickExternalLink));
+  document.documentElement.removeEventListener('click', onDocumentClick, { capture: true });
   $('#base-container').off('click', 'a[href^="/blog/view/"]', onClickBlogViewLink);
 };

--- a/src/scripts/open_in_tabs.js
+++ b/src/scripts/open_in_tabs.js
@@ -1,4 +1,10 @@
+import { pageModifications } from '../../util/mutations.js'; 
+
+const linkSelector = 'a[role="link"][target="_blank"]';
+
 const onClickExternalLink = event => event.stopPropagation();
+
+const processLinks = links => links.forEach(link => link.addEventListener('click', onClickExternalLink));
 
 const onClickBlogViewLink = event => {
   event.stopPropagation();
@@ -11,11 +17,12 @@ const onClickBlogViewLink = event => {
 };
 
 export const main = async function () {
-  $('#base-container').on('click', 'a[role="link"][target="_blank"]', onClickExternalLink);
+  pageModifications.register(linkSelector, processLinks); 
   $('#base-container').on('click', 'a[href^="/blog/view/"]', onClickBlogViewLink);
 };
 
 export const clean = async function () {
-  $('#base-container').off('click', 'a[role="link"][target="_blank"]', onClickExternalLink);
+  pageModifications.unregister(processLinks); 
+  [...document.querySelectorAll(linkSelector)].forEach(link => link.removeEventListener('click', onClickExternalLink));
   $('#base-container').off('click', 'a[href^="/blog/view/"]', onClickBlogViewLink);
 };

--- a/src/scripts/open_in_tabs.js
+++ b/src/scripts/open_in_tabs.js
@@ -1,4 +1,4 @@
-import { pageModifications } from '../../util/mutations.js'; 
+import { pageModifications } from '../util/mutations.js';
 
 const linkSelector = 'a[role="link"][target="_blank"]';
 
@@ -17,12 +17,12 @@ const onClickBlogViewLink = event => {
 };
 
 export const main = async function () {
-  pageModifications.register(linkSelector, processLinks); 
+  pageModifications.register(linkSelector, processLinks);
   $('#base-container').on('click', 'a[href^="/blog/view/"]', onClickBlogViewLink);
 };
 
 export const clean = async function () {
-  pageModifications.unregister(processLinks); 
+  pageModifications.unregister(processLinks);
   [...document.querySelectorAll(linkSelector)].forEach(link => link.removeEventListener('click', onClickExternalLink));
   $('#base-container').off('click', 'a[href^="/blog/view/"]', onClickBlogViewLink);
 };


### PR DESCRIPTION
### Description

This fixes #1019 by applying pageModifications targeting `a[role="link"][target="_blank"]` and attaching click event listener. 

### Testing steps

- While Open in Tabs is enabled, access the modals as shown the in the images below. 
- Click on the any of the links (e.g. blog name)
- On-dashboard blog view won't show but instead it will open a new tab as intended. 

![image](https://user-images.githubusercontent.com/17378596/226177454-60df38cb-b3a1-4497-a066-037735498f57.png)
![image](https://user-images.githubusercontent.com/17378596/226177494-d8fa3380-c621-4a5e-809d-1b1d6a7f8b08.png)

