### PR TITLE
Preferences util: Remove local storage loop delay

### DIFF
--- a/src/util/preferences.js
+++ b/src/util/preferences.js
@@ -16,11 +16,11 @@ export const getPreferences = async function (scriptName) {
     if (preference.type === 'iframe') { continue; }
 
     const storageKey = `${scriptName}.preferences.${key}`;
-    const { [storageKey]: savedPreference } = storage;
+    const savedPreference = storage[storageKey];
 
     if (savedPreference === undefined) {
       if (preference.inherit) {
-        const { [preference.inherit]: inheritedDefault } = storage;
+        const inheritedDefault = storage[preference.inherit];
         if (inheritedDefault !== undefined) {
           preference.default = inheritedDefault;
           browser.storage.local.remove(preference.inherit);

--- a/src/util/preferences.js
+++ b/src/util/preferences.js
@@ -6,6 +6,7 @@ export const getPreferences = async function (scriptName) {
   const scriptManifestURL = browser.runtime.getURL(`/scripts/${scriptName}.json`);
   const scriptManifestFile = await fetch(scriptManifestURL);
   const scriptManifest = await scriptManifestFile.json();
+  const storage = await browser.storage.local.get();
 
   const { preferences = {} } = scriptManifest;
   const unsetPreferences = {};
@@ -15,11 +16,11 @@ export const getPreferences = async function (scriptName) {
     if (preference.type === 'iframe') { continue; }
 
     const storageKey = `${scriptName}.preferences.${key}`;
-    const { [storageKey]: savedPreference } = await browser.storage.local.get(storageKey);
+    const { [storageKey]: savedPreference } = storage;
 
     if (savedPreference === undefined) {
       if (preference.inherit) {
-        const { [preference.inherit]: inheritedDefault } = await browser.storage.local.get(preference.inherit);
+        const { [preference.inherit]: inheritedDefault } = storage;
         if (inheritedDefault !== undefined) {
           preference.default = inheritedDefault;
           browser.storage.local.remove(preference.inherit);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Makes getPreferences asynchronously wait once instead of [number of preferences] times.

Part of a little project attempting to make the last tweak you enable not take like 7 seconds to actually go into effect.

This makes very little difference (couple hundred milliseconds). 

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

