### PR TITLE
Collapsed Queue: Prevent running with no options selected

### DIFF
--- a/src/scripts/collapsed_queue.js
+++ b/src/scripts/collapsed_queue.js
@@ -28,6 +28,8 @@ const processPosts = async function (postElements) {
 
 export const main = async function () {
   const { runInQueue, runInDrafts } = await getPreferences('collapsed_queue');
+  if (![runInQueue, runInDrafts].some(Boolean)) return;
+
   const regexGroup = [
     ...runInQueue ? ['queue'] : [],
     ...runInDrafts ? ['draft'] : []


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This ensures that Collapsed Queue only runs in the desired locations, even when no locations are selected.

I couldn't think of a way to do this using regular expressions besides adding an obviously-invalid string to the array of alternate matches, which would have been less clear in meaning than this.

Resolves #1174.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that all four combinations of selected options (none, drafts, queue, both) correctly do or do not cause the script to be active on the queue and drafts page.

