### PR TITLE
CleanFeed: process unstretched media

### DIFF
--- a/src/scripts/cleanfeed.css
+++ b/src/scripts/cleanfeed.css
@@ -3,7 +3,7 @@
   position: relative;
 }
 
-.xkit-cleanfeed-filtered figure:not([style]):not(:hover)::after,
+.xkit-cleanfeed-filtered figure:not([aria-label]):not(:hover)::after,
 .xkit-cleanfeed-filtered [role="application"]:not(:hover)::after {
   position: absolute;
   top: 0;

--- a/src/scripts/cleanfeed.css
+++ b/src/scripts/cleanfeed.css
@@ -1,4 +1,4 @@
-.xkit-cleanfeed-filtered figure:not([style]):not(:hover),
+.xkit-cleanfeed-filtered figure:not([aria-label]):not(:hover),
 .xkit-cleanfeed-filtered [role="application"]:not(:hover) {
   position: relative;
 }


### PR DESCRIPTION
### Description
Fixes Cleanfeed not filtering certain "unstretched" media by changing the selector that targets media.


### Testing steps
Find or make a post that is filtered by your Cleanfeed preferences, add inline styling to the media `<figure>` element. The element should still be hidden as normal. The filter should also still ignore anon avatars in asks.

Resolves #1277 

