### PR TITLE
Add Blogpacks, a script that allow you to create and save custom timelines

### DIFF
--- a/src/scripts/_index.json
+++ b/src/scripts/_index.json
@@ -1,6 +1,7 @@
 [
   "accesskit",
   "anti_capitalism",
+  "blogpacks",
   "classic_search",
   "cleanfeed",
   "collapsed_queue",

--- a/src/scripts/blogpacks.js
+++ b/src/scripts/blogpacks.js
@@ -17,7 +17,7 @@ const getSidebarOptions = (rows) => ({
 
 export const main = async () => {
   const { [storageKey]: blogpacks = [] } = await browser.storage.local.get(storageKey);
-  if (!blogpacks) return;
+  if (!blogpacks || blogpacks.length === 0) return;
   const sidebarRows = blogpacks.map(({ title, blogs }) => ({ label: title, link: getLink(blogs) }));
   addSidebarItem(getSidebarOptions(sidebarRows));
 };

--- a/src/scripts/blogpacks.js
+++ b/src/scripts/blogpacks.js
@@ -1,0 +1,24 @@
+import { addSidebarItem, removeSidebarItem } from '../util/sidebar.js';
+
+const storageKey = 'blogpacks.preferences.packs';
+const sidebarId = 'your-blogpacks';
+
+const getLink = (blogs) => '/timeline/blogpack?blogs=' + blogs;
+
+const getSidebarOptions = (rows) => ({
+  id: sidebarId,
+  title: 'Your blogpacks',
+  rows: rows.map(row => ({
+    label: row.label,
+    href: row.link,
+    carrot: true
+  }))
+});
+
+export const main = async () => {
+  const { [storageKey]: blogpacks = [] } = await browser.storage.local.get(storageKey);
+  if (!blogpacks) return;
+  const sidebarRows = blogpacks.map(({ title, blogs }) => ({ label: title, link: getLink(blogs) }));
+  addSidebarItem(getSidebarOptions(sidebarRows));
+};
+export const clean = async () => removeSidebarItem(sidebarId);

--- a/src/scripts/blogpacks.json
+++ b/src/scripts/blogpacks.json
@@ -1,0 +1,23 @@
+{
+  "title": "Blogpacks",
+  "description": "Create and save custom timelines",
+  "icon": {
+    "class_name": "ri-stack-line",
+    "color": "white",
+    "background_color": "#000"
+  },
+  "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#blogpacks",
+  "relatedTerms": [
+    "Blog Pack",
+    "Blogpacks",
+    "Secret Timeline"
+  ],
+  "preferences": {
+    "packs": {
+      "type": "iframe",
+      "label": "Manage your blogpacks",
+      "src": "/scripts/blogpacks/options/index.html",
+      "default": []
+    }
+  }
+}

--- a/src/scripts/blogpacks/options/index.css
+++ b/src/scripts/blogpacks/options/index.css
@@ -1,0 +1,167 @@
+:root {
+  --black: 21, 20, 25;
+  --white: 255, 255, 255;
+  --light-grey: 223, 223, 229;
+  --dark-grey: 207, 207, 216;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --black: 251, 251, 254;
+    --white: 66, 65, 77;
+    --light-grey: 83, 83, 94;
+    --dark-grey: 91, 91, 102;
+  }
+}
+
+html {
+  font-size: 14px;
+  scrollbar-color: rgb(var(--dark-grey)) transparent;
+  scrollbar-width: thin;
+  overflow-y: hidden;
+}
+
+body {
+  padding: 3px;
+
+  background-color: rgb(var(--white));
+  color: rgb(var(--black));
+  font-family: "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
+  font-size: 100%;
+  -webkit-user-select: none;
+  user-select: none;
+}
+
+section:not(:last-child) {
+  padding-bottom: 1ch;
+  border-bottom: 1px solid rgb(var(--dark-grey));
+  margin-bottom: 1em;
+}
+
+h3 {
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+input[type="text"] {
+  padding: 4px 8px;
+  border: none;
+  border-radius: 3px;
+
+  background-color: rgb(var(--light-grey));
+  color: rgb(var(--black));
+}
+
+#new-pack {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  grid-column-gap: 1rem;
+  grid-row-gap: 0.5rem;
+  align-items: center;
+  margin: 0;
+}
+
+#new-pack label {
+  grid-column: 1;
+}
+
+#new-pack input {
+  grid-column: 2;
+}
+
+#new-pack input:focus {
+  background-color: rgb(var(--dark-grey));
+}
+
+#new-pack button {
+  grid-column: 1 / 3;
+}
+
+#packs {
+  padding: 0;
+  margin: 0;
+
+  list-style-type: none;
+}
+
+#packs:empty::before {
+  content: "No blog packs are defined.";
+}
+
+.pack {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-column-gap: 1ch;
+  align-items: center;
+  padding-right: 1ch;
+  border-top: 1px solid rgb(var(--light-grey));
+}
+
+.pack:last-child {
+  border-bottom: 1px solid rgb(var(--light-grey));
+}
+
+.pack .move-buttons {
+  display: flex;
+  flex-direction: column;
+}
+
+.pack button {
+  padding: 3px;
+  border: none;
+
+  cursor: pointer;
+  background: none;
+}
+
+.pack button:disabled {
+  cursor: not-allowed;
+  opacity: 0.4;
+}
+
+.pack button i {
+  color: rgb(var(--black));
+  font-size: 1.5em;
+}
+
+.pack div {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: stretch;
+  padding: 1ch 0;
+}
+
+.pack .title {
+  margin-bottom: 0.5ch;
+}
+
+.pack input {
+  box-sizing: border-box;
+  width: 0;
+  min-width: 100%;
+}
+
+.pack input:disabled {
+  overflow-x: hidden;
+  border: none;
+
+  color: rgb(var(--black));
+  background: transparent;
+  text-overflow: ellipsis;
+}
+
+.pack input.title:disabled {
+  font-weight: bold;
+}
+
+.pack .controls {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.pack .controls > :not(:first-child) {
+  margin-left: 1ch;
+}

--- a/src/scripts/blogpacks/options/index.html
+++ b/src/scripts/blogpacks/options/index.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>XKit: Manage blog packs</title>
+    <link rel="stylesheet" href="/lib/normalize.min.css">
+    <link rel="stylesheet" href="/lib/remixicon/remixicon.css">
+    <link rel="stylesheet" href="index.css">
+  </head>
+  <body>
+    <main>
+      <section>
+        <h3>Add new blog pack</h3>
+        <form id="new-pack">
+          <label for="new-pack-title">Title</label>
+          <input id="new-pack-title" name="title" type="text" autocomplete="off" placeholder="My blog pack" required>
+          <label for="new-pack-blogs">Blogs</label>
+          <input id="new-pack-blogs" name="blogs" type="text" autocomplete="off" placeholder="blog1, blog2, blog3" required>
+          <button type="submit">Add pack</button>
+        </form>
+      </section>
+      <section>
+        <h3>Your custom packs</h3>
+        <ul id="packs"></ul>
+      </section>
+    </main>
+
+    <template id="pack-template">
+      <li class="pack">
+        <span class="move-buttons">
+          <button class="up"><i class="ri-arrow-up-s-line"></i></button>
+          <button class="down"><i class="ri-arrow-down-s-line"></i></button>
+        </span>
+        <div>
+          <input class="title" type="text" disabled required>
+          <input class="blogs" type="text" disabled required>
+        </div>
+        <span class="controls">
+          <button class="open" title="Open link in a new tab"><i class="ri-external-link-line"></i></button>
+          <button class="edit" title="Edit blog pack"><i class="ri-pencil-line"></i></button>
+          <button class="delete" title="Delete blog pack"><i class="ri-delete-bin-line"></i></button>
+        </span>
+      </li>
+    </template>
+
+    <script src="/browser_action/resize_frames.js" defer></script>
+    <script src="/lib/browser-polyfill.min.js"></script>
+    <script src="index.js"></script>
+  </body>
+</html>

--- a/src/scripts/blogpacks/options/index.js
+++ b/src/scripts/blogpacks/options/index.js
@@ -1,0 +1,124 @@
+const storageKey = 'blogpacks.preferences.packs';
+
+const packList = document.getElementById('packs');
+const packTemplate = document.getElementById('pack-template');
+
+const getLink = (blogs) => 'https://www.tumblr.com/timeline/blogpack?blogs=' + blogs;
+
+const sanitizeString = (str) => {
+  str = str.replace(/[^a-z0-9,-]/gim, '');
+  return str.trim();
+};
+
+const saveNewPack = async event => {
+  event.preventDefault();
+  const { currentTarget } = event;
+
+  if (!currentTarget.reportValidity()) {
+    return;
+  }
+  const { title, blogs } = currentTarget.elements;
+
+  const blogpack = {
+    title: title.value,
+    blogs: sanitizeString(blogs.value)
+  };
+
+  const { [storageKey]: blogpacks = [] } = await browser.storage.local.get(storageKey);
+  blogpacks.push(blogpack);
+  await browser.storage.local.set({ [storageKey]: blogpacks });
+
+  currentTarget.reset();
+};
+
+const movePack = async ({ currentTarget }) => {
+  const { [storageKey]: blogpacks = [] } = await browser.storage.local.get(storageKey);
+  const currentIndex = parseInt(currentTarget.closest('[id]').id);
+  const targetIndex = currentIndex + (currentTarget.className === 'down' ? 1 : -1);
+
+  [blogpacks[currentIndex], blogpacks[targetIndex]] = [blogpacks[targetIndex], blogpacks[currentIndex]];
+
+  browser.storage.local.set({ [storageKey]: blogpacks });
+};
+
+const openBlogpack = async ({ currentTarget }) => {
+  const { parentNode: { parentNode } } = currentTarget;
+
+  const { [storageKey]: blogpacks = [] } = await browser.storage.local.get(storageKey);
+  const index = parseInt(parentNode.id);
+  open(getLink(blogpacks[index].blogs), '_blank', 'noopener noreferrer');
+};
+
+const editBlogpack = async ({ currentTarget }) => {
+  const { parentNode: { parentNode } } = currentTarget;
+  const inputs = [...parentNode.querySelectorAll('input')];
+
+  if (currentTarget.title === 'Edit blog pack') {
+    currentTarget.title = 'Save blog pack';
+    currentTarget.firstElementChild.className = 'ri-save-3-fill';
+    inputs.forEach(input => {
+      input.disabled = false;
+    });
+  } else {
+    if (inputs.some(input => input.reportValidity() === false)) {
+      return;
+    }
+    currentTarget.title = 'Edit blog pack';
+    currentTarget.firstElementChild.className = 'ri-pencil-line';
+
+    const { [storageKey]: blogpacks = [] } = await browser.storage.local.get(storageKey);
+    const index = parseInt(parentNode.id);
+    const blogpack = blogpacks[index];
+
+    for (const input of inputs) {
+      input.disabled = true;
+      blogpack[input.className] = input.className === 'blogs' ? sanitizeString(input.value) : input.value;
+    }
+
+    browser.storage.local.set({ [storageKey]: blogpacks });
+  }
+};
+
+const deletePack = async ({ currentTarget }) => {
+  const { parentNode: { parentNode } } = currentTarget;
+
+  const { [storageKey]: blogpacks = [] } = await browser.storage.local.get(storageKey);
+  const index = parseInt(parentNode.id);
+  blogpacks.splice(index, 1);
+  browser.storage.local.set({ [storageKey]: blogpacks });
+};
+
+const renderPacks = async function () {
+  const { [storageKey]: blogpacks = [] } = await browser.storage.local.get(storageKey);
+
+  packList.append(...blogpacks.map(({ title, blogs }, index) => {
+    const packTemplateClone = packTemplate.content.cloneNode(true);
+
+    packTemplateClone.querySelector('.pack').id = index;
+
+    packTemplateClone.querySelector('.up').disabled = index === 0;
+    packTemplateClone.querySelector('.up').addEventListener('click', movePack);
+    packTemplateClone.querySelector('.down').disabled = index === (blogpacks.length - 1);
+    packTemplateClone.querySelector('.down').addEventListener('click', movePack);
+
+    packTemplateClone.querySelector('.title').value = title;
+    packTemplateClone.querySelector('.blogs').value = blogs;
+
+    packTemplateClone.querySelector('.open').addEventListener('click', openBlogpack);
+    packTemplateClone.querySelector('.edit').addEventListener('click', editBlogpack);
+    packTemplateClone.querySelector('.delete').addEventListener('click', deletePack);
+
+    return packTemplateClone;
+  }));
+};
+
+browser.storage.onChanged.addListener((changes, areaName) => {
+  if (areaName === 'local' && Object.keys(changes).includes(storageKey)) {
+    packList.textContent = '';
+    renderPacks();
+  }
+});
+
+document.getElementById('new-pack').addEventListener('submit', saveNewPack);
+
+renderPacks();


### PR DESCRIPTION
### Description

This PR add a new script to support [blogpacks](https://wip.tumblr.com/post/716494775180804097/is-there-a-chance-tumblr-could-make-a-custom), answering the #1264 enhancement request.
It allows to create lists of blogs in the Xkit popup (in a similar fashion to [tag bundles](https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#quick-tags)), that will then be displayed as links in the right sidebar.

<details><summary>Showcase</summary>

![blogpack demo](https://github.com/AprilSylph/XKit-Rewritten/assets/41714460/95512895-b109-4fb1-8b1d-5e77609bc1d7)

</details>

#### Technical details

A large portion of the code (mostly in `src/scripts/blogpacks/options` is a duplicate from the Quick Tags script, with a few minor tweaks.
The blog packs are stored in browser storage using the format below: 
```js
blogpacks.preferences.packs = [
  {
    title: string,
    blogs: string
  }, 
  ...
];
```

### Testing steps

#### XKit popup

- The script should display two fields and a button that create a new blogpack
  - blog names should be separated by commas `,`. Every character that is not in `[a-z][A-Z][0-9],-` should be removed upon saving (including spaces). Capitalised letters are ignored because it does not impact the url
 - The script should display a list of orderable blogpack entries
   - When there's no entry, there should be a placeholder message
   - Each entry can be deleted with the trash icon
   - Each entry can be edited with the pen icon. In this case, everything should behave the same as the first input fields
     - The pen icon is replaced by a save icon
   - Each entry can be opened directly in a new tab
This script does not check if the blog exists, nor if the blogs string is blank, nor if at least two blogs were provided (blogpacks requires >=2 blogs)

#### Sidebar list

- The list should not display if the plugin is disabled
- The list should not display if there is 0 blogpack
- The list should display on every page
- The list should display all packs defined in the plugin (no limit)
- Elements of the list should display the pack title
- Elements of the list should be link elements, and open the same tab by default
  - You can open in a new tab by middle/control-clicking, and copy the link with right click

#### Misc

- When updating/adding a blogpack in Xkit, the sidebar should be updated right away

### Further enhancements

Some things were left out of this PR for the sake of time and simplicity. Feel free to tell if you think something should be included in this PR. A list with rough estimations is provided below.

<details><summary>Possible enhancements</summary>

- Pick a cool colour for the icon (very easy)
- Do not display the list on every pages (easy)
- Make the list collapsible
- Hide the "Open link" icon when editing a pack (easy)
- 
- Store blogs differently in memory (url, list...) (easy-moderate)
- Display it in the left sidebar in a collapsible menu (a bit like sideblogs) (moderate)
- Add icons to blog packs (moderate)
- Add a searchbar for blog names (moderate-hard)
- Keep track of which blogpack is currently opened (easy) (require to "hack" the url by adding a new param)
- View and edit blogs in a pack directly on the blogpack page (hard)
- In Firefox, From XKit, open blogpacks in contextual tabs (hard/not possible ?)
</details>

:information_source: The accessibility of this script (for screen readers, etc) was not tested, since I'm not sure what tools to use for this