### PR TITLE
Vertical nav layout: Update sidebar utility

### DIFF
--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -86,7 +86,7 @@ const desktopContainerSelector = `aside ${keyToCss('desktopContainer', 'summary'
 // Sidebar on most other desktop pages
 const sidebarItemSelector = keyToCss('sidebarItem', 'sidebarContent');
 // Mobile drawer
-const navItemSelector = keyToCss('navItem');
+const navItemSelector = `${keyToCss('drawerContent')} ${keyToCss('navItem')}`;
 
 const sidebarItemSelectors = [desktopContainerSelector, sidebarItemSelector, navItemSelector];
 

--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -88,12 +88,8 @@ const sidebarItemSelector = keyToCss('sidebarItem', 'sidebarContent');
 // Mobile drawer
 const navItemSelector = `${keyToCss('drawerContent')} ${keyToCss('navItem')}`;
 
-const sidebarItemSelectors = [desktopContainerSelector, sidebarItemSelector, navItemSelector];
-
-const addSidebarToPage = () => {
+const addSidebarToPage = (siblingCandidates) => {
   if (/^\/settings/.test(location.pathname)) { return; }
-
-  const siblingCandidates = sidebarItemSelectors.flatMap(selector => [...document.querySelectorAll(selector)]);
 
   [...sidebarItems.children]
     .filter(sidebarItem => conditions.has(sidebarItem))
@@ -112,4 +108,4 @@ const addSidebarToPage = () => {
   target[insertAbove ? 'before' : 'after'](sidebarItems);
 };
 
-pageModifications.register(sidebarItemSelectors.join(', '), addSidebarToPage);
+pageModifications.register(`${desktopContainerSelector}, ${sidebarItemSelector}, ${navItemSelector}`, addSidebarToPage);

--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -86,10 +86,14 @@ const desktopContainerSelector = `aside ${keyToCss('desktopContainer', 'summary'
 // Sidebar on most other desktop pages
 const sidebarItemSelector = keyToCss('sidebarItem', 'sidebarContent');
 // Mobile drawer
-const navSubHeaderSelector = keyToCss('navSubHeader');
+const navItemSelector = keyToCss('navItem');
 
-const addSidebarToPage = (siblingCandidates) => {
+const sidebarItemSelectors = [desktopContainerSelector, sidebarItemSelector, navItemSelector];
+
+const addSidebarToPage = () => {
   if (/^\/settings/.test(location.pathname)) { return; }
+
+  const siblingCandidates = sidebarItemSelectors.flatMap(selector => [...document.querySelectorAll(selector)]);
 
   [...sidebarItems.children]
     .filter(sidebarItem => conditions.has(sidebarItem))
@@ -97,17 +101,15 @@ const addSidebarToPage = (siblingCandidates) => {
 
   const target = siblingCandidates
     .filter(target => !target.matches(blogViewSelector))
-    .filter(target => !target.matches(mrecContainerSelector))[0]
-    ?.parentElement
-    ?.firstElementChild;
+    .filter(target => !target.matches(mrecContainerSelector))[0];
 
   if (!target || target === sidebarItems) return;
 
   const insertAbove = getComputedStyle(target).position === 'sticky' ||
     target.matches(desktopContainerSelector) ||
-    target.matches(navSubHeaderSelector);
+    target.matches(navItemSelector);
 
   target[insertAbove ? 'before' : 'after'](sidebarItems);
 };
 
-pageModifications.register(`${desktopContainerSelector}, ${sidebarItemSelector}, ${navSubHeaderSelector}`, addSidebarToPage);
+pageModifications.register(sidebarItemSelectors.join(', '), addSidebarToPage);

--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -86,14 +86,16 @@ const desktopContainerSelector = `aside ${keyToCss('desktopContainer', 'summary'
 // Sidebar on most other desktop pages
 const sidebarItemSelector = keyToCss('sidebarItem', 'sidebarContent');
 // Mobile drawer
-const navItemSelector = `${keyToCss('drawerContent')} ${keyToCss('navItem')}`;
+const navItemSelector = `${keyToCss('drawerContent')} ${keyToCss('navigationLinks')} > ${keyToCss('navItem', 'subNav')}`;
+
+const updateSidebarItemVisibility = () => [...sidebarItems.children]
+  .filter(sidebarItem => conditions.has(sidebarItem))
+  .forEach(sidebarItem => { sidebarItem.hidden = !conditions.get(sidebarItem)(); });
 
 const addSidebarToPage = (siblingCandidates) => {
   if (/^\/settings/.test(location.pathname)) { return; }
 
-  [...sidebarItems.children]
-    .filter(sidebarItem => conditions.has(sidebarItem))
-    .forEach(sidebarItem => { sidebarItem.hidden = !conditions.get(sidebarItem)(); });
+  updateSidebarItemVisibility();
 
   const target = siblingCandidates
     .filter(target => !target.matches(blogViewSelector))
@@ -101,11 +103,17 @@ const addSidebarToPage = (siblingCandidates) => {
 
   if (!target || target === sidebarItems) return;
 
-  const insertAbove = getComputedStyle(target).position === 'sticky' ||
-    target.matches(desktopContainerSelector) ||
-    target.matches(navItemSelector);
+  const insertAbove = getComputedStyle(target).position === 'sticky' || target.matches(desktopContainerSelector);
 
   target[insertAbove ? 'before' : 'after'](sidebarItems);
 };
 
-pageModifications.register(`${desktopContainerSelector}, ${sidebarItemSelector}, ${navItemSelector}`, addSidebarToPage);
+const addSidebarToDrawer = (navItems) => {
+  updateSidebarItemVisibility();
+
+  const lastNavItem = navItems[navItems.length - 1];
+  lastNavItem?.after(sidebarItems);
+};
+
+pageModifications.register(`${desktopContainerSelector}, ${sidebarItemSelector}`, addSidebarToPage);
+pageModifications.register(navItemSelector, addSidebarToDrawer);

--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -85,6 +85,8 @@ const mrecContainerSelector = `${keyToCss('mrecContainer')} *`;
 const desktopContainerSelector = `aside ${keyToCss('desktopContainer', 'summary')}`;
 // Sidebar on most other desktop pages
 const sidebarItemSelector = keyToCss('sidebarItem', 'sidebarContent');
+// Footer beneath sidebar area
+const aboutFooterSelector = `${keyToCss('about')}${keyToCss('inSidebar')}`;
 // Mobile drawer
 const navItemSelector = `${keyToCss('drawerContent')} ${keyToCss('navigationLinks')} > ${keyToCss('navItem', 'subNav')}`;
 
@@ -103,7 +105,9 @@ const addSidebarToPage = (siblingCandidates) => {
 
   if (!target || target === sidebarItems) return;
 
-  const insertAbove = getComputedStyle(target).position === 'sticky' || target.matches(desktopContainerSelector);
+  const insertAbove = getComputedStyle(target).position === 'sticky' ||
+    target.matches(desktopContainerSelector) ||
+    target.matches(aboutFooterSelector);
 
   target[insertAbove ? 'before' : 'after'](sidebarItems);
 };
@@ -115,5 +119,5 @@ const addSidebarToDrawer = (navItems) => {
   lastNavItem?.after(sidebarItems);
 };
 
-pageModifications.register(`${desktopContainerSelector}, ${sidebarItemSelector}`, addSidebarToPage);
+pageModifications.register(`${desktopContainerSelector}, ${sidebarItemSelector}, ${aboutFooterSelector}`, addSidebarToPage);
 pageModifications.register(navItemSelector, addSidebarToDrawer);


### PR DESCRIPTION
Speedrun, let's go.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Updates the sidebar utility for the upcoming vertical nav layout and the current updated mobile navigation drawer.

~~The significant code change here is that because we need to prioritize the sidebar over the navigation section when both exist on the page (in the wrong DOM order), I re-query the candidate elements in the pageModifications callback in priority order instead of using the element list given by pageModifications itself.~~ never mind. I can read.

Question: Were XKit's sidebar items supposed to be at the top or the bottom of the mobile navigation drawer? I actually don't remember.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Load XKit Rewritten on an account with the new vertical nav layout and an account without it. Enable limit checker and confirm that the sidebar item appears at the bottom of the mobile navigation drawer or in the correct location in the right sidebar (above radar):

 - in the dashboard; mobile and desktop views (direct navigation and resize)
 - on an explore page
 - in the inbox
 - on each kind of blog "channel" page
 - on a search page
 - on a tagged page
 - on a "secret dashboard" like https://www.tumblr.com/timeline/trending
 - on a "blogpack" secret dashboard like https://www.tumblr.com/timeline/blogpack?blogs=april,transienturl

Confirm that the sidebar items do not appear:
 - on a settings page in the desktop view (exception: #1115)
 - in the "embedded blog view"

Do it again with ad-free on/off (I did not fully do this; only one of my accounts has ad-free)
