### PR TITLE
TimelineObject util: add `cache:false` option

### DIFF
--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -20,10 +20,12 @@ const unburyTimelineObject = () => {
 
 /**
  * @param {Element} postElement - An on-screen post
+ * @param {object} [options] - Configuration object
+ * @param {boolean} [options.cache] - Whether to use cached values
  * @returns {Promise<object>} - The post's buried timelineObject property
  */
-export const timelineObject = async function (postElement) {
-  if (!timelineObjectCache.has(postElement)) {
+export const timelineObject = async function (postElement, options) {
+  if (!timelineObjectCache.has(postElement) || options?.cache === false) {
     timelineObjectCache.set(postElement, inject(unburyTimelineObject, [], postElement));
   }
   return timelineObjectCache.get(postElement);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds back the ability to call `timelineObject` without pulling a potentially-outdated result from the cache. I had removed the distinction in #504.

Have not put much thought into whether this is worthwhile or whether the option should be reversed/named differently (`noCache: true` or whatever).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
(I tested this with NotificationBlock, but the diff was on another branch.)