### PR TITLE
Show Originals: Fix basic functionality with "virtual scroller" experiment

### DIFF
--- a/src/scripts/show_originals.css
+++ b/src/scripts/show_originals.css
@@ -1,4 +1,4 @@
-[data-show-originals="on"] ~ .xkit-show-originals-hidden article {
+[data-show-originals="on"] ~ [data-timeline] .xkit-show-originals-hidden article {
   display: none;
 }
 

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -1,4 +1,4 @@
-import { filterPostElements, postSelector, blogViewSelector } from '../util/interface.js';
+import { filterPostElements, blogViewSelector } from '../util/interface.js';
 import { isMyPost, timelineObject } from '../util/react_props.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
@@ -34,10 +34,7 @@ const addControls = async (timelineElement, location) => {
   const controls = Object.assign(document.createElement('div'), { className: controlsClass });
   controls.dataset.location = location;
 
-  const firstPost = timelineElement.querySelector(postSelector);
-  location === 'blogSubscriptions'
-    ? firstPost?.before(controls)
-    : firstPost?.parentElement?.prepend(controls);
+  timelineElement.before(controls);
 
   const handleClick = async ({ currentTarget: { dataset: { mode } } }) => {
     controls.dataset.showOriginals = mode;
@@ -87,7 +84,7 @@ const processTimelines = async () => {
   [...document.querySelectorAll('[data-timeline]')].forEach(async timelineElement => {
     const location = getLocation(timelineElement);
 
-    const currentControls = timelineElement.querySelector(`.${controlsClass}`);
+    const currentControls = timelineElement.parentElement.querySelector(`.${controlsClass}`);
     if (currentControls?.dataset?.location !== location) {
       currentControls?.remove();
       if (location) addControls(timelineElement, location);

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -84,7 +84,10 @@ const processTimelines = async () => {
   [...document.querySelectorAll('[data-timeline]')].forEach(async timelineElement => {
     const location = getLocation(timelineElement);
 
-    const currentControls = timelineElement.parentElement.querySelector(`.${controlsClass}`);
+    const currentControls = timelineElement.previousElementSibling?.classList?.contains(controlsClass)
+      ? timelineElement.previousElementSibling
+      : null;
+
     if (currentControls?.dataset?.location !== location) {
       currentControls?.remove();
       if (location) addControls(timelineElement, location);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This moves Show Originals' control element out of (above) the timeline element to avoid issues with the "virtual scroller" Tumblr feature.

This is a UI change on pages like https://www.tumblr.com/timeline/blog_subscriptions, but I don't think it's a big deal.

Not completely addressed: #1196. There is still a bunch of scrollbar thrashing that I'll have to investigate. This makes the feature work, though.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

