### PR TITLE
Tag Tracking+: Fix race condition and improve preference change behavior with `onStorageChanged`

### DIFF
--- a/src/scripts/tag_tracking_plus.css
+++ b/src/scripts/tag_tracking_plus.css
@@ -16,14 +16,19 @@
   content: 'No tracked tags!';
 }
 
-#tag-tracking-plus.only-show-new[data-loading="true"] ul:not(:empty)::after {
+#tag-tracking-plus[data-only-show-new="true"][data-loading="true"] ul:not(:empty)::after {
   content: 'Loading...';
 }
 
-#tag-tracking-plus.only-show-new[data-loading="false"][data-has-new="false"] ul:not(:empty)::after {
+#tag-tracking-plus[data-only-show-new="true"][data-loading="false"][data-has-new="false"] ul:not(:empty)::after {
   content: 'No unread tags.';
 }
 
-#tag-tracking-plus.only-show-new li:not([data-new="true"]) {
+#tag-tracking-plus[data-only-show-new="true"] li:not([data-new="true"]) {
+  display: none;
+}
+
+[data-tag-tracking-plus-show-sidebar="false"] #tag-tracking-plus,
+[data-tag-tracking-plus-show-search="false"] .xkit-tag-tracking-plus-search-count {
   display: none;
 }

--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -8,6 +8,7 @@ import { addSidebarItem, removeSidebarItem } from '../util/sidebar.js';
 import { getPreferences } from '../util/preferences.js';
 
 const storageKey = 'tag_tracking_plus.trackedTagTimestamps';
+let timestamps;
 
 const excludeClass = 'xkit-tag-tracking-plus-done';
 const includeFiltered = true;
@@ -23,7 +24,6 @@ let sidebarItem;
 const refreshCount = async function (tag) {
   if (!trackedTags.includes(tag)) return;
 
-  const { [storageKey]: timestamps = {} } = await browser.storage.local.get(storageKey);
   const savedTimestamp = timestamps[tag] ?? 0;
   const {
     response: {
@@ -108,7 +108,6 @@ const processPosts = async function (postElements) {
   const currentTag = decodeURIComponent(encodedCurrentTag);
   if (!trackedTags.includes(currentTag)) return;
 
-  const { [storageKey]: timestamps = {} } = await browser.storage.local.get(storageKey);
   const timeline = new RegExp(`/v2/hubs/${encodedCurrentTag}/timeline`);
 
   let updated = false;
@@ -153,12 +152,31 @@ const processTagLinks = function (tagLinkElements) {
   });
 };
 
+export const onStorageChanged = async (changes, areaName) => {
+  if (Object.keys(changes).includes(storageKey)) {
+    timestamps = changes[storageKey].newValue;
+  }
+  if (Object.keys(changes).some(key => key.startsWith('tag_tracking_plus.preferences'))) {
+    cleanSearchAndSidebar();
+    await setupSearchAndSidebar();
+  }
+};
+
 export const main = async function () {
   const trackedTagsData = (await apiFetch('/v2/user/tags')) ?? {};
   trackedTags = trackedTagsData.response?.tags?.map(({ name }) => name) ?? [];
 
   trackedTags.forEach(tag => unreadCounts.set(tag, undefined));
 
+  ({ [storageKey]: timestamps = {} } = await browser.storage.local.get(storageKey));
+
+  await setupSearchAndSidebar();
+
+  onNewPosts.addListener(processPosts);
+  refreshAllCounts(true).then(startRefreshInterval);
+};
+
+const setupSearchAndSidebar = async () => {
   const { showUnread, onlyShowNew } = await getPreferences('tag_tracking_plus');
   if (showUnread === 'both' || showUnread === 'search') {
     pageModifications.register(tagLinkSelector, processTagLinks);
@@ -171,28 +189,31 @@ export const main = async function () {
         label: `#${tag}`,
         href: `/tagged/${encodeURIComponent(tag)}?sort=recent`,
         onclick: onClickNavigate,
-        count: '\u22EF'
+        count: unreadCounts.get(tag) ?? '\u22EF',
+        attributes: { 'data-new': unreadCounts.get(tag) && unreadCounts.get(tag) !== '0' }
       }))
     });
 
     onlyShowNew && sidebarItem.classList.add('only-show-new');
     updateSidebarStatus();
   }
+};
 
-  onNewPosts.addListener(processPosts);
-  refreshAllCounts(true).then(startRefreshInterval);
+const cleanSearchAndSidebar = () => {
+  pageModifications.unregister(processTagLinks);
+  $(`${tagLinkSelector} [data-count-for]`).remove();
+
+  removeSidebarItem('tag-tracking-plus');
+  sidebarItem = undefined;
 };
 
 export const clean = async function () {
   stopRefreshInterval();
   onNewPosts.removeListener(processPosts);
-  pageModifications.unregister(processTagLinks);
 
-  removeSidebarItem('tag-tracking-plus');
-  $(`${tagLinkSelector} [data-count-for]`).remove();
+  cleanSearchAndSidebar();
 
   unreadCounts.clear();
-  sidebarItem = undefined;
 };
 
 export const stylesheet = true;

--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -26,15 +26,14 @@ const carrotSvg = dom('svg', {
  * @property {Function} onclick - Click event handler for this row
  * @property {string} [count] - Human-readable additional link text
  * @property {boolean} [carrot] - Whether to include a right-facing arrow on the link (ignored if count is specified)
- * @property {object} [attributes] - Object of attributes to add to the row element
  */
 
 /**
  * @param {sidebarRowOptions} options - Sidebar row options
  * @returns {HTMLLIElement} The constructed sidebar row
  */
-const buildSidebarRow = ({ label, onclick, href, count, carrot, attributes }) =>
-  dom('li', attributes ?? null, null, [
+const buildSidebarRow = ({ label, onclick, href, count, carrot }) =>
+  dom('li', null, null, [
     dom('a', { role: 'button', ...href ? { href } : {} }, { click: onclick }, [
       dom('span', null, null, [label]),
       count !== undefined

--- a/src/util/sidebar.js
+++ b/src/util/sidebar.js
@@ -26,14 +26,15 @@ const carrotSvg = dom('svg', {
  * @property {Function} onclick - Click event handler for this row
  * @property {string} [count] - Human-readable additional link text
  * @property {boolean} [carrot] - Whether to include a right-facing arrow on the link (ignored if count is specified)
+ * @property {object} [attributes] - Object of attributes to add to the row element
  */
 
 /**
  * @param {sidebarRowOptions} options - Sidebar row options
  * @returns {HTMLLIElement} The constructed sidebar row
  */
-const buildSidebarRow = ({ label, onclick, href, count, carrot }) =>
-  dom('li', null, null, [
+const buildSidebarRow = ({ label, onclick, href, count, carrot, attributes }) =>
+  dom('li', attributes ?? null, null, [
     dom('a', { role: 'button', ...href ? { href } : {} }, { click: onclick }, [
       dom('span', null, null, [label]),
       count !== undefined


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes the race condition causing Tag Tracking+ to only mark one post at a time as seen using NotificationBlock's storage architecture (keep a local copy of the storage in memory and don't rely on setting/getting local storage; using an `onStorageChanged` callback to grab any changes made by another instance of the extension).

Note: for all I know it's possible to get erroneous behavior with this method, too, albeit quite difficult in practice. In theory, if one did two back-to-back storage edits, which both asynchronously called `browser.storage.local.set`, this could maybe trigger `onStorageChanged` asynchronously twice, and if any code ran in between those two it would get the wrong data. I haven't seen `onStorageChanged` trigger twice though, so, eh. Anyway.

> This also—and I will make another PR that does not—resolves the fact that we now have an `onStorageChanged` handler and thus don't automatically call `clean().then(main)` on preference change by actually implementing a preference change handler that instantly cleans up and then re-adds the correct DOM elements according to the user's preferences without wiping the unread count cache and then slowly re-querying everything (visible on the sidebar elements). This has been a pet peeve of mine.
> 
> This, unfortunately, was a fairly large pain in the ass thanks to the sort-of-storing-data-in-the-DOM setup we currently have and the lack of easy access to the `<li>` elements in the sidebar items. I kind of hacked a prop into `buildSidebarRow` to enable this, which was needed for the scenario in which we are re-inserting the sidebar because the user changed the 
> 
> There's probably a better way to do this, like just always adding the sidebar element to the page and hiding it based on a classname on the body.

**Edit:** Ignore the quoted paragraphs.

This PR additionally replaces the behavior in which the entire script is restarted (`clean().then(main)`) on preference changes by implementing both of the the preference toggles entirely via data attributes which can be easily toggled instantly in `onStorageChanged`. This does mean inserting the whole sidebar element into the page even when it's disabled in preferences, but I don't think this is a big deal; Tumblr has like ten thousand DOM elements and this is like fifty.

Resolves #1247

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Test on an account with the virtual scroller experiment.

- Confirm that Tag Tracking+ clears the entire unread count of a tag when navigating to it
- Confirm that changing Tag Tracking+ preferences works, particularly when the initial load is still happening*

*not likely to be a problem with the data attribute method

I have not tested:

- Multiple tab coordination
- Behavior without the virtual scroller experiment
