### PR TITLE
CleanFeed: Add option to treat specified tags as mature

### DIFF
--- a/src/scripts/cleanfeed.js
+++ b/src/scripts/cleanfeed.js
@@ -23,14 +23,17 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
 
   const { blog: { name, isAdult }, communityLabels, trail, tags } = await timelineObject(postElement);
 
-  if (isAdult || communityLabels.hasCommunityLabel || localFlaggedBlogs.includes(name) || localFlaggedTags.some(t => tags.includes(t))) {
+  if (isAdult ||
+      communityLabels.hasCommunityLabel ||
+      localFlaggedBlogs.includes(name) ||
+      localFlaggedTags.some(t => tags.map(tag => tag.toLowerCase()).includes(t))) {
     postElement.classList.add(hiddenClass);
     return;
   }
 
   const reblogs = postElement.querySelectorAll(reblogSelector);
   trail.forEach((trailItem, i) => {
-    if (trailItem.blog?.isAdult || localFlaggedBlogs.includes(trailItem.blog?.name || localFlaggedTags.some(t => trailItem.tags?.includes(t)))) {
+    if (trailItem.blog?.isAdult || localFlaggedBlogs.includes(trailItem.blog?.name)) {
       reblogs[i].classList.add(hiddenClass);
     }
   });
@@ -38,8 +41,8 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
 
 export const main = async function () {
   ({ blockingMode, localBlogFlagging, localTagFlagging } = await getPreferences('cleanfeed'));
-  localFlaggedBlogs = localBlogFlagging.split(',').map(username => username.trim());
-  localFlaggedTags = localTagFlagging.split(',').map(tag => tag.trim());
+  localFlaggedBlogs = localBlogFlagging.toLowerCase().split(',').map(username => username.trim());
+  localFlaggedTags = localTagFlagging.toLowerCase().split(',').map(tag => tag.replace(/\#/gi, '').trim());
 
   styleElement.textContent = localFlaggedBlogs
     .map(username => `[title="${username}"] img[alt="${translate('Avatar')}"] { filter: blur(20px); }`)

--- a/src/scripts/cleanfeed.js
+++ b/src/scripts/cleanfeed.js
@@ -42,7 +42,7 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
 export const main = async function () {
   ({ blockingMode, localBlogFlagging, localTagFlagging } = await getPreferences('cleanfeed'));
   localFlaggedBlogs = localBlogFlagging.toLowerCase().split(',').map(username => username.trim());
-  localFlaggedTags = localTagFlagging.toLowerCase().split(',').map(tag => tag.replace(/#/gi, '').trim());
+  localFlaggedTags = localTagFlagging.toLowerCase().split(',').map(tag => tag.replaceAll('#', '').trim());
 
   styleElement.textContent = localFlaggedBlogs
     .map(username => `[title="${username}"] img[alt="${translate('Avatar')}"] { filter: blur(20px); }`)

--- a/src/scripts/cleanfeed.js
+++ b/src/scripts/cleanfeed.js
@@ -41,8 +41,8 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
 
 export const main = async function () {
   ({ blockingMode, localBlogFlagging, localTagFlagging } = await getPreferences('cleanfeed'));
-  localFlaggedBlogs = localBlogFlagging.toLowerCase().split(',').map(username => username.trim());
-  localFlaggedTags = localTagFlagging.toLowerCase().split(',').map(tag => tag.replaceAll('#', '').trim());
+  localFlaggedBlogs = localBlogFlagging.split(',').map(username => username.trim().toLowerCase());
+  localFlaggedTags = localTagFlagging.split(',').map(tag => tag.replaceAll('#', '').trim().toLowerCase());
 
   styleElement.textContent = localFlaggedBlogs
     .map(username => `[title="${username}"] img[alt="${translate('Avatar')}"] { filter: blur(20px); }`)

--- a/src/scripts/cleanfeed.js
+++ b/src/scripts/cleanfeed.js
@@ -42,7 +42,7 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
 export const main = async function () {
   ({ blockingMode, localBlogFlagging, localTagFlagging } = await getPreferences('cleanfeed'));
   localFlaggedBlogs = localBlogFlagging.toLowerCase().split(',').map(username => username.trim());
-  localFlaggedTags = localTagFlagging.toLowerCase().split(',').map(tag => tag.replace(/\#/gi, '').trim());
+  localFlaggedTags = localTagFlagging.toLowerCase().split(',').map(tag => tag.replace(/#/gi, '').trim());
 
   styleElement.textContent = localFlaggedBlogs
     .map(username => `[title="${username}"] img[alt="${translate('Avatar')}"] { filter: blur(20px); }`)

--- a/src/scripts/cleanfeed.json
+++ b/src/scripts/cleanfeed.json
@@ -21,7 +21,7 @@
     "localBlogFlagging": {
       "label": "Treat these blogs as mature (comma-separated)",
       "type": "textarea",
-      "default": ""
+      "default": "",
       "inherit": "cleanfeed.preferences.localFlagging"
     },
     "localTagFlagging": {

--- a/src/scripts/cleanfeed.json
+++ b/src/scripts/cleanfeed.json
@@ -18,10 +18,15 @@
       ],
       "default": "smart"
     },
-    "localFlagging": {
+    "localBlogFlagging": {
       "label": "Treat these blogs as mature (comma-separated)",
       "type": "textarea",
       "default": ""
+    },
+    "localTagFlagging": {
+      "label": "Treat these tags as mature (comma-separated)",
+      "type": "textarea",
+      "default": "nsfw, nsft"
     }
   }
 }

--- a/src/scripts/cleanfeed.json
+++ b/src/scripts/cleanfeed.json
@@ -22,6 +22,7 @@
       "label": "Treat these blogs as mature (comma-separated)",
       "type": "textarea",
       "default": ""
+      "inherit": "cleanfeed.preferences.localFlagging"
     },
     "localTagFlagging": {
       "label": "Treat these tags as mature (comma-separated)",


### PR DESCRIPTION
### Description
Resolves [#1178](https://github.com/AprilSylph/XKit-Rewritten/issues/1178)
Adds an option to treat specified tags as mature in the same way specified blogs can be treated as mature

### Testing steps
Add a tag to the text field in the CleanFeed options and view a post with said tag

