### PR TITLE
Show Originals: Fix controls element moving on resize

### DIFF
--- a/src/scripts/show_originals.css
+++ b/src/scripts/show_originals.css
@@ -1,4 +1,4 @@
-[data-show-originals="on"] ~ [data-timeline] [data-show-originals-hidden] article {
+[data-show-originals="on"] ~ div > [data-show-originals-hidden] article {
   display: none;
 }
 

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -34,7 +34,7 @@ const addControls = async (timelineElement, location) => {
   const controls = Object.assign(document.createElement('div'), { className: controlsClass });
   controls.dataset.location = location;
 
-  timelineElement.before(controls);
+  timelineElement.prepend(controls);
 
   const handleClick = async ({ currentTarget: { dataset: { mode } } }) => {
     controls.dataset.showOriginals = mode;
@@ -84,9 +84,8 @@ const processTimelines = async () => {
   [...document.querySelectorAll('[data-timeline]')].forEach(async timelineElement => {
     const location = getLocation(timelineElement);
 
-    const currentControls = timelineElement.previousElementSibling?.classList?.contains(controlsClass)
-      ? timelineElement.previousElementSibling
-      : null;
+    const currentControls = [...timelineElement.children]
+      .find(element => element.matches(`.${controlsClass}`));
 
     if (currentControls?.dataset?.location !== location) {
       currentControls?.remove();


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This moves the DOM position of the Show Originals controls element (again) to be inside the timeline element, but outside the scroll container, ensuring that it doesn't move around.

Using `controls ~ div > post` as a selector is perhaps a little fragile (if there are two nested container divs in some future timeline DOM change, it'll break), but considering that I had to make a change at all, apparently anything can be a little fragile. I would have guessed that the "above the first post" location would be the most resilient, but in this case it wasn't, so ¯\\_(ツ)\_/¯

Resolves #1219.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

With the virtual scroll experiment both on and off, I tested that the Show Originals controls functioned on the dashboard, in the blog view modal, and in the blog view modal on a specific post.

