### PR TITLE
Anti-Capitalism: block cruelSummer takeover

### DIFF
--- a/src/scripts/anti_capitalism.js
+++ b/src/scripts/anti_capitalism.js
@@ -8,7 +8,7 @@ const listTimelineObjectInnerSelector = keyToCss('listTimelineObjectInner');
 
 const styleElement = buildStyle(`
 .${hiddenClass},
-${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner')} {
+${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner', 'cruelSummer')} {
   display: none !important;
 }`
 );

--- a/src/scripts/anti_capitalism.js
+++ b/src/scripts/anti_capitalism.js
@@ -18,13 +18,19 @@ const processVideoCTAs = videoCTAs => videoCTAs
   .filter(Boolean)
   .forEach(({ classList }) => classList.add(hiddenClass));
 
+const processTimelineOptionsWrappers = wrappers => wrappers
+  .filter(wrapper => wrapper.querySelector('a[href="/dashboard/freeform_campaign"]'))
+  .forEach(({ classList }) => classList.add(hiddenClass));
+
 export const main = async () => {
   document.documentElement.append(styleElement);
   pageModifications.register(`${listTimelineObjectInnerSelector}:first-child ${keyToCss('videoCTA', 'videoImageCTA')}`, processVideoCTAs);
+  pageModifications.register(keyToCss('timelineOptionsItemWrapper'), processTimelineOptionsWrappers);
 };
 
 export const clean = async () => {
   pageModifications.unregister(processVideoCTAs);
+  pageModifications.unregister(processTimelineOptionsWrappers);
   styleElement.remove();
   $(`.${hiddenClass}`).removeClass(hiddenClass);
 };

--- a/src/scripts/anti_capitalism.js
+++ b/src/scripts/anti_capitalism.js
@@ -13,6 +13,12 @@ ${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd',
 }`
 );
 
+const chromiumStyleElement = buildStyle(`
+${keyToCss('timelineOptionsItemWrapper')}:not(${keyToCss('active')}):has(> a[href="/dashboard/freeform_campaign"]) {
+  display: none !important;
+}`
+);
+
 const processVideoCTAs = videoCTAs => videoCTAs
   .map(videoCTA => videoCTA.closest(listTimelineObjectInnerSelector))
   .filter(Boolean)
@@ -20,11 +26,13 @@ const processVideoCTAs = videoCTAs => videoCTAs
 
 export const main = async () => {
   document.documentElement.append(styleElement);
+  document.documentElement.append(chromiumStyleElement);
   pageModifications.register(`${listTimelineObjectInnerSelector}:first-child ${keyToCss('videoCTA', 'videoImageCTA')}`, processVideoCTAs);
 };
 
 export const clean = async () => {
   pageModifications.unregister(processVideoCTAs);
   styleElement.remove();
+  chromiumStyleElement.remove();
   $(`.${hiddenClass}`).removeClass(hiddenClass);
 };

--- a/src/scripts/anti_capitalism.js
+++ b/src/scripts/anti_capitalism.js
@@ -13,12 +13,6 @@ ${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd',
 }`
 );
 
-const chromiumStyleElement = buildStyle(`
-${keyToCss('timelineOptionsItemWrapper')}:not(${keyToCss('active')}):has(> a[href="/dashboard/freeform_campaign"]) {
-  display: none !important;
-}`
-);
-
 const processVideoCTAs = videoCTAs => videoCTAs
   .map(videoCTA => videoCTA.closest(listTimelineObjectInnerSelector))
   .filter(Boolean)
@@ -26,13 +20,11 @@ const processVideoCTAs = videoCTAs => videoCTAs
 
 export const main = async () => {
   document.documentElement.append(styleElement);
-  document.documentElement.append(chromiumStyleElement);
   pageModifications.register(`${listTimelineObjectInnerSelector}:first-child ${keyToCss('videoCTA', 'videoImageCTA')}`, processVideoCTAs);
 };
 
 export const clean = async () => {
   pageModifications.unregister(processVideoCTAs);
   styleElement.remove();
-  chromiumStyleElement.remove();
   $(`.${hiddenClass}`).removeClass(hiddenClass);
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This hides the bottom elements from the "cruel summer" takeover ad, including the start menu and "reminder: turn your computer off before midnight on 12/31/99" animated sticker GIF.

~~In Chromium-based browsers,~~ it also hides the "1999" dashboard tab added by this takeover. ~~I used a `:has()` selector to do this; it is possible via adding our own class so that it will also work in Firefox, but this is difficult to implement without bugs because changing tabs updates the classlists on the tab item wrappers.~~

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Enable anti-capitalism. Confirm that the elements in question no longer appear.

