### PR TITLE
Seen Posts: Fix functionality with "virtual scroller" experiment

### DIFF
--- a/src/scripts/seen_posts.css
+++ b/src/scripts/seen_posts.css
@@ -1,9 +1,9 @@
-body:not(.xkit-seen-posts-only-dim-avatar) .xkit-seen-posts-seen:not(:hover),
-body.xkit-seen-posts-only-dim-avatar .xkit-seen-posts-seen:not(:hover) article > :first-child  > :first-child img {
+body:not(.xkit-seen-posts-only-dim-avatar) [data-seen-posts-seen]:not(:hover),
+body.xkit-seen-posts-only-dim-avatar [data-seen-posts-seen]:not(:hover) article > :first-child  > :first-child img {
   opacity: 0.5;
 }
 
-body.xkit-seen-posts-hide .xkit-seen-posts-seen article {
+body.xkit-seen-posts-hide [data-seen-posts-seen] article {
   display: none;
 }
 

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -3,7 +3,7 @@ import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
 import { keyToCss } from '../util/css_map.js';
 
-const excludeClass = 'xkit-seen-posts-done';
+const excludeAttribute = 'data-seen-posts-done';
 const timeline = '/v2/timeline/dashboard';
 const includeFiltered = true;
 
@@ -52,11 +52,15 @@ const lengthenTimelines = () =>
 const dimPosts = function (postElements) {
   lengthenTimelines();
 
-  for (const postElement of filterPostElements(postElements, { excludeClass, timeline, includeFiltered })) {
+  for (const postElement of filterPostElements(postElements, { timeline, includeFiltered })) {
     const { id } = postElement.dataset;
+    const timelineItem = getTimelineItemWrapper(postElement);
+
+    if (timelineItem.getAttribute(excludeAttribute) === '') return;
+    timelineItem.setAttribute(excludeAttribute, '');
 
     if (seenPosts.includes(id)) {
-      getTimelineItemWrapper(postElement).setAttribute(dimAttribute, '');
+      timelineItem.setAttribute(dimAttribute, '');
     } else {
       observer.observe(postElement.querySelector('article'));
     }
@@ -108,9 +112,9 @@ export const clean = async function () {
   timers.forEach((timerId) => clearTimeout(timerId));
   timers.clear();
 
-  $(`.${excludeClass}`).removeClass(excludeClass);
-  $(`.${hideClass}`).removeClass(hideClass);
+  $(`[${excludeAttribute}]`).removeAttr(excludeAttribute);
   $(`[${dimAttribute}]`).removeAttr(dimAttribute);
+  $(`.${hideClass}`).removeClass(hideClass);
   $(`.${onlyDimAvatarsClass}`).removeClass(onlyDimAvatarsClass);
   $(`.${lengthenedClass}`).removeClass(lengthenedClass);
 };

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -36,12 +36,10 @@ const markAsSeen = (articleElement) => {
   observer.unobserve(articleElement);
   timers.delete(articleElement);
 
-  getTimelineItemWrapper(articleElement).style.outline = '3px solid red';
-
   const postElement = articleElement.closest(postSelector);
   seenPosts.push(postElement.dataset.id);
   seenPosts.splice(0, seenPosts.length - 10000);
-  // browser.storage.local.set({ [storageKey]: seenPosts });
+  browser.storage.local.set({ [storageKey]: seenPosts });
 };
 
 const lengthenTimelines = () =>

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -56,7 +56,7 @@ const dimPosts = function (postElements) {
     const { id } = postElement.dataset;
     const timelineItem = getTimelineItemWrapper(postElement);
 
-    if (timelineItem.getAttribute(excludeAttribute) === '') return;
+    if (timelineItem.getAttribute(excludeAttribute) !== null) return;
     timelineItem.setAttribute(excludeAttribute, '');
 
     if (seenPosts.includes(id)) {

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -36,10 +36,12 @@ const markAsSeen = (articleElement) => {
   observer.unobserve(articleElement);
   timers.delete(articleElement);
 
+  getTimelineItemWrapper(articleElement).style.outline = '3px solid red';
+
   const postElement = articleElement.closest(postSelector);
   seenPosts.push(postElement.dataset.id);
   seenPosts.splice(0, seenPosts.length - 10000);
-  browser.storage.local.set({ [storageKey]: seenPosts });
+  // browser.storage.local.set({ [storageKey]: seenPosts });
 };
 
 const lengthenTimelines = () =>

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -1,4 +1,4 @@
-import { filterPostElements, postSelector } from '../util/interface.js';
+import { filterPostElements, getTimelineItemWrapper, postSelector } from '../util/interface.js';
 import { getPreferences } from '../util/preferences.js';
 import { onNewPosts } from '../util/mutations.js';
 import { keyToCss } from '../util/css_map.js';
@@ -7,7 +7,7 @@ const excludeClass = 'xkit-seen-posts-done';
 const timeline = '/v2/timeline/dashboard';
 const includeFiltered = true;
 
-const dimClass = 'xkit-seen-posts-seen';
+const dimAttribute = 'data-seen-posts-seen';
 const onlyDimAvatarsClass = 'xkit-seen-posts-only-dim-avatar';
 const hideClass = 'xkit-seen-posts-hide';
 const lengthenedClass = 'xkit-seen-posts-lengthened';
@@ -56,7 +56,7 @@ const dimPosts = function (postElements) {
     const { id } = postElement.dataset;
 
     if (seenPosts.includes(id)) {
-      postElement.classList.add(dimClass);
+      getTimelineItemWrapper(postElement).setAttribute(dimAttribute, '');
     } else {
       observer.observe(postElement.querySelector('article'));
     }
@@ -110,7 +110,7 @@ export const clean = async function () {
 
   $(`.${excludeClass}`).removeClass(excludeClass);
   $(`.${hideClass}`).removeClass(hideClass);
-  $(`.${dimClass}`).removeClass(dimClass);
+  $(`[${dimAttribute}]`).removeAttr(dimAttribute);
   $(`.${onlyDimAvatarsClass}`).removeClass(onlyDimAvatarsClass);
   $(`.${lengthenedClass}`).removeClass(lengthenedClass);
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This applies the same modifications for post hiding (moving the class to the `cell` if present; using a data attribute) that fixed other scripts with the virtual scroller in #1213.

It also moves Seen Posts' `excludeClass` functionality to this method as well. This is important because double processing of posts has an unintended functional side effect with Seen Posts

Resolves #1211.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

I typically:
- unrevert the test code
- enable Show Originals on the original posts view (to test interoperability)
- enable Seen Posts and scroll a bit down my dash, confirming that posts I see are marked red by the test code but not dimmed
- soft navigate somewhere else (e.g. explore)
- soft navigate back and confirm that the posts I saw and marked are dimmed
- toggle Show Originals to the all posts view
- confirm that some of the reblog posts I had previously not seen in between the original posts that I did see are not dimmed

I did this with and without the virtual scroller flag, and also did a fresh run with the virtual scroller flag and scrolled up and down a bunch, confirming that no posts became dimmed on remount,
