### PR TITLE
New Tweak: Hide the home/following notification badge

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -93,6 +93,11 @@
       "label": "Hide the activity notification badge",
       "default": false
     },
+    "hide_following_notification_badge": {
+      "type": "checkbox",
+      "label": "Hide the home/following notification badge",
+      "default": false
+    },
     "no_where_were_we": {
       "type": "checkbox",
       "label": "Hide the \"Now, where were we?\" button",

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -93,14 +93,14 @@
       "label": "Hide my follower count where possible",
       "default": false
     },
-    "hide_activity_notification_badge": {
-      "type": "checkbox",
-      "label": "Hide the activity notification badge",
-      "default": false
-    },
     "hide_following_notification_badge": {
       "type": "checkbox",
       "label": "Hide the home/following notification badge",
+      "default": false
+    },
+    "hide_activity_notification_badge": {
+      "type": "checkbox",
+      "label": "Hide the activity notification badge",
       "default": false
     },
     "no_where_were_we": {

--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -95,12 +95,12 @@
     },
     "hide_following_notification_badge": {
       "type": "checkbox",
-      "label": "Hide the home/following notification badge",
+      "label": "Hide the Home/Following unread badge",
       "default": false
     },
     "hide_activity_notification_badge": {
       "type": "checkbox",
-      "label": "Hide the activity notification badge",
+      "label": "Hide the Activity notification badge",
       "default": false
     },
     "no_where_were_we": {

--- a/src/scripts/tweaks/hide_following_notification_badge.js
+++ b/src/scripts/tweaks/hide_following_notification_badge.js
@@ -1,0 +1,18 @@
+import { keyToCss } from '../../util/css_map.js';
+import { buildStyle } from '../../util/interface.js';
+import { translate } from '../../util/language_data.js';
+
+const followingHomeButton = `:is(li[title="${translate('Home')}"], button[aria-label="${translate('Home')}"], a[href="/dashboard/following"])`;
+
+const styleElement = buildStyle(`
+${followingHomeButton} {
+  outline: 1px solid red;
+  outline-offset: -1px;
+}
+${followingHomeButton} ${keyToCss('notificationBadge')} {
+  display: none;
+}
+`);
+
+export const main = async () => document.documentElement.append(styleElement);
+export const clean = async () => styleElement.remove();

--- a/src/scripts/tweaks/hide_following_notification_badge.js
+++ b/src/scripts/tweaks/hide_following_notification_badge.js
@@ -5,10 +5,6 @@ import { translate } from '../../util/language_data.js';
 const followingHomeButton = `:is(li[title="${translate('Home')}"], button[aria-label="${translate('Home')}"], a[href="/dashboard/following"])`;
 
 const styleElement = buildStyle(`
-${followingHomeButton} {
-  outline: 1px solid red;
-  outline-offset: -1px;
-}
 ${followingHomeButton} ${keyToCss('notificationBadge')} {
   display: none;
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Similar to the the tweak that hides the notification badge for activity, this adds one that hides the notification badge for new posts on your chronological dashboard (following feed/home button). I've wanted this for years, people assume the activity one does this already, and it's particularly relevant as people are using it as a specific criticism of the vertical nav layout.

I am actually... confused? because I currently only see the badge in question appearing in the vertical nav layout? But a) I remember wanting this for ages so it must have been a thing, and b) the linked discussion definitely implies that it was a thing very recently?

Resolves #1132.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that the badges in both the vertical nav layout's "home" nav item and "following" dashboard tab bar tab are hidden by this tweak.
- Confirm that the badge in the mobile layout's "home" nav item... would be if it existed(?????)
- Confirm that the badge in the non-vertical-nav-layout's "home" header button... would be if it existed(?????)

