### PR TITLE
Popup: Add standalone control panel link

### DIFF
--- a/src/browser_action/links.css
+++ b/src/browser_action/links.css
@@ -1,7 +1,5 @@
 #links {
   position: relative;
-
-  margin: 1em 0;
   padding: 0 1em;
 }
 

--- a/src/browser_action/popup.css
+++ b/src/browser_action/popup.css
@@ -57,11 +57,23 @@ body {
   user-select: none;
 }
 
+body.standalone {
+  width: 100%;
+  max-width: 632px;
+  margin: 1ch auto;
+
+  outline: 1px solid rgb(var(--active-grey));
+}
+
 #embedded-banner {
   padding: 4px 8px;
   border-bottom: 1px solid rgb(var(--active-grey));
 
   text-align: center;
+}
+
+body:not(.embedded) #embedded-banner {
+  display: none;
 }
 
 nav {
@@ -154,4 +166,17 @@ label:not(:first-child),
 input:not(:first-child),
 select:not(:first-child) {
   margin-left: 1ch;
+}
+
+#non-standalone-footer {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 1ch;
+
+  border-top: 1px dotted rgb(var(--active-grey));
+}
+
+body.standalone #non-standalone-footer {
+  display: none;
 }

--- a/src/browser_action/popup.html
+++ b/src/browser_action/popup.html
@@ -15,7 +15,7 @@
     <link rel="stylesheet" href="links.css">
   </head>
   <body>
-    <header id="embedded-banner" hidden>XKit Rewritten can also be configured via the button in the browser toolbar.</header>
+    <header id="embedded-banner">XKit Rewritten can also be configured via the button in the browser toolbar.</header>
     <main>
       <nav>
         <a href="#configuration" role="button" class="selected">Configuration</a>
@@ -75,6 +75,9 @@
           <li><a href="https://github.com/AprilSylph/Outbox-for-Tumblr#readme" target="_blank">Outbox for Tumblr</a></li>
           <li><a href="https://github.com/AprilSylph/Filtering-Plus#readme" target="_blank">Filtering+ for Tumblr</a></li>
         </ul>
+        <footer id="non-standalone-footer">
+          <a href="popup.html?standalone=true" target="_blank">open control panel in a tab <i class="ri-external-link-line"></i></a>
+        </footer>
       </section>
     </main>
 

--- a/src/browser_action/popup.js
+++ b/src/browser_action/popup.js
@@ -56,5 +56,9 @@ const versionElement = document.getElementById('version');
 versionElement.textContent = browser.runtime.getManifest().version;
 
 const params = new URLSearchParams(location.search);
-const pageIsEmbedded = params.get('embedded') === 'true';
-document.getElementById('embedded-banner').hidden = !pageIsEmbedded;
+if (params.get('embedded') === 'true') {
+  document.body.classList.add('embedded');
+}
+if (params.get('standalone') === 'true') {
+  document.body.classList.add('standalone');
+}


### PR DESCRIPTION
Just an idea I had.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
| | |
| - | - |
| <img width="994" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/5e47a697-418f-4d80-9a68-a1b3ddd79e92"> | <img width="994" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/bbdfea90-7eb1-4fab-9393-286235c99ccf"> |

This adds a link to the XKit Rewritten control panel that opens it in a new tab, useful for e.g. copying lots of tag bundles from XKit 7.

Obviously (to us), what this provides is a duplicate of the feature in the browser's extension preferences page to open the control panel embedded there, but a) most people don't know about that, and maybe more people will find this version, and b) Chromium's version of the embedded preference pane kinda sucks. Yes, yes, Firefox best bae etc.

Bonus points for the ability to use inspect element on the preference pane without the shadow DOM getting in the way.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

