### PR TITLE
Implement feature deprecation

### DIFF
--- a/docs/Chapter 4.1 - Feature manifests.md
+++ b/docs/Chapter 4.1 - Feature manifests.md
@@ -103,3 +103,9 @@ If the preference `type` is `"select"`, this value should be a string that match
 - Required: No
 
 The storage key to inherit the value of, if the preference has not been set. Only to be used when moving preferences between scripts; the storage key specified here will be deleted in the process.
+
+### `"deprecated"`
+- Type: Boolean
+- Required: No
+
+Whether to hide the feature on installations on which it has never been enabled.

--- a/docs/Chapter 4.1 - Feature manifests.md
+++ b/docs/Chapter 4.1 - Feature manifests.md
@@ -108,4 +108,4 @@ The storage key to inherit the value of, if the preference has not been set. Onl
 - Type: Boolean
 - Required: No
 
-Whether to hide the feature on installations on which it has never been enabled.
+Whether to hide the feature on installations on which it was not enabled at the time of deprecation.

--- a/src/browser_action/configuration.css
+++ b/src/browser_action/configuration.css
@@ -144,6 +144,12 @@ label[for="filter"] {
   font-weight: normal;
 }
 
+.script:not(.disabled)[data-deprecated="true"] .title::after {
+  content: "(deprecated)";
+  margin-left: 0.5ch;
+  font-weight: normal;
+}
+
 .script ul.preferences {
   padding: 0 1ch;
   margin: 1ch 0;

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -137,12 +137,13 @@ const renderScripts = async function () {
   for (const scriptName of [...orderedEnabledScripts, ...disabledScripts]) {
     const url = getURL(`/scripts/${scriptName}.json`);
     const file = await fetch(url);
-    const { title = scriptName, description = '', icon = {}, help = '', relatedTerms = [], preferences = {}, deprecated } = await file.json();
+    const { title = scriptName, description = '', icon = {}, help = '', relatedTerms = [], preferences = {}, deprecated = false } = await file.json();
 
     const scriptTemplateClone = document.getElementById('script').content.cloneNode(true);
 
     const detailsElement = scriptTemplateClone.querySelector('details.script');
     detailsElement.dataset.relatedTerms = relatedTerms;
+    detailsElement.dataset.deprecated = deprecated;
 
     if (enabledScripts.includes(scriptName) === false) {
       detailsElement.classList.add('disabled');

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -151,7 +151,7 @@ const renderScripts = async function () {
       detailsElement.classList.add('disabled');
 
       if (deprecated && !specialAccess.includes(scriptName)) {
-        detailsElement.hidden = true;
+        continue;
       }
     }
 

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -131,7 +131,6 @@ const renderScripts = async function () {
   scriptsDiv.textContent = '';
 
   const installedScripts = await getInstalledScripts();
-
   const { enabledScripts = [], specialAccess = [] } = await browser.storage.local.get();
 
   const orderedEnabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName));

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -129,8 +129,7 @@ const renderScripts = async function () {
 
   const installedScripts = await getInstalledScripts();
 
-  const storageLocal = await browser.storage.local.get();
-  const { enabledScripts = [], previouslyEnabledScripts = [] } = storageLocal;
+  const { enabledScripts = [], previouslyEnabledScripts = [] } = await browser.storage.local.get();
 
   const orderedEnabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName));
   const disabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName) === false);
@@ -148,11 +147,7 @@ const renderScripts = async function () {
     if (enabledScripts.includes(scriptName) === false) {
       detailsElement.classList.add('disabled');
 
-      if (
-        deprecated &&
-        !previouslyEnabledScripts.includes(scriptName) &&
-        !Object.keys(storageLocal).some(key => key.startsWith(`${scriptName}.`))
-      ) {
+      if (deprecated && !previouslyEnabledScripts.includes(scriptName)) {
         detailsElement.hidden = true;
       }
     }

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -129,7 +129,8 @@ const renderScripts = async function () {
 
   const installedScripts = await getInstalledScripts();
 
-  const { enabledScripts = [], previouslyEnabledScripts = [] } = await browser.storage.local.get();
+  const storageLocal = await browser.storage.local.get();
+  const { enabledScripts = [], previouslyEnabledScripts = [] } = storageLocal;
 
   const orderedEnabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName));
   const disabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName) === false);
@@ -147,7 +148,11 @@ const renderScripts = async function () {
     if (enabledScripts.includes(scriptName) === false) {
       detailsElement.classList.add('disabled');
 
-      if (deprecated && !previouslyEnabledScripts.includes(scriptName)) {
+      if (
+        deprecated &&
+        !previouslyEnabledScripts.includes(scriptName) &&
+        !Object.keys(storageLocal).some(key => key.startsWith(`${scriptName}.`))
+      ) {
         // detailsElement.hidden = true;
         detailsElement.style.outline = '2px solid red';
         detailsElement.style.outlineOffset = '-2px';

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -153,9 +153,7 @@ const renderScripts = async function () {
         !previouslyEnabledScripts.includes(scriptName) &&
         !Object.keys(storageLocal).some(key => key.startsWith(`${scriptName}.`))
       ) {
-        // detailsElement.hidden = true;
-        detailsElement.style.outline = '2px solid red';
-        detailsElement.style.outlineOffset = '-2px';
+        detailsElement.hidden = true;
       }
     }
 

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -127,7 +127,9 @@ const renderScripts = async function () {
   scriptsDiv.textContent = '';
 
   const installedScripts = await getInstalledScripts();
-  const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
+
+  const storageLocal = await browser.storage.local.get();
+  const { enabledScripts = [] } = storageLocal;
 
   const orderedEnabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName));
   const disabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName) === false);
@@ -135,7 +137,7 @@ const renderScripts = async function () {
   for (const scriptName of [...orderedEnabledScripts, ...disabledScripts]) {
     const url = getURL(`/scripts/${scriptName}.json`);
     const file = await fetch(url);
-    const { title = scriptName, description = '', icon = {}, help = '', relatedTerms = [], preferences = {} } = await file.json();
+    const { title = scriptName, description = '', icon = {}, help = '', relatedTerms = [], preferences = {}, deprecated } = await file.json();
 
     const scriptTemplateClone = document.getElementById('script').content.cloneNode(true);
 
@@ -144,6 +146,12 @@ const renderScripts = async function () {
 
     if (enabledScripts.includes(scriptName) === false) {
       detailsElement.classList.add('disabled');
+
+      if (deprecated && !Object.keys(storageLocal).some(key => key.startsWith(`${scriptName}.`))) {
+        // detailsElement.hidden = true;
+        detailsElement.style.outline = '2px solid red';
+        detailsElement.style.outlineOffset = '-2px';
+      }
     }
 
     if (icon.class_name !== undefined) {

--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -15,7 +15,7 @@ const getInstalledScripts = async function () {
 const writeEnabled = async function ({ currentTarget }) {
   const { checked, id } = currentTarget;
   const detailsElement = currentTarget.closest('details');
-  let { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
+  let { enabledScripts = [], previouslyEnabledScripts = [] } = await browser.storage.local.get();
 
   const hasPreferences = detailsElement.querySelector('.preferences:not(:empty)');
   if (hasPreferences) detailsElement.open = checked;
@@ -25,10 +25,11 @@ const writeEnabled = async function ({ currentTarget }) {
     detailsElement.classList.remove('disabled');
   } else {
     enabledScripts = enabledScripts.filter(x => x !== id);
+    previouslyEnabledScripts.includes(id) || previouslyEnabledScripts.push(id);
     detailsElement.classList.add('disabled');
   }
 
-  browser.storage.local.set({ enabledScripts });
+  browser.storage.local.set({ enabledScripts, previouslyEnabledScripts });
 };
 
 const debounce = (func, ms) => {
@@ -128,8 +129,7 @@ const renderScripts = async function () {
 
   const installedScripts = await getInstalledScripts();
 
-  const storageLocal = await browser.storage.local.get();
-  const { enabledScripts = [] } = storageLocal;
+  const { enabledScripts = [], previouslyEnabledScripts = [] } = await browser.storage.local.get();
 
   const orderedEnabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName));
   const disabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName) === false);
@@ -147,7 +147,7 @@ const renderScripts = async function () {
     if (enabledScripts.includes(scriptName) === false) {
       detailsElement.classList.add('disabled');
 
-      if (deprecated && !Object.keys(storageLocal).some(key => key.startsWith(`${scriptName}.`))) {
+      if (deprecated && !previouslyEnabledScripts.includes(scriptName)) {
         // detailsElement.hidden = true;
         detailsElement.style.outline = '2px solid red';
         detailsElement.style.outlineOffset = '-2px';

--- a/src/scripts/timestamps.json
+++ b/src/scripts/timestamps.json
@@ -33,5 +33,6 @@
       ],
       "default": "op"
     }
-  }
+  },
+  "deprecated": true
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

resolves #1058

As per the linked issue and the discussion in its comments, this adds a "deprecated" property to script manifests that will hide them unless they're enabled at the time of deprecation (still ironing out details as I write this), and deprecates Timestamps.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Load a branch without this PR.
- Optionally, enable and then disable and/or play with the settings of Timestamps.
- Switch to a branch with this PR.
- Confirm that Timestamps disappears from XKit's preferences.

Restart with clean storage. (I ctrl-c'd `npm start`; importing `{}` into the backup interface doesn't currently wipe your storage.)

- Load a branch without this PR.
- Enable Timestamps.
- Switch to a branch with this PR.
- Confirm that Timestamps still appears in XKit's preferences.
- Disable Timestamps.
- Confirm that Timestamps still appears in XKit's preferences.


