### PR TITLE
Trim Reblogs: Add warning about trimming asks

### DIFF
--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -57,9 +57,11 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
   if (trail.some(({ layout = [] }) => layout.some(({ type }) => type === 'ask'))) {
     await new Promise(resolve => {
       showModal({
-        title: 'Note: Ask in Thread',
+        title: '⚠️ This thread contains an ask!',
         message: [
-          `If you trim an ask/answer from a thread, the thread will appear broken on custom themes, e.g. ${blog?.name ?? 'blogname'}.tumblr.com.`
+          `Trimming an ask from a thread will result in it appearing broken on custom themes (i.e. ${blog?.name}.tumblr.com).`,
+          '\n\n',
+          'To avoid issues with custom themes, leave the ask intact when trimming.'
         ],
         buttons: [
           modalCancelButton,

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -54,6 +54,21 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
     });
   }
 
+  if (trail.some(({ layout = [] }) => layout.some(({ type }) => type === 'ask'))) {
+    await new Promise(resolve => {
+      showModal({
+        title: 'Note: Ask in Thread',
+        message: [
+          'If you trim an ask/answer from a thread, the thread will appear broken on blog themes (blogname.tumblr.com).'
+        ],
+        buttons: [
+          modalCancelButton,
+          dom('button', { class: 'blue' }, { click: resolve }, ['Continue'])
+        ]
+      });
+    });
+  }
+
   const createPreviewItem = ({ blog, brokenBlog, content, disableCheckbox = false }) => {
     const { avatar, name } = blog ?? brokenBlog ?? blogPlaceholder;
     const { url: src } = avatar[avatar.length - 1];

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -29,9 +29,11 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
   const postId = postElement.dataset.id;
 
   const {
-    blog: { uuid },
-    isBlocksPostFormat
+    blog: { uuid }
   } = await timelineObject(postElement);
+
+  const { response: postData } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}?fields[blogs]=name,avatar`);
+  const { blog, content = [], trail = [], isBlocksPostFormat } = postData;
 
   if (isBlocksPostFormat === false) {
     await new Promise(resolve => {
@@ -51,9 +53,6 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
       });
     });
   }
-
-  const { response: postData } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}?fields[blogs]=name,avatar`);
-  const { blog, content = [], trail = [] } = postData;
 
   const createPreviewItem = ({ blog, brokenBlog, content, disableCheckbox = false }) => {
     const { avatar, name } = blog ?? brokenBlog ?? blogPlaceholder;

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -59,7 +59,7 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
       showModal({
         title: 'Note: Ask in Thread',
         message: [
-          'If you trim an ask/answer from a thread, the thread will appear broken on blog themes (blogname.tumblr.com).'
+          `If you trim an ask/answer from a thread, the thread will appear broken on custom themes, e.g. ${blog?.name ?? 'blogname'}.tumblr.com.`
         ],
         buttons: [
           modalCancelButton,


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds a warning message when one uses Trim Reblogs on an ask post, noting that it causes post corruption on blog themes.

<img width="516" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/2094261d-87b6-4434-be89-820a29fd648c">

Copy improvement suggestions are welcome.

Resolves #1089.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Use Trim Reblogs on an ask.
- Use Trim Reblogs on a legacy post (I get them from https://www.tumblr.com/best-of-reblogs).