### PR TITLE
Tag Tracking+: add error handling to `refreshCount`

### DIFF
--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -38,7 +38,7 @@ const refreshCount = async function (tag) {
         }
       }
     } = await apiFetch(
-      Math.random() > 0.5 ? `/v2/hubs/${encodeURIComponent(tag)}/timeline` : '/sjkdnksjn',
+      `/v2/hubs/${encodeURIComponent(tag)}/timeline`,
       { queryParams: { limit: 20, sort: 'recent' } }
     );
 

--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -26,37 +26,43 @@ let sidebarItem;
 const refreshCount = async function (tag) {
   if (!trackedTags.includes(tag)) return;
 
-  const savedTimestamp = timestamps[tag] ?? 0;
-  const {
-    response: {
-      timeline: {
-        elements = [],
-        links
+  let unreadCountString = '⚠';
+
+  try {
+    const savedTimestamp = timestamps[tag] ?? 0;
+    const {
+      response: {
+        timeline: {
+          elements = [],
+          links
+        }
+      }
+    } = await apiFetch(
+      `/v2/hubs/${encodeURIComponent(tag)}/timeline`,
+      { queryParams: { limit: 20, sort: 'recent' } }
+    );
+
+    const posts = elements.filter(({ objectType, displayType, recommendedSource }) =>
+      objectType === 'post' &&
+      displayType === undefined &&
+      recommendedSource === null
+    );
+
+    let unreadCount = 0;
+
+    for (const { timestamp } of posts) {
+      if (timestamp <= savedTimestamp) {
+        break;
+      } else {
+        unreadCount++;
       }
     }
-  } = await apiFetch(
-    `/v2/hubs/${encodeURIComponent(tag)}/timeline`,
-    { queryParams: { limit: 20, sort: 'recent' } }
-  );
 
-  const posts = elements.filter(({ objectType, displayType, recommendedSource }) =>
-    objectType === 'post' &&
-    displayType === undefined &&
-    recommendedSource === null
-  );
-
-  let unreadCount = 0;
-
-  for (const { timestamp } of posts) {
-    if (timestamp <= savedTimestamp) {
-      break;
-    } else {
-      unreadCount++;
-    }
+    const showPlus = unreadCount === posts.length && links?.next;
+    unreadCountString = `${unreadCount}${showPlus ? '+' : ''}`;
+  } catch (exception) {
+    console.error(exception);
   }
-
-  const showPlus = unreadCount === posts.length && links?.next;
-  const unreadCountString = `${unreadCount}${showPlus ? '+' : ''}`;
 
   [document, ...(!sidebarItem || document.contains(sidebarItem) ? [] : [sidebarItem])]
     .flatMap(node =>

--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -38,7 +38,7 @@ const refreshCount = async function (tag) {
         }
       }
     } = await apiFetch(
-      `/v2/hubs/${encodeURIComponent(tag)}/timeline`,
+      Math.random() > 0.5 ? `/v2/hubs/${encodeURIComponent(tag)}/timeline` : '/sjkdnksjn',
       { queryParams: { limit: 20, sort: 'recent' } }
     );
 

--- a/src/scripts/tag_tracking_plus.js
+++ b/src/scripts/tag_tracking_plus.js
@@ -26,7 +26,7 @@ let sidebarItem;
 const refreshCount = async function (tag) {
   if (!trackedTags.includes(tag)) return;
 
-  let unreadCountString = '⚠';
+  let unreadCountString = '⚠️';
 
   try {
     const savedTimestamp = timestamps[tag] ?? 0;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As per the linked issue, this catches errors thrown by the refresh function in Tag Tracking+ and displays "⚠" instead of a count if it does so.

Resolves #847.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Un-revert the reverted commit and confirm that the script continues to update the non-errored tags.