### PR TITLE
update live carousel selector

### DIFF
--- a/src/scripts/tweaks/no_live.js
+++ b/src/scripts/tweaks/no_live.js
@@ -12,7 +12,7 @@ const processFrames = frames =>
 
 export const main = async function () {
   pageModifications.register(
-    '[data-timeline="/v2/timeline/dashboard"] iframe[src^="https://api.gateway.tumblr-live.com/"]',
+    `[data-timeline="/v2/timeline/dashboard"] :is(iframe[src^="https://api.gateway.tumblr-live.com/"], ${keyToCss('liveMarqueeContainer')})`,
     processFrames
   );
   document.documentElement.append(styleElement);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This updates the CSS selector used to hide the Tumblr live carousel. I don't actually think the iframe selector is necessary, but I didn't save the HTML of the old element, so better safe than sorry.

Resolves #1047.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Enable Tweaks and the tweak to hide the Live carousel on an account with the new, iframe-less carousel. Confirm that it works.
