### PR TITLE
AccessKit Disable Gifs: Apply to animated avatars

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -4,7 +4,7 @@
   right: 1ch;
 
   height: 1em;
-  padding: 5px;
+  padding: 0.6ch;
   border-radius: 3px;
 
   background-color: rgb(var(--black));
@@ -16,6 +16,10 @@
 
 .xkit-paused-gif-label::before {
   content: "GIF";
+}
+
+.xkit-paused-gif-label.mini {
+  font-size: 0.6rem;
 }
 
 .xkit-paused-gif {

--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -22,6 +22,10 @@
   font-size: 0.6rem;
 }
 
+.xkit-paused-gif-label.verymini {
+  font-size: 0.3rem;
+}
+
 .xkit-paused-gif {
   position: absolute;
   visibility: visible;

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -18,9 +18,11 @@ const pauseGif = function (gifElement) {
     canvas.getContext('2d').drawImage(image, 0, 0);
 
     const gifLabel = document.createElement('p');
-    gifLabel.className = gifElement.clientWidth < 150
-      ? 'xkit-paused-gif-label mini'
-      : 'xkit-paused-gif-label';
+    gifLabel.className = gifElement.clientWidth < 30
+      ? 'xkit-paused-gif-label verymini'
+      : gifElement.clientWidth < 150
+        ? 'xkit-paused-gif-label mini'
+        : 'xkit-paused-gif-label';
 
     gifElement.parentNode.append(canvas, gifLabel);
   };

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -78,7 +78,7 @@ const processRows = function (rowsElements) {
 export const main = async function () {
   document.body.classList.add(className);
   const gifImage = `
-    :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img[srcset*=".gif"]:not(${keyToCss('poster')})
+    :is(figure, ${keyToCss('tagImage', 'takeoverBanner', 'avatar')}) :is(img[srcset*=".gif"], img[srcset*=".webp"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
 

--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -18,7 +18,9 @@ const pauseGif = function (gifElement) {
     canvas.getContext('2d').drawImage(image, 0, 0);
 
     const gifLabel = document.createElement('p');
-    gifLabel.className = 'xkit-paused-gif-label';
+    gifLabel.className = gifElement.clientWidth < 150
+      ? 'xkit-paused-gif-label mini'
+      : 'xkit-paused-gif-label';
 
     gifElement.parentNode.append(canvas, gifLabel);
   };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This applies AccessKit Disable Gifs to animated WebP user avatars.

(Needs some more testing and probably cleanup of the mini label code).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

