### PR TITLE
Prevent visible UI flicker when processing new posts

### DIFF
--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -60,7 +60,7 @@ const onBeforeRepaint = () => {
 
   const addedNodes = addedNodesPool
     .splice(0)
-    .filter(addedNode => addedNode instanceof Element && addedNode.isConnected);
+    .filter(addedNode => addedNode.isConnected);
 
   if (addedNodes.length === 0) return;
 

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -1,3 +1,4 @@
+import { keyToCss } from './css_map.js';
 import { postSelector } from './interface.js';
 const rootNode = document.getElementById('root');
 
@@ -81,6 +82,8 @@ const onBeforeRepaint = () => {
   }
 };
 
+const cellSelector = keyToCss('cell');
+
 const observer = new MutationObserver(mutations => {
   const addedNodes = mutations
     .flatMap(({ addedNodes }) => [...addedNodes])
@@ -88,10 +91,7 @@ const observer = new MutationObserver(mutations => {
 
   addedNodesPool.push(...addedNodes);
 
-  if ([
-    ...addedNodes.filter(addedNode => addedNode.matches(postSelector)),
-    ...addedNodes.flatMap(addedNode => [...addedNode.querySelectorAll(postSelector)])
-  ].length) {
+  if (addedNodes.some(addedNode => addedNode.parentElement?.matches(cellSelector))) {
     cancelAnimationFrame(timerId);
     onBeforeRepaint();
   } else if (repaintQueued === false) {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

You know I had to do it to em

(actually, I don't know what that meme means or where it comes from. hopefully it's not, like, racist. anyway.)

This improves the behavior discussed in https://github.com/AprilSylph/XKit-Rewritten/discussions/1207#discussioncomment-6747508 somewhat by running `pageModifications` instantly instead of in a `requestAnimationFrame` callback if and only if the modification in question is the mount of a post (or whatever) into a virtual scroll experiment `cell` element. These mounts are currently (often?) run using `requestAnimationFrame`, which means that our trick of delaying `pageModifications` processing only within the current frame doesn't work and causes a render without our modifications for one frame.

It leaves the `requestAnimationFrame` trick (debounce, effectively) in place in other cases.

~~This would be more elegant if one could detect the part of the event loop the current code is running in; just doing this for posts is more of a symptomatic fix than a—hey wait a second.~~ (I pushed the second commit after writing that sentence).

Pretty much addresses #1200, though further optimization would be ideal (and relegates some of #1213 to a performance improvement PR rather than a fix PR), apparently, which was sort of an accident...? Although I should have, and I suppose did, see this coming:

>It seems reasonable that, in theory, XKit's current processing might be able to avoid these scrollbar shenanigans. Specifically: if you scroll up, a post renders in with its full height, the virtual scroll container rerenders (moving everything down), XKit processes the post and hides it, the cell height becomes 0, the resize observer fires, the virtual scroll container rerenders (moving everything back up)... and then the javascript event loop ends and the browser actually renders the page for the first time, then nothing actually changed re: scroll position.
> 
> I am not actually 100% clear on whether this is working or not, at the moment. I thought it wasn't, but

It wasn't, and this is why.

(I was going to draft this but it worked a lot better than I thought it would so I'm not sure now.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

I have no specific tests for non-breakage.

To see the effect, turn Shorten Posts on with its minimum height, and with/without this PR, compare:
 - scrolling with your mouse cursor to an area far above/below your current scroll position: with this PR, posts should appear shortened instead of thrashing
 - using Scroll to Bottom