### PR TITLE
AccessKit: Exclude post editor contents from "disable animations"

### DIFF
--- a/src/scripts/accesskit/disable_animations.js
+++ b/src/scripts/accesskit/disable_animations.js
@@ -4,7 +4,7 @@ import { buildStyle } from '../../util/interface.js';
 const playPauseSelector = `${keyToCss('overlayPoof')} ${keyToCss('overlay')} svg`;
 
 const styleElement = buildStyle(`
-:not(${playPauseSelector}) {
+:not(${playPauseSelector}):not(${keyToCss('blockEditorContainer')} *) {
   animation: none !important;
   transition: none !important;
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Prevents the "disable animations" feature from breaking photoset creation in the new post editor in Chromium-based browsers (see linked issue for repro details).

Resolves #1100.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

In Chromium:

Enable AccessKit and the disable animations function. Insert two separate images into the new (gutenblr) post editor. Try to drag one beside the other with the four-squares (dragHandle) button in the top left and ensure the drag animation works normally and the photoset is successfully created.

