### PR TITLE
Tweaks: Fix Live carousel tweak on "for you" default accounts

### DIFF
--- a/src/scripts/tweaks/no_live.js
+++ b/src/scripts/tweaks/no_live.js
@@ -12,7 +12,7 @@ const processFrames = frames =>
 
 export const main = async function () {
   pageModifications.register(
-    `[data-timeline="/v2/timeline/dashboard"] :is(iframe[src^="https://api.gateway.tumblr-live.com/"], ${keyToCss('liveMarqueeContainer', 'liveMarqueeTitle')})`,
+    `:is(iframe[src^="https://api.gateway.tumblr-live.com/"], ${keyToCss('liveMarqueeContainer', 'liveMarqueeTitle')})`,
     processFrames
   );
   document.documentElement.append(styleElement);

--- a/src/scripts/tweaks/no_live.js
+++ b/src/scripts/tweaks/no_live.js
@@ -12,7 +12,7 @@ const processFrames = frames =>
 
 export const main = async function () {
   pageModifications.register(
-    `[data-timeline="/v2/timeline/dashboard"] :is(iframe[src^="https://api.gateway.tumblr-live.com/"], ${keyToCss('liveMarqueeContainer', 'liveMarqueeTitle')})`,
+    `:is([data-timeline="/v2/timeline/dashboard"], [data-timeline^="/v2/tabs/for_you"]) :is(iframe[src^="https://api.gateway.tumblr-live.com/"], ${keyToCss('liveMarqueeContainer', 'liveMarqueeTitle')})`,
     processFrames
   );
   document.documentElement.append(styleElement);

--- a/src/scripts/tweaks/no_live.js
+++ b/src/scripts/tweaks/no_live.js
@@ -12,7 +12,7 @@ const processFrames = frames =>
 
 export const main = async function () {
   pageModifications.register(
-    `:is([data-timeline="/v2/timeline/dashboard"], [data-timeline^="/v2/tabs/for_you"]) :is(iframe[src^="https://api.gateway.tumblr-live.com/"], ${keyToCss('liveMarqueeContainer', 'liveMarqueeTitle')})`,
+    `[data-timeline="/v2/timeline/dashboard"] :is(iframe[src^="https://api.gateway.tumblr-live.com/"], ${keyToCss('liveMarqueeContainer', 'liveMarqueeTitle')})`,
     processFrames
   );
   document.documentElement.append(styleElement);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

On accounts created after May 8th, 2023, the default tab is "for you" and thus the Live carousel appears on the "for you" tab. I was previously overly cautious (e.g. in case Staff added some sort of Live-specific tab where this carousel was important; there is precedent for this with e.g. the blog subs tab and its blog carousel) and only made the Live tweak active on the following tab, which caused it to be inactive on these accounts.

This removes the timeline check, ensuring that the carousel is hidden on any tab. This seems prudent if the default tab may become customizable.

Resolves #1180.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Log into an account with the "for you" tab as the default.
- Confirm that the "hide the Live carousel" tweak works on https://www.tumblr.com/ and https://www.tumblr.com/dashboard/stuff_for_you.
- Log into an account with the "following" tab as the default and confirm that the tweak still works.

