### PR TITLE
NotificationBlock: Add note about "Mute Notifications"

### DIFF
--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -9,9 +9,9 @@ import { userBlogNames } from '../util/user.js';
 
 const storageKey = 'notificationblock.blockedPostTargetIDs';
 const meatballButtonBlockId = 'notificationblock-block';
-const meatballButtonBlockLabel = 'Block notifications';
+const meatballButtonBlockLabel = 'Hide notifications';
 const meatballButtonUnblockId = 'notificationblock-unblock';
-const meatballButtonUnblockLabel = 'Unblock notifications';
+const meatballButtonUnblockLabel = 'Unhide notifications';
 const notificationSelector = keyToCss('notification');
 
 let blockedPostTargetIDs;
@@ -48,8 +48,8 @@ const onButtonClicked = async function ({ currentTarget }) {
   const shouldBlockNotifications = blockedPostTargetIDs.includes(rootId) === false;
 
   const title = shouldBlockNotifications
-    ? 'Block this post\'s notifications?'
-    : 'Unblock this post\'s notifications?';
+    ? 'Hide this post\'s notifications?'
+    : 'Unhide this post\'s notifications?';
   const message = shouldBlockNotifications
     ? [
         'Notifications for this post will be hidden from your activity feed.',
@@ -60,8 +60,8 @@ const onButtonClicked = async function ({ currentTarget }) {
     : ['Notifications for this post will appear in your activity feed again.'];
 
   const textContent = shouldBlockNotifications
-    ? 'Block notifications'
-    : 'Unblock notifications';
+    ? 'Hide notifications'
+    : 'Unhide notifications';
   const className = shouldBlockNotifications
     ? 'red'
     : 'blue';

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -50,11 +50,15 @@ const onButtonClicked = async function ({ currentTarget }) {
   const title = shouldBlockNotifications
     ? 'Block this post\'s notifications?'
     : 'Unblock this post\'s notifications?';
-  const message = [
-    shouldBlockNotifications
-      ? 'Notifications for this post will be hidden from your activity feed.'
-      : 'Notifications for this post will appear in your activity feed again.'
-  ];
+  const message = shouldBlockNotifications
+    ? [
+        'Notifications for this post will be hidden from your activity feed.',
+        '\n\n',
+        'You can use Tumblr\'s "Mute Notifications" option in addition to or instead of this feature. ',
+        'It will completely prevent the post from generating notifications once enabled, and can be applied temporarily or permanently.'
+      ]
+    : ['Notifications for this post will appear in your activity feed again.'];
+
   const textContent = shouldBlockNotifications
     ? 'Block notifications'
     : 'Unblock notifications';

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -9,9 +9,9 @@ import { userBlogNames } from '../util/user.js';
 
 const storageKey = 'notificationblock.blockedPostTargetIDs';
 const meatballButtonBlockId = 'notificationblock-block';
-const meatballButtonBlockLabel = 'Hide notifications';
+const meatballButtonBlockLabel = 'Block notifications';
 const meatballButtonUnblockId = 'notificationblock-unblock';
-const meatballButtonUnblockLabel = 'Unhide notifications';
+const meatballButtonUnblockLabel = 'Unblock notifications';
 const notificationSelector = keyToCss('notification');
 
 let blockedPostTargetIDs;
@@ -48,8 +48,8 @@ const onButtonClicked = async function ({ currentTarget }) {
   const shouldBlockNotifications = blockedPostTargetIDs.includes(rootId) === false;
 
   const title = shouldBlockNotifications
-    ? 'Hide this post\'s notifications?'
-    : 'Unhide this post\'s notifications?';
+    ? 'Block this post\'s notifications?'
+    : 'Unblock this post\'s notifications?';
   const message = shouldBlockNotifications
     ? [
         'Notifications for this post will be hidden from your activity feed.',
@@ -60,8 +60,8 @@ const onButtonClicked = async function ({ currentTarget }) {
     : ['Notifications for this post will appear in your activity feed again.'];
 
   const textContent = shouldBlockNotifications
-    ? 'Hide notifications'
-    : 'Unhide notifications';
+    ? 'Block notifications'
+    : 'Unblock notifications';
   const className = shouldBlockNotifications
     ? 'red'
     : 'blue';

--- a/src/scripts/notificationblock.json
+++ b/src/scripts/notificationblock.json
@@ -1,6 +1,6 @@
 {
   "title": "NotificationBlock",
-  "description": "Hide a post's notifications",
+  "description": "Block a post's notifications",
   "icon": {
     "class_name": "ri-notification-off-line",
     "color": "white",

--- a/src/scripts/notificationblock.json
+++ b/src/scripts/notificationblock.json
@@ -1,6 +1,6 @@
 {
   "title": "NotificationBlock",
-  "description": "Block a post's notifications",
+  "description": "Hide a post's notifications",
   "icon": {
     "class_name": "ri-notification-off-line",
     "color": "white",

--- a/src/scripts/notificationblock.json
+++ b/src/scripts/notificationblock.json
@@ -7,5 +7,5 @@
     "background_color": "#f5223c"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#notificationblock",
-  "relatedTerms": [ "activity" ]
+  "relatedTerms": [ "activity", "mute notifications", "notes" ]
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds a note to the NotificationBlock interface about the new "Mute Notifications" native feature.

It also—and I'm fine with not doing this if it seems confusing—changes the terminology throughout the NotificationBlock UI to "hide," as the native feature is much closer to what "block" actually means than what the script does. It does not update the name of the script itself, although we could do that too (it would still start with "Notification").

<img width="591" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/c5e5643b-0a53-467c-9e60-ec73f9e80401">

Copy improvement suggestions are welcome.


Resolves #1173.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
n/a

