### PR TITLE
New Tweak: Hide the labels on the Blaze and Tip buttons

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -55,6 +55,11 @@
       "label": "Hide control button tooltips in the post footer",
       "default": false
     },
+    "hide_blaze_tip_labels": {
+      "type": "checkbox",
+      "label": "Hide the \"blaze\" and \"tip\" button labels",
+      "default": false
+    },
     "hide_filtered_posts": {
       "type": "checkbox",
       "label": "Hide filtered posts entirely",

--- a/src/scripts/tweaks/hide_blaze_tip_labels.js
+++ b/src/scripts/tweaks/hide_blaze_tip_labels.js
@@ -1,8 +1,8 @@
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle, postSelector } from '../../util/interface.js';
+import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
-${postSelector} ${keyToCss('igniteButton', 'tippingButton')} > ${keyToCss('label')} {
+article ${keyToCss('igniteButton', 'tippingButton')} > ${keyToCss('label')} {
   display: none;
 }
 `);

--- a/src/scripts/tweaks/hide_blaze_tip_labels.js
+++ b/src/scripts/tweaks/hide_blaze_tip_labels.js
@@ -1,0 +1,11 @@
+import { keyToCss } from '../../util/css_map.js';
+import { buildStyle, postSelector } from '../../util/interface.js';
+
+const styleElement = buildStyle(`
+${postSelector} ${keyToCss('igniteButton', 'tippingButton')} > ${keyToCss('label')} {
+  display: none;
+}
+`);
+
+export const main = async () => document.documentElement.append(styleElement);
+export const clean = async () => styleElement.remove();


### PR DESCRIPTION
Booting up the ol' "xkit rewritten" time tracker entry. 

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds a tweak that hides the text labels on the blaze and tip buttons in the post footer. Once you've seen them a couple hundred times, you know what they are, I figure.

Resolves #1055.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Enable the new tweak. Confirm that blaze and tip icons on original posts no longer have text labels, but that they still appear as expected.