### PR TITLE
New Tweak: Restore post links in attribution header

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -7,7 +7,10 @@
     "background_color": "#ecc84b"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#tweaks",
-  "relatedTerms": [ "Blacklist", "Separator" ],
+  "relatedTerms": [
+    "Blacklist",
+    "Separator"
+  ],
   "preferences": {
     "slim_filtered_screens": {
       "type": "checkbox",
@@ -93,6 +96,11 @@
     "no_live": {
       "type": "checkbox",
       "label": "Hide the Tumblr Live carousel",
+      "default": false
+    },
+    "restore_attribution_links": {
+      "type": "checkbox",
+      "label": "Restore links to individual posts in the post header",
       "default": false
     }
   }

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -12,6 +12,11 @@
     "Separator"
   ],
   "preferences": {
+    "restore_attribution_links": {
+      "type": "checkbox",
+      "label": "Restore links to individual posts in the post header",
+      "default": false
+    },
     "slim_filtered_screens": {
       "type": "checkbox",
       "label": "Use a slim layout for filtered posts",
@@ -96,11 +101,6 @@
     "no_live": {
       "type": "checkbox",
       "label": "Hide the Tumblr Live carousel",
-      "default": false
-    },
-    "restore_attribution_links": {
-      "type": "checkbox",
-      "label": "Restore links to individual posts in the post header",
       "default": false
     }
   }

--- a/src/scripts/tweaks/restore_attribution_links.js
+++ b/src/scripts/tweaks/restore_attribution_links.js
@@ -1,5 +1,4 @@
 import { onNewPosts } from '../../util/mutations.js';
-import { filterPostElements } from '../../util/interface.js';
 import { keyToCss } from '../../util/css_map.js';
 import { timelineObject } from '../../util/react_props.js';
 
@@ -7,7 +6,7 @@ const postAttributionSelector = keyToCss('postAttribution');
 const reblogAttributionSelector = keyToCss('reblogAttribution');
 
 const processPosts = async function (postElements) {
-  filterPostElements(postElements).forEach(async postElement => {
+  postElements.forEach(async postElement => {
     const { postUrl, rebloggedFromUrl } = await timelineObject(postElement);
     const postAttribution = postElement.querySelector(postAttributionSelector);
     const postAttributionLink = postAttribution?.querySelector('a');

--- a/src/scripts/tweaks/restore_attribution_links.js
+++ b/src/scripts/tweaks/restore_attribution_links.js
@@ -1,0 +1,33 @@
+import { onNewPosts } from '../../util/mutations.js';
+import { filterPostElements } from '../../util/interface.js';
+import { keyToCss } from '../../util/css_map.js';
+import { timelineObject } from '../../util/react_props.js';
+
+const timeline = /\/v2\/timeline\/dashboard/;
+
+const postAttributionSelector = keyToCss('postAttribution');
+const reblogAttributionSelector = keyToCss('reblogAttribution');
+
+const processPosts = async function (postElements) {
+  filterPostElements(postElements, { timeline }).forEach(async postElement => {
+    const { postUrl, rebloggedFromUrl } = await timelineObject(postElement);
+    const postAttribution = postElement.querySelector(postAttributionSelector);
+    const postAttributionLink = postAttribution?.querySelector('a');
+    if (postAttributionLink !== undefined) {
+      postAttributionLink.href = postUrl;
+    }
+    const reblogAttribution = postElement.querySelector(reblogAttributionSelector);
+    const reblogAttributionLink = reblogAttribution?.querySelector('a');
+    if (reblogAttributionLink !== undefined && rebloggedFromUrl !== undefined) {
+      reblogAttributionLink.href = rebloggedFromUrl;
+    }
+  });
+};
+
+export const main = async function () {
+  onNewPosts.addListener(processPosts);
+};
+
+export const clean = async function () {
+  onNewPosts.removeListener(processPosts);
+};

--- a/src/scripts/tweaks/restore_attribution_links.js
+++ b/src/scripts/tweaks/restore_attribution_links.js
@@ -3,13 +3,11 @@ import { filterPostElements } from '../../util/interface.js';
 import { keyToCss } from '../../util/css_map.js';
 import { timelineObject } from '../../util/react_props.js';
 
-const timeline = /\/v2\/timeline\/dashboard/;
-
 const postAttributionSelector = keyToCss('postAttribution');
 const reblogAttributionSelector = keyToCss('reblogAttribution');
 
 const processPosts = async function (postElements) {
-  filterPostElements(postElements, { timeline }).forEach(async postElement => {
+  filterPostElements(postElements).forEach(async postElement => {
     const { postUrl, rebloggedFromUrl } = await timelineObject(postElement);
     const postAttribution = postElement.querySelector(postAttributionSelector);
     const postAttributionLink = postAttribution?.querySelector('a');

--- a/src/scripts/tweaks/restore_attribution_links.js
+++ b/src/scripts/tweaks/restore_attribution_links.js
@@ -2,20 +2,18 @@ import { onNewPosts } from '../../util/mutations.js';
 import { keyToCss } from '../../util/css_map.js';
 import { timelineObject } from '../../util/react_props.js';
 
-const postAttributionSelector = keyToCss('postAttribution');
-const reblogAttributionSelector = keyToCss('reblogAttribution');
+const postAttributionLinkSelector = `${keyToCss('postAttribution')} a`;
+const reblogAttributionLinkSelector = `${keyToCss('reblogAttribution')} a`;
 
 const processPosts = async function (postElements) {
   postElements.forEach(async postElement => {
     const { postUrl, rebloggedFromUrl } = await timelineObject(postElement);
-    const postAttribution = postElement.querySelector(postAttributionSelector);
-    const postAttributionLink = postAttribution?.querySelector('a');
-    if (postAttributionLink !== undefined) {
+    const postAttributionLink = postElement.querySelector(postAttributionLinkSelector);
+    if (postAttributionLink !== null) {
       postAttributionLink.href = postUrl;
     }
-    const reblogAttribution = postElement.querySelector(reblogAttributionSelector);
-    const reblogAttributionLink = reblogAttribution?.querySelector('a');
-    if (reblogAttributionLink !== undefined && rebloggedFromUrl !== undefined) {
+    const reblogAttributionLink = postElement.querySelector(reblogAttributionLinkSelector);
+    if (reblogAttributionLink !== null && rebloggedFromUrl !== undefined) {
       reblogAttributionLink.href = rebloggedFromUrl;
     }
   });

--- a/src/scripts/tweaks/restore_attribution_links.js
+++ b/src/scripts/tweaks/restore_attribution_links.js
@@ -1,20 +1,47 @@
 import { onNewPosts } from '../../util/mutations.js';
 import { keyToCss } from '../../util/css_map.js';
 import { timelineObject } from '../../util/react_props.js';
+import { navigate } from '../../util/tumblr_helpers.js';
 
 const postAttributionLinkSelector = `${keyToCss('postAttribution')} a`;
 const reblogAttributionLinkSelector = `${keyToCss('reblogAttribution')} a`;
 
+const onLinkClick = event => {
+  event.stopPropagation();
+  if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;
+
+  const { blogName, postId } = event.currentTarget.dataset;
+  if (blogName && postId) {
+    event.preventDefault();
+    navigate(`/@${blogName}/${postId}`);
+  }
+};
+
 const processPosts = async function (postElements) {
   postElements.forEach(async postElement => {
-    const { postUrl, rebloggedFromUrl } = await timelineObject(postElement);
+    const {
+      blogName,
+      id,
+      postUrl,
+      rebloggedFromId,
+      rebloggedFromName,
+      rebloggedFromUrl
+    } = await timelineObject(postElement);
     const postAttributionLink = postElement.querySelector(postAttributionLinkSelector);
+
     if (postAttributionLink !== null) {
       postAttributionLink.href = postUrl;
+      postAttributionLink.dataset.blogName = blogName;
+      postAttributionLink.dataset.postId = id;
+      postAttributionLink.addEventListener('click', onLinkClick, { capture: true });
     }
+
     const reblogAttributionLink = postElement.querySelector(reblogAttributionLinkSelector);
     if (reblogAttributionLink !== null && rebloggedFromUrl !== undefined) {
       reblogAttributionLink.href = rebloggedFromUrl;
+      reblogAttributionLink.dataset.blogName = rebloggedFromName;
+      reblogAttributionLink.dataset.postId = rebloggedFromId;
+      reblogAttributionLink.addEventListener('click', onLinkClick, { capture: true });
     }
   });
 };


### PR DESCRIPTION
### Description
Tumblr recently removed the links to the actual post (and the reblogged post, if any) from the header, and [apparently intends](https://www.tumblr.com/changes/718768407758225408/tuesday-may-30th-2023) to keep this change.

However, the links are helpful for many people, so now there is a tweak which restores them.

Fixes #1077.

(Note: the tweak does not attempt to remove the helpful links when disabled. Of course, they will be "removed" on next page reload.)

### Testing steps

1. Enable "Restore links to individual posts in the post header" in the Tweaks module.
2. Examine the links on the blog names in the post attribution header.

I wasn't entirely sure which arguments to use with `filterPostElements`, so I used "Hide Liked Posts" as a model. Feel free to suggest a better way.