### PR TITLE
Fix/improve content hiding with "virtual scroller" experiment

### DIFF
--- a/src/scripts/anti_capitalism.js
+++ b/src/scripts/anti_capitalism.js
@@ -1,5 +1,5 @@
 import { keyToCss } from '../util/css_map.js';
-import { buildStyle, closestTimelineItem } from '../util/interface.js';
+import { buildStyle, getTimelineItemWrapper } from '../util/interface.js';
 import { pageModifications } from '../util/mutations.js';
 
 const hiddenAttribute = 'data-anti-capitalism-hidden';
@@ -14,7 +14,7 @@ ${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd',
 );
 
 const processVideoCTAs = videoCTAs => videoCTAs
-  .map(closestTimelineItem)
+  .map(getTimelineItemWrapper)
   .filter(Boolean)
   .forEach(timelineItem => timelineItem.setAttribute(hiddenAttribute, ''));
 

--- a/src/scripts/anti_capitalism.js
+++ b/src/scripts/anti_capitalism.js
@@ -1,30 +1,36 @@
 import { keyToCss } from '../util/css_map.js';
-import { buildStyle } from '../util/interface.js';
+import { buildStyle, closestTimelineItem } from '../util/interface.js';
 import { pageModifications } from '../util/mutations.js';
 
-const hiddenClass = 'xkit-anti-capitalism-hidden';
+const hiddenAttribute = 'data-anti-capitalism-hidden';
 
 const listTimelineObjectInnerSelector = keyToCss('listTimelineObjectInner');
 
 const styleElement = buildStyle(`
-.${hiddenClass},
+[${hiddenAttribute}] > div,
 ${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner')} {
   display: none !important;
 }`
 );
 
 const processVideoCTAs = videoCTAs => videoCTAs
-  .map(videoCTA => videoCTA.closest(listTimelineObjectInnerSelector))
+  .map(closestTimelineItem)
   .filter(Boolean)
-  .forEach(({ classList }) => classList.add(hiddenClass));
+  .forEach(timelineItem => timelineItem.setAttribute(hiddenAttribute, ''));
 
 export const main = async () => {
   document.documentElement.append(styleElement);
-  pageModifications.register(`${listTimelineObjectInnerSelector}:first-child ${keyToCss('videoCTA', 'videoImageCTA')}`, processVideoCTAs);
+  pageModifications.register(
+    `
+      ${listTimelineObjectInnerSelector}:first-child ${keyToCss('videoCTA', 'videoImageCTA')},
+      ${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner')}
+    `,
+    processVideoCTAs
+  );
 };
 
 export const clean = async () => {
   pageModifications.unregister(processVideoCTAs);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };

--- a/src/scripts/mutual_checker.css
+++ b/src/scripts/mutual_checker.css
@@ -7,6 +7,6 @@ svg.xkit-mutual-icon {
 	margin-right: 0.5ch;
 }
 
-[data-timeline="/v2/timeline/dashboard"] .xkit-mutual-checker-hidden article {
+[data-timeline="/v2/timeline/dashboard"] [data-mutual-checker-hidden] article {
   display: none;
 }

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -1,4 +1,4 @@
-import { closestTimelineItem, filterPostElements } from '../util/interface.js';
+import { getTimelineItemWrapper, filterPostElements } from '../util/interface.js';
 import { timelineObject } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { primaryBlogName } from '../util/user.js';
@@ -61,7 +61,7 @@ const addIcons = function (postElements) {
       postElement.classList.add(mutualsClass);
       postAttribution.prepend(icon.cloneNode(true));
     } else if (showOnlyMutuals) {
-      closestTimelineItem(postElement).setAttribute(hiddenAttribute, '');
+      getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
     }
   });
 };

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -1,4 +1,4 @@
-import { filterPostElements } from '../util/interface.js';
+import { closestTimelineItem, filterPostElements } from '../util/interface.js';
 import { timelineObject } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { primaryBlogName } from '../util/user.js';
@@ -8,7 +8,7 @@ import { dom } from '../util/dom.js';
 import { getPreferences } from '../util/preferences.js';
 
 const mutualIconClass = 'xkit-mutual-icon';
-const hiddenClass = 'xkit-mutual-checker-hidden';
+const hiddenAttribute = 'data-mutual-checker-hidden';
 const mutualsClass = 'from-mutual';
 const postAttributionSelector = `header ${keyToCss('attributionHeaderText')}`;
 
@@ -61,7 +61,7 @@ const addIcons = function (postElements) {
       postElement.classList.add(mutualsClass);
       postAttribution.prepend(icon.cloneNode(true));
     } else if (showOnlyMutuals) {
-      postElement.classList.add(hiddenClass);
+      closestTimelineItem(postElement).setAttribute(hiddenAttribute, '');
     }
   });
 };
@@ -91,7 +91,7 @@ export const clean = async function () {
   onNewPosts.removeListener(addIcons);
 
   $(`.${mutualsClass}`).removeClass(mutualsClass);
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
   $(`.${mutualIconClass}`).remove();
 };
 

--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -1,5 +1,5 @@
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle, closestTimelineItem } from '../../util/interface.js';
+import { buildStyle, getTimelineItemWrapper } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
 
 const hiddenAttribute = 'data-no-recommended-blog-carousels-hidden';
@@ -14,7 +14,7 @@ const listTimelineObjectSelector = keyToCss('listTimelineObject');
 const blogCarouselSelector = `${listTimelineObjectSelector} ${keyToCss('blogCarousel')}`;
 
 const hideBlogCarousels = blogCarousels => blogCarousels
-  .map(closestTimelineItem)
+  .map(getTimelineItemWrapper)
   .filter(timelineItem =>
     timelineItem.previousElementSibling.querySelector(keyToCss('titleObject'))
   )

--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -1,26 +1,26 @@
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle } from '../../util/interface.js';
+import { buildStyle, closestTimelineItem } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
 
-const hiddenClass = 'xkit-no-recommended-blog-carousels-hidden';
+const hiddenAttribute = 'data-no-recommended-blog-carousels-hidden';
 
 const styleElement = buildStyle(`
-  .${hiddenClass} { position: relative; }
-  .${hiddenClass} > div { visibility: hidden; position: absolute; max-width: 100%; }
-  .${hiddenClass} > div :is(img, video, canvas) { display: none }
+  [${hiddenAttribute}] { position: relative; }
+  [${hiddenAttribute}] > div { visibility: hidden; position: absolute; max-width: 100%; }
+  [${hiddenAttribute}] > div :is(img, video, canvas) { display: none }
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');
 const blogCarouselSelector = `${listTimelineObjectSelector} ${keyToCss('blogCarousel')}`;
 
 const hideBlogCarousels = blogCarousels => blogCarousels
-  .map(blogCarousel => blogCarousel.closest(listTimelineObjectSelector))
-  .filter(listTimelineObject =>
-    listTimelineObject.previousElementSibling.querySelector(keyToCss('titleObject'))
+  .map(closestTimelineItem)
+  .filter(timelineItem =>
+    timelineItem.previousElementSibling.querySelector(keyToCss('titleObject'))
   )
-  .forEach(listTimelineObject => {
-    listTimelineObject.classList.add(hiddenClass);
-    listTimelineObject.previousElementSibling.classList.add(hiddenClass);
+  .forEach(timelineItem => {
+    timelineItem.setAttribute(hiddenAttribute, '');
+    timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
   });
 
 export const main = async function () {
@@ -31,5 +31,5 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(hideBlogCarousels);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };

--- a/src/scripts/no_recommended/hide_radar.js
+++ b/src/scripts/no_recommended/hide_radar.js
@@ -2,14 +2,14 @@ import { pageModifications } from '../../util/mutations.js';
 import { translate } from '../../util/language_data.js';
 import { buildStyle } from '../../util/interface.js';
 
-const hiddenClass = 'xkit-no-recommended-radar-hidden';
+const hiddenAttribute = 'data-no-recommended-radar-hidden';
 
-const styleElement = buildStyle(`.${hiddenClass} { display: none; }`);
+const styleElement = buildStyle(`[${hiddenAttribute}] { display: none; }`);
 
 const checkForRadar = function (sidebarTitles) {
   sidebarTitles
     .filter(h1 => h1.textContent === translate('Radar'))
-    .forEach(h1 => h1.parentNode.classList.add(hiddenClass));
+    .forEach(h1 => h1.parentNode.setAttribute(hiddenAttribute, ''));
 };
 
 export const main = async function () {
@@ -20,5 +20,5 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(checkForRadar);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };

--- a/src/scripts/no_recommended/hide_recommended_blogs.js
+++ b/src/scripts/no_recommended/hide_recommended_blogs.js
@@ -3,17 +3,17 @@ import { pageModifications } from '../../util/mutations.js';
 import { translate } from '../../util/language_data.js';
 import { buildStyle } from '../../util/interface.js';
 
-const hiddenClass = 'xkit-no-recommended-blogs-hidden';
+const hiddenAttribute = 'data-no-recommended-blogs-hidden';
 
-const styleElement = buildStyle(`.${hiddenClass} { display: none; }`);
+const styleElement = buildStyle(`[${hiddenAttribute}] { display: none; }`);
 
 const hideDashboardRecommended = function (sidebarTitles) {
   sidebarTitles
     .filter(h1 => h1.textContent === translate('Check out these blogs'))
-    .forEach(h1 => h1.parentNode.classList.add(hiddenClass));
+    .forEach(h1 => h1.parentNode.setAttribute(hiddenAttribute, ''));
 };
 
-const hideTagPageRecommended = topBlogsLists => topBlogsLists.forEach(ul => ul.parentNode.classList.add(hiddenClass));
+const hideTagPageRecommended = topBlogsLists => topBlogsLists.forEach(ul => ul.setAttribute(hiddenAttribute, ''));
 
 export const main = async function () {
   pageModifications.register('aside > div > h1', hideDashboardRecommended);
@@ -28,5 +28,5 @@ export const clean = async function () {
   pageModifications.unregister(hideDashboardRecommended);
   pageModifications.unregister(hideTagPageRecommended);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };

--- a/src/scripts/no_recommended/hide_recommended_posts.js
+++ b/src/scripts/no_recommended/hide_recommended_posts.js
@@ -1,4 +1,4 @@
-import { buildStyle, closestTimelineItem, filterPostElements, postSelector } from '../../util/interface.js';
+import { buildStyle, getTimelineItemWrapper, filterPostElements, postSelector } from '../../util/interface.js';
 import { onNewPosts } from '../../util/mutations.js';
 import { timelineObject } from '../../util/react_props.js';
 
@@ -53,7 +53,7 @@ const processPosts = async function (postElements) {
     if (loggingReason.startsWith('search:')) return;
     if (loggingReason === 'orbitznews') return;
 
-    const timelineItem = closestTimelineItem(postElement);
+    const timelineItem = getTimelineItemWrapper(postElement);
 
     timelineItem.setAttribute(hiddenAttribute, '');
 

--- a/src/scripts/no_recommended/hide_tag_carousels.js
+++ b/src/scripts/no_recommended/hide_tag_carousels.js
@@ -1,5 +1,5 @@
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle, closestTimelineItem } from '../../util/interface.js';
+import { buildStyle, getTimelineItemWrapper } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
 
 const hiddenAttribute = 'data-no-recommended-tag-carousels-hidden';
@@ -16,7 +16,7 @@ const carouselWrapperSelector = `${listTimelineObjectSelector} ${keyToCss('carou
 
 const hideTagCarousels = carouselWrappers => carouselWrappers
   .filter(carouselWrapper => carouselWrapper.querySelector(tagCardCarouselItemSelector) !== null)
-  .map(closestTimelineItem)
+  .map(getTimelineItemWrapper)
   .forEach(timelineItem => {
     timelineItem.setAttribute(hiddenAttribute, '');
     timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');

--- a/src/scripts/no_recommended/hide_tag_carousels.js
+++ b/src/scripts/no_recommended/hide_tag_carousels.js
@@ -1,13 +1,13 @@
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle } from '../../util/interface.js';
+import { buildStyle, closestTimelineItem } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
 
-const hiddenClass = 'xkit-no-recommended-tag-carousels-hidden';
+const hiddenAttribute = 'data-no-recommended-tag-carousels-hidden';
 
 const styleElement = buildStyle(`
-  .${hiddenClass} { position: relative; }
-  .${hiddenClass} > div { visibility: hidden; position: absolute; max-width: 100%; }
-  .${hiddenClass} > div img, .${hiddenClass} > div canvas { visibility: hidden; }
+  [${hiddenAttribute}] { position: relative; }
+  [${hiddenAttribute}] > div { visibility: hidden; position: absolute; max-width: 100%; }
+  [${hiddenAttribute}] > div img, [${hiddenAttribute}] > div canvas { visibility: hidden; }
 `);
 
 const tagCardCarouselItemSelector = keyToCss('tagCardCarouselItem');
@@ -16,10 +16,10 @@ const carouselWrapperSelector = `${listTimelineObjectSelector} ${keyToCss('carou
 
 const hideTagCarousels = carouselWrappers => carouselWrappers
   .filter(carouselWrapper => carouselWrapper.querySelector(tagCardCarouselItemSelector) !== null)
-  .map(carouselWrapper => carouselWrapper.closest(listTimelineObjectSelector))
-  .forEach(listTimelineObject => {
-    listTimelineObject.classList.add(hiddenClass);
-    listTimelineObject.previousElementSibling.classList.add(hiddenClass);
+  .map(closestTimelineItem)
+  .forEach(timelineItem => {
+    timelineItem.setAttribute(hiddenAttribute, '');
+    timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
   });
 
 export const main = async function () {
@@ -30,5 +30,5 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(hideTagCarousels);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };

--- a/src/scripts/postblock.css
+++ b/src/scripts/postblock.css
@@ -1,3 +1,3 @@
-.xkit-postblock-hidden article {
+[data-postblock-hidden] article {
   display: none;
 }

--- a/src/scripts/postblock.js
+++ b/src/scripts/postblock.js
@@ -1,4 +1,4 @@
-import { filterPostElements } from '../util/interface.js';
+import { closestTimelineItem, filterPostElements } from '../util/interface.js';
 import { registerMeatballItem, unregisterMeatballItem } from '../util/meatballs.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 import { timelineObject } from '../util/react_props.js';
@@ -7,7 +7,7 @@ import { dom } from '../util/dom.js';
 
 const meatballButtonId = 'postblock';
 const meatballButtonLabel = 'Block this post';
-const hiddenClass = 'xkit-postblock-hidden';
+const hiddenAttribute = 'data-postblock-hidden';
 const storageKey = 'postblock.blockedPostRootIDs';
 
 const processPosts = async function (postElements) {
@@ -20,9 +20,9 @@ const processPosts = async function (postElements) {
     const rootID = rebloggedRootId || postID;
 
     if (blockedPostRootIDs.includes(rootID)) {
-      postElement.classList.add(hiddenClass);
+      closestTimelineItem(postElement).setAttribute(hiddenAttribute, '');
     } else {
-      postElement.classList.remove(hiddenClass);
+      closestTimelineItem(postElement).removeAttribute(hiddenAttribute);
     }
   });
 };
@@ -66,7 +66,7 @@ export const clean = async function () {
   unregisterMeatballItem(meatballButtonId);
   onNewPosts.removeListener(processPosts);
 
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };
 
 export const stylesheet = true;

--- a/src/scripts/postblock.js
+++ b/src/scripts/postblock.js
@@ -1,4 +1,4 @@
-import { closestTimelineItem, filterPostElements } from '../util/interface.js';
+import { getTimelineItemWrapper, filterPostElements } from '../util/interface.js';
 import { registerMeatballItem, unregisterMeatballItem } from '../util/meatballs.js';
 import { showModal, hideModal, modalCancelButton } from '../util/modals.js';
 import { timelineObject } from '../util/react_props.js';
@@ -20,9 +20,9 @@ const processPosts = async function (postElements) {
     const rootID = rebloggedRootId || postID;
 
     if (blockedPostRootIDs.includes(rootID)) {
-      closestTimelineItem(postElement).setAttribute(hiddenAttribute, '');
+      getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
     } else {
-      closestTimelineItem(postElement).removeAttribute(hiddenAttribute);
+      getTimelineItemWrapper(postElement).removeAttribute(hiddenAttribute);
     }
   });
 };

--- a/src/scripts/show_originals.css
+++ b/src/scripts/show_originals.css
@@ -1,4 +1,4 @@
-[data-show-originals="on"] ~ .xkit-show-originals-hidden article {
+[data-show-originals="on"] ~ [data-show-originals-hidden] article {
   display: none;
 }
 

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -1,4 +1,4 @@
-import { filterPostElements, postSelector, blogViewSelector } from '../util/interface.js';
+import { filterPostElements, postSelector, blogViewSelector, closestTimelineItem } from '../util/interface.js';
 import { isMyPost, timelineObject } from '../util/react_props.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
@@ -6,7 +6,7 @@ import { keyToCss } from '../util/css_map.js';
 import { translate } from '../util/language_data.js';
 import { userBlogs } from '../util/user.js';
 
-const hiddenClass = 'xkit-show-originals-hidden';
+const hiddenAttribute = 'data-show-originals-hidden';
 const lengthenedClass = 'xkit-show-originals-lengthened';
 const controlsClass = 'xkit-show-originals-controls';
 
@@ -108,7 +108,7 @@ const processPosts = async function (postElements) {
       if (showReblogsWithContributedContent && content.length > 0) { return; }
       if (whitelist.includes(blogName)) { return; }
 
-      postElement.classList.add(hiddenClass);
+      closestTimelineItem(postElement).setAttribute(hiddenAttribute, '');
     });
 };
 
@@ -132,8 +132,7 @@ export const main = async function () {
 export const clean = async function () {
   onNewPosts.removeListener(processPosts);
 
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
-  $('[data-show-originals]').removeAttr('data-show-originals');
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
   $(`.${lengthenedClass}`).removeClass(lengthenedClass);
   $(`.${controlsClass}`).remove();
 };

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -1,4 +1,4 @@
-import { filterPostElements, postSelector, blogViewSelector, closestTimelineItem } from '../util/interface.js';
+import { filterPostElements, postSelector, blogViewSelector, getTimelineItemWrapper } from '../util/interface.js';
 import { isMyPost, timelineObject } from '../util/react_props.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
@@ -108,7 +108,7 @@ const processPosts = async function (postElements) {
       if (showReblogsWithContributedContent && content.length > 0) { return; }
       if (whitelist.includes(blogName)) { return; }
 
-      closestTimelineItem(postElement).setAttribute(hiddenAttribute, '');
+      getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
     });
 };
 

--- a/src/scripts/tweaks/caught_up_line.js
+++ b/src/scripts/tweaks/caught_up_line.js
@@ -1,5 +1,5 @@
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle, closestTimelineItem } from '../../util/interface.js';
+import { buildStyle, getTimelineItemWrapper } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
 
 const hiddenAttribute = 'data-tweaks-caught-up-line-title';
@@ -19,11 +19,11 @@ const listTimelineObjectSelector = keyToCss('listTimelineObject');
 const tagChicletCarouselItemSelector = `${listTimelineObjectSelector} ${keyToCss('tagChicletCarouselItem')}`;
 
 const createCaughtUpLine = tagChicletCarouselItems => tagChicletCarouselItems
-  .map(closestTimelineItem)
+  .map(getTimelineItemWrapper)
   .filter((element, index, array) => array.indexOf(element) === index)
-  .forEach(listTimelineObject => {
-    listTimelineObject.setAttribute(borderAttribute, '');
-    listTimelineObject.previousElementSibling.setAttribute(hiddenAttribute, '');
+  .forEach(timelineItem => {
+    timelineItem.setAttribute(borderAttribute, '');
+    timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
   });
 
 export const main = async function () {

--- a/src/scripts/tweaks/caught_up_line.js
+++ b/src/scripts/tweaks/caught_up_line.js
@@ -1,13 +1,13 @@
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle } from '../../util/interface.js';
+import { buildStyle, closestTimelineItem } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
 
-const hiddenClass = 'xkit-tweaks-caught-up-line-title';
-const borderClass = 'xkit-tweaks-caught-up-line-border';
+const hiddenAttribute = 'data-tweaks-caught-up-line-title';
+const borderAttribute = 'data-tweaks-caught-up-line-border';
 
 const styleElement = buildStyle(`
-  .${hiddenClass} > div { display: none; }
-  .${borderClass} > div {
+  [${hiddenAttribute}] > div { display: none; }
+  [${borderAttribute}] > div {
     box-sizing: content-box;
     height: 0px;
     overflow-y: hidden;
@@ -19,11 +19,11 @@ const listTimelineObjectSelector = keyToCss('listTimelineObject');
 const tagChicletCarouselItemSelector = `${listTimelineObjectSelector} ${keyToCss('tagChicletCarouselItem')}`;
 
 const createCaughtUpLine = tagChicletCarouselItems => tagChicletCarouselItems
-  .map(tagChicletCarouselItem => tagChicletCarouselItem.closest(listTimelineObjectSelector))
+  .map(closestTimelineItem)
   .filter((element, index, array) => array.indexOf(element) === index)
   .forEach(listTimelineObject => {
-    listTimelineObject.classList.add(borderClass);
-    listTimelineObject.previousElementSibling.classList.add(hiddenClass);
+    listTimelineObject.setAttribute(borderAttribute, '');
+    listTimelineObject.previousElementSibling.setAttribute(hiddenAttribute, '');
   });
 
 export const main = async function () {
@@ -34,6 +34,6 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(createCaughtUpLine);
   styleElement.remove();
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
-  $(`.${borderClass}`).removeClass(borderClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
+  $(`[${borderAttribute}]`).removeAttr(borderAttribute);
 };

--- a/src/scripts/tweaks/hide_filtered_posts.js
+++ b/src/scripts/tweaks/hide_filtered_posts.js
@@ -1,13 +1,13 @@
 import { pageModifications } from '../../util/mutations.js';
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle } from '../../util/interface.js';
+import { buildStyle, closestTimelineItem } from '../../util/interface.js';
 
-const hiddenClass = 'xkit-tweaks-hide-filtered-posts-hidden';
-const styleElement = buildStyle(`.${hiddenClass} { display: none; }`);
+const hiddenAttribute = 'data-tweaks-hide-filtered-posts-hidden';
+const styleElement = buildStyle(`[${hiddenAttribute}] article { display: none; }`);
 
 const hideFilteredPosts = filteredScreens => filteredScreens
-  .map(filteredScreen => filteredScreen.closest('article'))
-  .forEach(article => article.classList.add(hiddenClass));
+  .map(closestTimelineItem)
+  .forEach(timelineItem => timelineItem.setAttribute(hiddenAttribute, ''));
 
 export const main = async function () {
   const filteredScreenSelector = `article ${keyToCss('filteredScreen')}`;
@@ -19,5 +19,5 @@ export const clean = async function () {
   pageModifications.unregister(hideFilteredPosts);
   styleElement.remove();
 
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };

--- a/src/scripts/tweaks/hide_filtered_posts.js
+++ b/src/scripts/tweaks/hide_filtered_posts.js
@@ -1,12 +1,12 @@
 import { pageModifications } from '../../util/mutations.js';
 import { keyToCss } from '../../util/css_map.js';
-import { buildStyle, closestTimelineItem } from '../../util/interface.js';
+import { buildStyle, getTimelineItemWrapper } from '../../util/interface.js';
 
 const hiddenAttribute = 'data-tweaks-hide-filtered-posts-hidden';
 const styleElement = buildStyle(`[${hiddenAttribute}] article { display: none; }`);
 
 const hideFilteredPosts = filteredScreens => filteredScreens
-  .map(closestTimelineItem)
+  .map(getTimelineItemWrapper)
   .forEach(timelineItem => timelineItem.setAttribute(hiddenAttribute, ''));
 
 export const main = async function () {

--- a/src/scripts/tweaks/hide_liked_posts.js
+++ b/src/scripts/tweaks/hide_liked_posts.js
@@ -1,5 +1,5 @@
 import { onNewPosts } from '../../util/mutations.js';
-import { buildStyle, closestTimelineItem, filterPostElements } from '../../util/interface.js';
+import { buildStyle, getTimelineItemWrapper, filterPostElements } from '../../util/interface.js';
 import { isMyPost, timelineObject } from '../../util/react_props.js';
 
 const timeline = /\/v2\/timeline\/dashboard/;
@@ -12,7 +12,7 @@ const processPosts = async function (postElements) {
     const { liked } = await timelineObject(postElement);
     const myPost = await isMyPost(postElement);
 
-    if (liked && !myPost) closestTimelineItem(postElement).setAttribute(hiddenAttribute, '');
+    if (liked && !myPost) getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
   });
 };
 

--- a/src/scripts/tweaks/hide_liked_posts.js
+++ b/src/scripts/tweaks/hide_liked_posts.js
@@ -1,18 +1,18 @@
 import { onNewPosts } from '../../util/mutations.js';
-import { buildStyle, filterPostElements } from '../../util/interface.js';
+import { buildStyle, closestTimelineItem, filterPostElements } from '../../util/interface.js';
 import { isMyPost, timelineObject } from '../../util/react_props.js';
 
 const timeline = /\/v2\/timeline\/dashboard/;
 
-const hiddenClass = 'xkit-tweaks-hide-liked-posts-hidden';
-const styleElement = buildStyle(`.${hiddenClass} article { display: none; }`);
+const hiddenAttribute = 'data-tweaks-hide-liked-posts-hidden';
+const styleElement = buildStyle(`[${hiddenAttribute}] article { display: none; }`);
 
 const processPosts = async function (postElements) {
   filterPostElements(postElements, { timeline }).forEach(async postElement => {
     const { liked } = await timelineObject(postElement);
     const myPost = await isMyPost(postElement);
 
-    if (liked && !myPost) postElement.classList.add(hiddenClass);
+    if (liked && !myPost) closestTimelineItem(postElement).setAttribute(hiddenAttribute, '');
   });
 };
 
@@ -25,5 +25,5 @@ export const clean = async function () {
   onNewPosts.removeListener(processPosts);
   styleElement.remove();
 
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };

--- a/src/scripts/tweaks/hide_my_posts.js
+++ b/src/scripts/tweaks/hide_my_posts.js
@@ -1,5 +1,5 @@
 import { onNewPosts } from '../../util/mutations.js';
-import { buildStyle, closestTimelineItem, filterPostElements } from '../../util/interface.js';
+import { buildStyle, getTimelineItemWrapper, filterPostElements } from '../../util/interface.js';
 import { isMyPost } from '../../util/react_props.js';
 
 const excludeClass = 'xkit-tweaks-hide-my-posts-done';
@@ -13,7 +13,7 @@ const processPosts = async function (postElements) {
     const myPost = await isMyPost(postElement);
 
     if (myPost) {
-      closestTimelineItem(postElement).setAttribute(hiddenAttribute, '');
+      getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
     }
   });
 };

--- a/src/scripts/tweaks/hide_my_posts.js
+++ b/src/scripts/tweaks/hide_my_posts.js
@@ -1,19 +1,19 @@
 import { onNewPosts } from '../../util/mutations.js';
-import { buildStyle, filterPostElements } from '../../util/interface.js';
+import { buildStyle, closestTimelineItem, filterPostElements } from '../../util/interface.js';
 import { isMyPost } from '../../util/react_props.js';
 
 const excludeClass = 'xkit-tweaks-hide-my-posts-done';
 const timeline = /\/v2\/timeline\/dashboard/;
 
-const hiddenClass = 'xkit-tweaks-hide-my-posts-hidden';
-const styleElement = buildStyle(`.${hiddenClass} article { display: none; }`);
+const hiddenAttribute = 'data-tweaks-hide-my-posts-hidden';
+const styleElement = buildStyle(`[${hiddenAttribute}] article { display: none; }`);
 
 const processPosts = async function (postElements) {
   filterPostElements(postElements, { excludeClass, timeline }).forEach(async postElement => {
     const myPost = await isMyPost(postElement);
 
     if (myPost) {
-      postElement.classList.add(hiddenClass);
+      closestTimelineItem(postElement).setAttribute(hiddenAttribute, '');
     }
   });
 };
@@ -28,5 +28,5 @@ export const clean = async function () {
   styleElement.remove();
 
   $(`.${excludeClass}`).removeClass(excludeClass);
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };

--- a/src/scripts/tweaks/no_live.js
+++ b/src/scripts/tweaks/no_live.js
@@ -1,13 +1,13 @@
 import { pageModifications } from '../../util/mutations.js';
-import { buildStyle } from '../../util/interface.js';
+import { buildStyle, getTimelineItemWrapper } from '../../util/interface.js';
 import { keyToCss } from '../../util/css_map.js';
 
-const hiddenClass = 'xkit-tweaks-no-live-hidden';
-const styleElement = buildStyle(`.${hiddenClass} { display: none; }`);
+const hiddenAttribute = 'data-tweaks-no-live-hidden';
+const styleElement = buildStyle(`[${hiddenAttribute}] > * { display: none; }`);
 
 const processFrames = frames =>
   frames.forEach(frame =>
-    frame.closest(keyToCss('listTimelineObjectInner'))?.classList?.add(hiddenClass)
+    getTimelineItemWrapper(frame).setAttribute(hiddenAttribute, '')
   );
 
 export const main = async function () {
@@ -22,5 +22,5 @@ export const clean = async function () {
   pageModifications.unregister(processFrames);
   styleElement.remove();
 
-  $(`.${hiddenClass}`).removeClass(hiddenClass);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };

--- a/src/util/interface.js
+++ b/src/util/interface.js
@@ -7,7 +7,7 @@ export const blogViewSelector = '[style*="--blog-title-color"] *';
 const listTimelineObjectSelector = keyToCss('listTimelineObject');
 const cellSelector = keyToCss('cell');
 
-export const closestTimelineItem = element => element.closest(cellSelector) || element.closest(listTimelineObjectSelector);
+export const getTimelineItemWrapper = element => element.closest(cellSelector) || element.closest(listTimelineObjectSelector);
 
 /**
  * @typedef {object} PostFilterOptions

--- a/src/util/interface.js
+++ b/src/util/interface.js
@@ -1,7 +1,13 @@
+import { keyToCss } from './css_map.js';
 import { dom } from './dom.js';
 
 export const postSelector = '[tabindex="-1"][data-id]';
 export const blogViewSelector = '[style*="--blog-title-color"] *';
+
+const listTimelineObjectSelector = keyToCss('listTimelineObject');
+const cellSelector = keyToCss('cell');
+
+export const closestTimelineItem = element => element.closest(cellSelector) || element.closest(listTimelineObjectSelector);
 
 /**
  * @typedef {object} PostFilterOptions


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As per discussion #1207, this fixes and improves content hiding on accounts with the "virtual scroller" experiment. This experiment wraps timeline items in `cell` wrappers and unmounts the wrapper contents when they are far off the screen.

This PR:

 - Implements a helper function (`closestTimelineItem`—open to better names) which finds either the `cell` or `listTimelineObject` containing an element, unifying logic between accounts with and without the experiment.
 - Places the content-hiding class on the `cell` when it exists, ensuring that content is still hidden when it is re-mounted on scroll, preventing scrollbar jumps.
 - Changes from class names to data attributes for all content hiding, preventing a changed classname from the React code overwriting the hidden property on a cell

Seen Posts, Shorten Posts, and Collapsed Queue are not addressed here; they'll require additional logic and I created separate issues for each.

Resolves #1195.

I migrated this over from a dev branch where I have the majority of my PRs merged and manually resolved the conflicts, so while I had tested each script before that process, they should probably go through some basic testing afterward. I also have not tested these with the virtual scroll experiment turned off yet.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

