### PR TITLE
Seen Posts: Fix faded checkmarks in mobile view

### DIFF
--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -1,12 +1,6 @@
 body:not(.xkit-seen-posts-only-dim-avatar) .xkit-seen-posts-seen:not(:hover),
-body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article > :first-child img {
+body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article > :first-child  > :first-child img {
   opacity: 0.5;
-}
-
-@media (max-width: 990px) {
-  body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article > :first-child > :not(:first-child) img {
-    opacity: 1;
-  }
 }
 
 body.xkit-seen-posts-hide .xkit-seen-posts-seen article {

--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -3,6 +3,12 @@ body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article >
   opacity: 0.5;
 }
 
+@media (max-width: 990px) {
+  body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article > :first-child > :not(:first-child) img {
+    opacity: 1;
+  }
+}
+
 body.xkit-seen-posts-hide .xkit-seen-posts-seen article {
   display: none;
 }


### PR DESCRIPTION
### Description

This fixes #986 by adding a media rule with the max-width of 990px, and applying `opacity: 1;` to the other images besides the first image (avatar). 

### Testing steps
- Turn on Seen Posts > Dim avatars
- View a post with checkmarks 
- Refresh and locate the same post
- Change the window size to 990px or lower for the mobile view 

Before:
![current bug](https://user-images.githubusercontent.com/17378596/226971874-7ff323e3-4388-4e6e-b368-f7b99be6d921.png)

After: 
![intended function](https://user-images.githubusercontent.com/17378596/226971911-8078a442-f9b1-4401-a23a-15b9407177de.png)

