### PR TITLE
Set browser action tooltip to "XKit Rewritten"

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -19,7 +19,7 @@
 
   "browser_action": {
     "browser_style": true,
-    "default_title": "XKit Control Panel",
+    "default_title": "XKit Rewritten",
     "default_popup": "browser_action/popup.html",
     "default_icon": {
       "16": "icons/16.png",


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As per the linked issue, this makes the tooltip that appears when you mouse over the extension's control icon the name of the extension, to be consistent with other extensions (and as I think makes the most sense).

Currently, this does not change the actual title attribute of the preference window, i.e. if you open it standalone (I hadn't realized this was separate from the button tooltip). I have no particular opinion if it should be "XKit Control Panel," "XKit Rewritten Control Panel," "XKit Rewritten," whatever.

<img width="644" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/070b54f6-0930-4cb1-bee0-72703a9ceba6">

Resolves #988.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Ensure that the tooltip changes as desired in both Firefox and Chromium.
