### PR TITLE
AccessKit Disable Gifs: Use miniature labels on small images

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -4,7 +4,7 @@
   right: 1ch;
 
   height: 1em;
-  padding: 5px;
+  padding: 0.6ch;
   border-radius: 3px;
 
   background-color: rgb(var(--black));
@@ -16,6 +16,10 @@
 
 .xkit-paused-gif-label::before {
   content: "GIF";
+}
+
+.xkit-paused-gif-label.mini {
+  font-size: 0.6rem;
 }
 
 .xkit-paused-gif {

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -18,7 +18,9 @@ const pauseGif = function (gifElement) {
     canvas.getContext('2d').drawImage(image, 0, 0);
 
     const gifLabel = document.createElement('p');
-    gifLabel.className = 'xkit-paused-gif-label';
+    gifLabel.className = gifElement.clientWidth < 150
+      ? 'xkit-paused-gif-label mini'
+      : 'xkit-paused-gif-label';
 
     gifElement.parentNode.append(canvas, gifLabel);
   };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This implements a smaller version of the disable gifs overlay label for use on small images like the previews in the blog card modal.

<img width="317" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/e8250d31-c66b-4149-a276-89b80ff3cd5f">

<img width="301" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/23dc8014-0dcd-4510-9771-61a3d7cbd9ed">

<img width="644" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/d5eda721-7dbb-47a2-8dad-81c81169767f">


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

View paused GIFs in the explore sidebar, in a blog card modal, in the search/tagged page in masonry view, etc. Small images should have small GIF labels; hopefully this should feel natural.

