### PR TITLE
New Tweak: Force the default dashboard tab to "Following"

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -102,6 +102,11 @@
       "type": "checkbox",
       "label": "Hide the Tumblr Live carousel",
       "default": false
+    },
+    "following_tab": {
+      "type": "checkbox",
+      "label": "Force the \"Following\" dashboard tab to be the default",
+      "default": false
     }
   }
 }

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -105,7 +105,7 @@
     },
     "following_tab": {
       "type": "checkbox",
-      "label": "Force the \"Following\" dashboard tab to be the default",
+      "label": "Force the default dashboard tab to \"Following\"",
       "default": false
     }
   }

--- a/src/scripts/tweaks/following_tab.js
+++ b/src/scripts/tweaks/following_tab.js
@@ -1,0 +1,25 @@
+import { navigate } from '../../util/tumblr_helpers.js';
+
+const attemptRedirect = () => {
+  if (
+    ['/dashboard', '/'].includes(location.pathname) &&
+    document.querySelector('main > [data-timeline^="/v2/tabs/for_you"]')
+  ) {
+    navigate('/dashboard/following');
+  }
+};
+const observer = new MutationObserver(attemptRedirect);
+
+export const main = async function () {
+  attemptRedirect();
+
+  observer.observe(document.getElementById('root'), {
+    childList: true,
+    subtree: true,
+    attributeFilter: ['data-timeline']
+  });
+};
+
+export const clean = async function () {
+  observer.disconnect();
+};

--- a/src/scripts/tweaks/following_tab.js
+++ b/src/scripts/tweaks/following_tab.js
@@ -4,8 +4,8 @@ const attemptRedirect = () => {
   if (
     ['/dashboard', '/'].includes(location.pathname) &&
     document
-      .querySelector('main')
-      ?.querySelector(':scope > [data-timeline^="/v2/tabs/for_you"]')
+      .querySelector('main > [data-timeline]')
+      ?.matches('[data-timeline^="/v2/tabs/for_you"]')
   ) {
     navigate('/dashboard/following');
   }

--- a/src/scripts/tweaks/following_tab.js
+++ b/src/scripts/tweaks/following_tab.js
@@ -3,7 +3,9 @@ import { navigate } from '../../util/tumblr_helpers.js';
 const attemptRedirect = () => {
   if (
     ['/dashboard', '/'].includes(location.pathname) &&
-    document.querySelector('main > [data-timeline^="/v2/tabs/for_you"]')
+    document
+      .querySelector('main')
+      ?.querySelector(':scope > [data-timeline^="/v2/tabs/for_you"]')
   ) {
     navigate('/dashboard/following');
   }


### PR DESCRIPTION
Is Staff planning to add a feature that makes your first dashboard tab customizable **and the default** (or that remembers your last-selected dashboard tab or something) any time soon? If yes, this is obviously pointless. I, however, was not sure if that was the implication of

> We are also working on making dashboard tabs even more customizable, including adding the ability to choose which tab appears first.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds a tweak that forces navigation to tumblr.com and tumblr.com/dashboard to actually point to the "Following" dashboard tab instead of the "For You" dashboard tab, as it does for accounts created after May 8th, 2023.

I will probably publish an equivalent to this as a userscript (already written) and then no-op it when it is no longer needed if we don't want to add it to XKit and the behavior is not expected to be implemented natively soon.

Resolves #1158

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Load the new tweak on a blog created after May 8th, 2023.

 - Open a tab at tumblr.com
 - Open a tab at tumblr.com/dashboard
 - Navigate to the dashboard from a non-dash page via clicking the Tumblr logo
 - Navigate to the dashboard from a non-dash page via clicking the home icon
 - Navigate to the dashboard from a different dashboard tab via clicking the Tumblr logo
 - Navigate to the dashboard from a different dashboard tab via clicking the home icon

Also, perform the above actions in the mobile layout.

In each case, it should appear that the "Following" tab is the target of said navigation actions.


