### PR TITLE
Quote Replies: Fix script not functioning

### DIFF
--- a/src/scripts/quote_replies.js
+++ b/src/scripts/quote_replies.js
@@ -16,7 +16,7 @@ const originalPostTagStorageKey = 'quick_tags.preferences.originalPostTag';
 
 const activitySelector = `${keyToCss('notification')} > ${keyToCss('activity')}`;
 
-const activityPageSelector = `section${keyToCss('notifications')} > ${keyToCss('notification')}`;
+const activityPageSelector = `section${keyToCss('notifications')} ${keyToCss('notification')}`;
 const dropdownSelector = `${keyToCss('activityPopover')} > [role="tabpanel"] ${keyToCss('notification')}`;
 
 let originalPostTag;

--- a/src/scripts/quote_replies.js
+++ b/src/scripts/quote_replies.js
@@ -17,7 +17,7 @@ const originalPostTagStorageKey = 'quick_tags.preferences.originalPostTag';
 const activitySelector = `${keyToCss('notification')} > ${keyToCss('activity')}`;
 
 const activityPageSelector = `section${keyToCss('notifications')} > ${keyToCss('notification')}`;
-const dropdownSelector = `${keyToCss('activityPopover')} > [role="tabpanel"] > ${keyToCss('notification')}`;
+const dropdownSelector = `${keyToCss('activityPopover')} > [role="tabpanel"] ${keyToCss('notification')}`;
 
 let originalPostTag;
 let tagReplyingBlog;


### PR DESCRIPTION
For the record, my preference for not hiding the quote replies button on non-hovered activity items was partially so that this kind of thing would have been more obvious and would have been fixed weeks/months ago :D

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes Quote Replies having been completely broken by small changes in the latest update to the activity items. (That I can tell, the extra div element in the dropdown serves no purpose and might have been a "mistake," but whatever :D)

This was not reported by anyone, but was just mentioned in the tags of a few posts! I had not noticed it. Please, anyone who is reading this: if you find that XKit Rewritten is broken by an update, **tell us about it**!

**edit:** resolves #1126

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that Quote Replies buttons appear next to mentions in the activity dropdown menu and on the activity page,

