### PR TITLE
Tweaks: Prevent hiding pending blaze status label

### DIFF
--- a/src/scripts/tweaks/hide_blaze_tip_labels.js
+++ b/src/scripts/tweaks/hide_blaze_tip_labels.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
-article ${keyToCss('igniteButton', 'tippingButton')} > ${keyToCss('label')} {
+article ${keyToCss('igniteButton', 'tippingButton')} > svg:not([style*="#ff8a00"]) ~ ${keyToCss('label')} {
   display: none;
 }
 `);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This excludes the label following an ~~active~~ pending blaze button from the "Hide the 'blaze' and 'tip' button labels" tweak.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

You know what, I don't actually know how one would easily test this. But, hypothetically: enable the relevant tweak, blaze a post, and check that the label indicating that it is pending is visible while other labels continue to be hidden.
