### PR TITLE
Seen Posts: Fix functionality with "virtual scroller" experiment (better)

### DIFF
--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -39,8 +39,7 @@ const markAsSeen = (articleElement) => {
   const postElement = articleElement.closest(postSelector);
   seenPosts.push(postElement.dataset.id);
   seenPosts.splice(0, seenPosts.length - 10000);
-  getTimelineItemWrapper(postElement).style.border = '3px solid red';
-  // browser.storage.local.set({ [storageKey]: seenPosts });
+  browser.storage.local.set({ [storageKey]: seenPosts });
 };
 
 const lengthenTimelines = () =>

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -36,8 +36,10 @@ const markAsSeen = (articleElement) => {
   observer.unobserve(articleElement);
   timers.delete(articleElement);
 
-  const postElement = articleElement.closest(postSelector);
-  seenPosts.push(postElement.dataset.id);
+  const { dataset: { id } } = articleElement.closest(postSelector);
+  if (seenPosts.includes(id)) return;
+
+  seenPosts.push(id);
   seenPosts.splice(0, seenPosts.length - 10000);
   browser.storage.local.set({ [storageKey]: seenPosts });
 };

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -56,13 +56,13 @@ const dimPosts = function (postElements) {
     const { id } = postElement.dataset;
     const timelineItem = getTimelineItemWrapper(postElement);
 
-    if (timelineItem.getAttribute(excludeAttribute) !== null) return;
+    const isFirstRender = timelineItem.getAttribute(excludeAttribute) === null;
     timelineItem.setAttribute(excludeAttribute, '');
 
-    if (seenPosts.includes(id)) {
-      timelineItem.setAttribute(dimAttribute, '');
-    } else {
+    if (seenPosts.includes(id) === false) {
       observer.observe(postElement.querySelector('article'));
+    } else if (isFirstRender) {
+      timelineItem.setAttribute(dimAttribute, '');
     }
   }
 };

--- a/src/scripts/seen_posts.js
+++ b/src/scripts/seen_posts.js
@@ -39,7 +39,8 @@ const markAsSeen = (articleElement) => {
   const postElement = articleElement.closest(postSelector);
   seenPosts.push(postElement.dataset.id);
   seenPosts.splice(0, seenPosts.length - 10000);
-  browser.storage.local.set({ [storageKey]: seenPosts });
+  getTimelineItemWrapper(postElement).style.border = '3px solid red';
+  // browser.storage.local.set({ [storageKey]: seenPosts });
 };
 
 const lengthenTimelines = () =>


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As per [my](https://github.com/AprilSylph/XKit-Rewritten/issues/1211#issuecomment-1684491464) [comments](https://github.com/AprilSylph/XKit-Rewritten/issues/1211#issuecomment-1684504017), this fixes an issue with my [previous PR](https://github.com/AprilSylph/XKit-Rewritten/pull/1221) in which unseen posts might never be marked as seen if they lose their IntersectionObserver handlers by getting unmounted.

Resolves #1211. For real this time.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
With the virtual scroller enabled, I:

 - put the test code in
 - tried REALLY HARD to scroll aggressively and trigger the scenario where a post loses its handler and does not become marked red when seen
 - didn't observe that
 - also did the tests specified in #1221 

