### PR TITLE
Prevent console error on `tumblr.com/live`

### DIFF
--- a/src/scripts/tweaks/no_live.js
+++ b/src/scripts/tweaks/no_live.js
@@ -7,7 +7,7 @@ const styleElement = buildStyle(`[${hiddenAttribute}] > * { display: none; }`);
 
 const processFrames = frames =>
   frames.forEach(frame =>
-    getTimelineItemWrapper(frame).setAttribute(hiddenAttribute, '')
+    getTimelineItemWrapper(frame)?.setAttribute(hiddenAttribute, '')
   );
 
 export const main = async function () {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Oops.

This prevents a harmless console error on https://www.tumblr.com/live resulting from the same selector matching its iframe and the one in the Live carousel.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

