### PR TITLE
Standardize text preference processing

### DIFF
--- a/src/scripts/hide_avatars.js
+++ b/src/scripts/hide_avatars.js
@@ -9,7 +9,7 @@ export const main = async function () {
 
   styleElement.textContent = hiddenAvatars
     .split(',')
-    .map(username => `[title="${username.trim()}"] img[alt="${translate('Avatar')}"] { display: none; }`)
+    .map(username => `[title="${username.trim().toLowerCase()}"] img[alt="${translate('Avatar')}"] { display: none; }`)
     .join('\n');
 
   document.documentElement.append(styleElement);

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -119,7 +119,7 @@ export const main = async function () {
     whitelistedUsernames
   } = await getPreferences('show_originals'));
 
-  whitelist = whitelistedUsernames.split(',').map(username => username.trim());
+  whitelist = whitelistedUsernames.split(',').map(username => username.trim().toLowerCase());
   const nonGroupUserBlogs = userBlogs
     .filter(blog => !blog.isGroupChannel)
     .map(blog => blog.name);

--- a/src/scripts/themed_posts.js
+++ b/src/scripts/themed_posts.js
@@ -80,7 +80,7 @@ const processPosts = async function (postElements) {
 
 export const main = async function () {
   ({ reblogTrailTheming, enableOnPeepr, blacklistedUsernames, missingPostMode } = await getPreferences('themed_posts'));
-  blacklist = blacklistedUsernames.split(',').map(username => username.trim());
+  blacklist = blacklistedUsernames.split(',').map(username => username.trim().toLowerCase());
 
   if (reblogTrailTheming) {
     styleElement.textContent += `


### PR DESCRIPTION
### Description
Standardizes all preferences using text inputs to ignore case and strip hashtags.
Currently, Hide Avatars, Show Originals, and Themed Posts do not ignore case, and Quick Reblog, Tag Replacer, Painter, and Cleanfeed ignore case and strip hashtags.

Resolves #1188 and #982

