### PR TITLE
Migrate to Manifest V3

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -77,8 +77,18 @@
     return installedScripts;
   };
 
+  const initInjection = () => {
+    const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
+    const script = document.createElement('script');
+    script.nonce = nonce;
+    script.src = browser.runtime.getURL('/injected.js');
+    document.documentElement.append(script);
+  };
+
   const init = async function () {
     $('style.xkit').remove();
+
+    initInjection();
 
     browser.storage.onChanged.addListener(onStorageChanged);
 

--- a/src/injected.js
+++ b/src/injected.js
@@ -100,7 +100,7 @@
     }
   };
 
-  const doApiFetch = async (resource, init = {}) => {
+  const doApiFetch = async (resource, init) => {
     // add XKit header to all API requests
     init.headers ??= {};
     init.headers['X-XKit'] = '1';

--- a/src/injected.js
+++ b/src/injected.js
@@ -161,8 +161,8 @@
     doPostForm
   };
 
-  document.documentElement.addEventListener('xkitinjectionrequest', async event => {
-    const { detail: { id, name, args }, target } = event;
+  document.documentElement.addEventListener('xkitinjectionrequest', async ({ detail, target }) => {
+    const { id, name, args } = JSON.parse(detail);
 
     const fallback = async () => new Error(`function "${name}" is not implemented in injectable_functions.js`);
     const func = injectables[name] ?? fallback;
@@ -170,12 +170,12 @@
     try {
       const result = await func(...args, target);
       target.dispatchEvent(
-        new CustomEvent('xkitinjectionresponse', { detail: { id, result } })
+        new CustomEvent('xkitinjectionresponse', { detail: JSON.stringify({ id, result }) })
       );
     } catch (exception) {
       target.dispatchEvent(
         new CustomEvent('xkitinjectionresponse', {
-          detail: {
+          detail: JSON.stringify({
             id,
             exception: {
               message: exception.message,
@@ -183,7 +183,7 @@
               stack: exception.stack,
               ...exception
             }
-          }
+          })
         })
       );
     }

--- a/src/injected.js
+++ b/src/injected.js
@@ -1,0 +1,191 @@
+'use strict';
+
+{
+  const getCssMap = async () => window.tumblr.getCssMap();
+  const getLanguageData = () => window.tumblr.languageData;
+
+  const unburyTimelineObject = (postElement) => {
+    const reactKey = Object.keys(postElement).find(key => key.startsWith('__reactFiber'));
+    let fiber = postElement[reactKey];
+
+    while (fiber !== null) {
+      const { timelineObject } = fiber.memoizedProps || {};
+      if (timelineObject !== undefined) {
+        return timelineObject;
+      } else {
+        fiber = fiber.return;
+      }
+    }
+  };
+
+  const unburyBlog = (element) => {
+    const reactKey = Object.keys(element).find(key => key.startsWith('__reactFiber'));
+    let fiber = element[reactKey];
+
+    while (fiber !== null) {
+      const { blog, blogSettings } = fiber.memoizedProps || {};
+      if (blog ?? blogSettings) {
+        return blog ?? blogSettings;
+      } else {
+        fiber = fiber.return;
+      }
+    }
+  };
+
+  const unburyTargetPostIds = async (notificationSelector) => {
+    [...document.querySelectorAll(notificationSelector)]
+      .forEach(notificationElement => {
+        const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
+        let fiber = notificationElement[reactKey];
+
+        while (fiber !== null) {
+          const { notification } = fiber.memoizedProps || {};
+          if (notification !== undefined) {
+            const { targetRootPostId, targetPostId } = notification;
+            notificationElement.dataset.targetRootPostId = targetRootPostId || targetPostId;
+            break;
+          } else {
+            fiber = fiber.return;
+          }
+        }
+      });
+  };
+
+  const getNotificationProps = function (notificationElement) {
+    const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
+    let fiber = notificationElement[reactKey];
+
+    while (fiber !== null) {
+      const { notification } = fiber.memoizedProps || {};
+      if (notification !== undefined) {
+        return notification;
+      } else {
+        fiber = fiber.return;
+      }
+    }
+  };
+
+  const testHeaderElement = (selector, menuElement) => {
+    const reactKey = Object.keys(menuElement).find(key => key.startsWith('__reactFiber'));
+    let fiber = menuElement[reactKey];
+
+    while (fiber !== null) {
+      if (fiber.elementType === 'header') {
+        return fiber.stateNode.matches(selector);
+      } else {
+        fiber = fiber.return;
+      }
+    }
+  };
+
+  const controlTagsInput = async ({ add, remove }) => {
+    add = add.map(tag => tag.trim()).filter((tag, index, array) => array.indexOf(tag) === index);
+
+    const selectedTagsElement = document.getElementById('selected-tags');
+    if (!selectedTagsElement) { return; }
+
+    const reactKey = Object.keys(selectedTagsElement).find(key => key.startsWith('__reactFiber'));
+    let fiber = selectedTagsElement[reactKey];
+
+    while (fiber !== null) {
+      let tags = fiber.stateNode?.state?.tags;
+      if (Array.isArray(tags)) {
+        tags.push(...add.filter(tag => tags.includes(tag) === false));
+        tags = tags.filter(tag => remove.includes(tag) === false);
+        fiber.stateNode.setState({ tags });
+        break;
+      } else {
+        fiber = fiber.return;
+      }
+    }
+  };
+
+  const doApiFetch = async (resource, init = {}) => {
+    // add XKit header to all API requests
+    init.headers ??= {};
+    init.headers['X-XKit'] = '1';
+
+    // convert all keys in the body to snake_case
+    if (init.body !== undefined) {
+      const objects = [init.body];
+
+      while (objects.length !== 0) {
+        const currentObjects = objects.splice(0);
+
+        currentObjects.forEach(obj => {
+          Object.keys(obj).forEach(key => {
+            const snakeCaseKey = key
+              .replace(/^[A-Z]/, match => match.toLowerCase())
+              .replace(/[A-Z]/g, match => `_${match.toLowerCase()}`);
+
+            if (snakeCaseKey !== key) {
+              obj[snakeCaseKey] = obj[key];
+              delete obj[key];
+            }
+          });
+        });
+
+        objects.push(
+          ...currentObjects
+            .flatMap(Object.values)
+            .filter(value => value instanceof Object)
+        );
+      }
+    }
+
+    return window.tumblr.apiFetch(resource, init);
+  };
+
+  const doNavigate = location => window.tumblr.navigate(location);
+
+  const doPostForm = async (resource, body) =>
+    fetch(resource, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+      body
+    }).then(async response =>
+      response.ok ? response.json() : Promise.reject(await response.json())
+    );
+
+  const injectables = {
+    getCssMap,
+    getLanguageData,
+    unburyTimelineObject,
+    unburyBlog,
+    unburyTargetPostIds,
+    getNotificationProps,
+    testHeaderElement,
+    controlTagsInput,
+    doApiFetch,
+    doNavigate,
+    doPostForm
+  };
+
+  document.documentElement.addEventListener('xkitinjectionrequest', async event => {
+    const { detail: { id, name, args }, target } = event;
+
+    const fallback = async () => new Error(`function "${name}" is not implemented in injectable_functions.js`);
+    const func = injectables[name] ?? fallback;
+
+    try {
+      const result = await func(...args, target);
+      target.dispatchEvent(
+        new CustomEvent('xkitinjectionresponse', { detail: { id, result } })
+      );
+    } catch (exception) {
+      target.dispatchEvent(
+        new CustomEvent('xkitinjectionresponse', {
+          detail: {
+            id,
+            exception: {
+              message: exception.message,
+              name: exception.name,
+              stack: exception.stack,
+              ...exception
+            }
+          }
+        })
+      );
+    }
+  });
+}

--- a/src/injected.js
+++ b/src/injected.js
@@ -161,6 +161,14 @@
     doPostForm
   };
 
+  /**
+   * Apparently required in Firefox to prevent "Permission denied to access property" error when sending an
+   * object cross-world.
+   * @see https://stackoverflow.com/a/46081249
+   */
+  /* globals cloneInto */
+  const clone = data => typeof cloneInto !== 'undefined' ? cloneInto(data, document.defaultView) : data;
+
   document.documentElement.addEventListener('xkitinjectionrequest', async event => {
     const { detail: { id, name, args }, target } = event;
 
@@ -170,12 +178,12 @@
     try {
       const result = await func(...args, target);
       target.dispatchEvent(
-        new CustomEvent('xkitinjectionresponse', { detail: { id, result } })
+        new CustomEvent('xkitinjectionresponse', { detail: clone({ id, result }) })
       );
     } catch (exception) {
       target.dispatchEvent(
         new CustomEvent('xkitinjectionresponse', {
-          detail: {
+          detail: clone({
             id,
             exception: {
               message: exception.message,
@@ -183,7 +191,7 @@
               stack: exception.stack,
               ...exception
             }
-          }
+          })
         })
       );
     }

--- a/src/injected.js
+++ b/src/injected.js
@@ -161,8 +161,8 @@
     doPostForm
   };
 
-  document.documentElement.addEventListener('xkitinjectionrequest', async ({ detail, target }) => {
-    const { id, name, args } = JSON.parse(detail);
+  document.documentElement.addEventListener('xkitinjectionrequest', async event => {
+    const { detail: { id, name, args }, target } = event;
 
     const fallback = async () => new Error(`function "${name}" is not implemented in injectable_functions.js`);
     const func = injectables[name] ?? fallback;
@@ -170,12 +170,12 @@
     try {
       const result = await func(...args, target);
       target.dispatchEvent(
-        new CustomEvent('xkitinjectionresponse', { detail: JSON.stringify({ id, result }) })
+        new CustomEvent('xkitinjectionresponse', { detail: { id, result } })
       );
     } catch (exception) {
       target.dispatchEvent(
         new CustomEvent('xkitinjectionresponse', {
-          detail: JSON.stringify({
+          detail: {
             id,
             exception: {
               message: exception.message,
@@ -183,7 +183,7 @@
               stack: exception.stack,
               ...exception
             }
-          })
+          }
         })
       );
     }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "XKit Rewritten",
   "version": "0.22.2",
 
@@ -17,7 +17,7 @@
     "128": "icons/128.png"
   },
 
-  "browser_action": {
+  "action": {
     "browser_style": true,
     "default_title": "XKit Rewritten",
     "default_popup": "browser_action/popup.html",
@@ -36,7 +36,16 @@
   },
 
   "permissions": [ "storage" ],
-  "web_accessible_resources": [ "*.js", "*.json", "*.css", "*.svg" ],
+  "host_permissions": [
+    "*://www.tumblr.com/*"
+  ],
+  "web_accessible_resources": [
+    {
+      "resources": [ "*.js", "*.json", "*.css", "*.svg" ],
+      "matches": [ "*://www.tumblr.com/*" ]
+    }
+  ],
+
   "content_scripts": [
     {
       "matches": [
@@ -65,10 +74,10 @@
     }
   ],
 
-  "minimum_chrome_version": "89",
+  "minimum_chrome_version": "102",
   "browser_specific_settings": {
     "gecko": {
-      "strict_min_version": "89.0a1"
+      "strict_min_version": "101.0a1"
     }
   }
 }

--- a/src/scripts/notificationblock.js
+++ b/src/scripts/notificationblock.js
@@ -22,6 +22,7 @@ const buildCss = () => `:is(${
   blockedPostTargetIDs.map(rootId => `[data-target-root-post-id="${rootId}"]`).join(', ')
 }) { display: none !important; }`;
 
+/*
 const unburyTargetPostIds = async (notificationSelector) => {
   [...document.querySelectorAll(notificationSelector)]
     .forEach(notificationElement => {
@@ -40,8 +41,9 @@ const unburyTargetPostIds = async (notificationSelector) => {
       }
     });
 };
+ */
 
-const processNotifications = () => inject(unburyTargetPostIds, [notificationSelector]);
+const processNotifications = () => inject('unburyTargetPostIds', [notificationSelector]);
 
 const muteNotificationsMessage = [
   '\n\n',

--- a/src/scripts/quote_replies.js
+++ b/src/scripts/quote_replies.js
@@ -23,6 +23,7 @@ let originalPostTag;
 let tagReplyingBlog;
 let newTab;
 
+/*
 const getNotificationProps = function () {
   const notificationElement = document.currentScript.parentElement;
   const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
@@ -37,9 +38,10 @@ const getNotificationProps = function () {
     }
   }
 };
+ */
 
 const processNotifications = notifications => notifications.forEach(async notification => {
-  const { notification: notificationProps, tumblelogName } = await inject(getNotificationProps, [], notification);
+  const { notification: notificationProps, tumblelogName } = await inject('getNotificationProps', [], notification);
 
   if (!['reply', 'note_mention'].includes(notificationProps.type)) return;
 

--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -1,6 +1,6 @@
 import { inject } from './inject.js';
 
-export const cssMap = await inject(async () => window.tumblr.getCssMap());
+export const cssMap = await inject('getCssMap');
 
 /**
  * @param {...string} keys - One or more element source names

--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -10,8 +10,7 @@ export const inject = (name, args = [], target = document.documentElement) =>
     const requestId = String(Math.random());
     const data = { name, args, id: requestId };
 
-    const responseHandler = ({ detail }) => {
-      const { id, result, exception } = JSON.parse(detail);
+    const responseHandler = ({ detail: { id, result, exception } }) => {
       if (id !== requestId) return;
 
       target.removeEventListener('xkitinjectionresponse', responseHandler);
@@ -20,6 +19,6 @@ export const inject = (name, args = [], target = document.documentElement) =>
     target.addEventListener('xkitinjectionresponse', responseHandler);
 
     target.dispatchEvent(
-      new CustomEvent('xkitinjectionrequest', { detail: JSON.stringify(data), bubbles: true })
+      new CustomEvent('xkitinjectionrequest', { detail: data, bubbles: true })
     );
   });

--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -1,4 +1,12 @@
 /**
+ * Apparently required in Firefox to prevent "Permission denied to access property" error when sending an
+ * object cross-world.
+ * @see https://stackoverflow.com/a/46081249
+ */
+/* globals cloneInto */
+const clone = data => typeof cloneInto !== 'undefined' ? cloneInto(data, document.defaultView) : data;
+
+/**
  * @param {string} name - Function name to run in the page context; must be in injectables.js
  * @param {Array} [args] - Array of arguments to pass to the function via spread
  * @param {Element} [target] - Target element; will be accessible as the last argument to the
@@ -19,6 +27,6 @@ export const inject = (name, args = [], target = document.documentElement) =>
     target.addEventListener('xkitinjectionresponse', responseHandler);
 
     target.dispatchEvent(
-      new CustomEvent('xkitinjectionrequest', { detail: data, bubbles: true })
+      new CustomEvent('xkitinjectionrequest', { detail: clone(data), bubbles: true })
     );
   });

--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -10,7 +10,8 @@ export const inject = (name, args = [], target = document.documentElement) =>
     const requestId = String(Math.random());
     const data = { name, args, id: requestId };
 
-    const responseHandler = ({ detail: { id, result, exception } }) => {
+    const responseHandler = ({ detail }) => {
+      const { id, result, exception } = JSON.parse(detail);
       if (id !== requestId) return;
 
       target.removeEventListener('xkitinjectionresponse', responseHandler);
@@ -19,6 +20,6 @@ export const inject = (name, args = [], target = document.documentElement) =>
     target.addEventListener('xkitinjectionresponse', responseHandler);
 
     target.dispatchEvent(
-      new CustomEvent('xkitinjectionrequest', { detail: data, bubbles: true })
+      new CustomEvent('xkitinjectionrequest', { detail: JSON.stringify(data), bubbles: true })
     );
   });

--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -1,59 +1,24 @@
-import { dom } from './dom.js';
-
-const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
-const AsyncFunction = Object.getPrototypeOf(async function () {}).constructor;
-
 /**
- * @param {Function} func - Function to run in the page context (can be async)
+ * @param {string} name - Function name to run in the page context; must be in injectables.js
  * @param {Array} [args] - Array of arguments to pass to the function via spread
- * @param {Element} [target] - Element to append script to; will be accessible as
- *                             document.currentScript.parentElement in the injected function.
+ * @param {Element} [target] - Target element; will be accessible as the last argument to the
+ *                             injected function.
  * @returns {Promise<any>} The return value of the function, or the caught exception
  */
-export const inject = async (func, args = [], target = document.documentElement) => {
-  const name = `xkit$${func.name || 'injected'}`;
-  const async = func instanceof AsyncFunction;
+export const inject = (name, args = [], target = document.documentElement) =>
+  new Promise((resolve, reject) => {
+    const requestId = String(Math.random());
+    const data = { name, args, id: requestId };
 
-  const script = dom('script', { nonce }, null, [`{
-    const { dataset } = document.currentScript;
-    const ${name} = ${func.toString()};
-    const returnValue = ${name}(...${JSON.stringify(args)});
-    ${async
-      ? `returnValue
-          .then(result => { dataset.result = JSON.stringify(result || null); })
-          .catch(exception => { dataset.exception = JSON.stringify({
-            message: exception.message,
-            name: exception.name,
-            stack: exception.stack,
-            ...exception
-          })})
-        `
-      : 'dataset.result = JSON.stringify(returnValue || null);'
-    }
-  }`]);
+    const responseHandler = ({ detail: { id, result, exception } }) => {
+      if (id !== requestId) return;
 
-  if (async) {
-    return new Promise((resolve, reject) => {
-      const attributeObserver = new MutationObserver((mutations, observer) => {
-        if (mutations.some(({ attributeName }) => attributeName === 'data-result')) {
-          observer.disconnect();
-          resolve(JSON.parse(script.dataset.result));
-        } else if (mutations.some(({ attributeName }) => attributeName === 'data-exception')) {
-          observer.disconnect();
-          reject(JSON.parse(script.dataset.exception));
-        }
-      });
+      target.removeEventListener('xkitinjectionresponse', responseHandler);
+      exception ? reject(exception) : resolve(result);
+    };
+    target.addEventListener('xkitinjectionresponse', responseHandler);
 
-      attributeObserver.observe(script, {
-        attributes: true,
-        attributeFilter: ['data-result', 'data-exception']
-      });
-      target.append(script);
-      script.remove();
-    });
-  } else {
-    target.append(script);
-    script.remove();
-    return JSON.parse(script.dataset.result);
-  }
-};
+    target.dispatchEvent(
+      new CustomEvent('xkitinjectionrequest', { detail: data, bubbles: true })
+    );
+  });

--- a/src/util/language_data.js
+++ b/src/util/language_data.js
@@ -1,6 +1,6 @@
 import { inject } from './inject.js';
 
-export const languageData = await inject(() => window.tumblr.languageData);
+export const languageData = await inject('getLanguageData');
 
 /**
  * @param {string} rootString - The English string to translate

--- a/src/util/meatballs.js
+++ b/src/util/meatballs.js
@@ -8,6 +8,7 @@ import { blogData, timelineObject } from './react_props.js';
 const postHeaderSelector = `${postSelector} article > header`;
 const blogHeaderSelector = `[style*="--blog-title-color"] > div > div > header, ${keyToCss('blogCardHeaderBar')}`;
 
+/*
 const testHeaderElement = (selector) => {
   const menuElement = document.currentScript.parentElement;
   const reactKey = Object.keys(menuElement).find(key => key.startsWith('__reactFiber'));
@@ -21,6 +22,7 @@ const testHeaderElement = (selector) => {
     }
   }
 };
+ */
 
 const meatballItems = {};
 const blogMeatballItems = {};
@@ -62,12 +64,12 @@ export const unregisterBlogMeatballItem = id => {
 };
 
 const addMeatballItems = meatballMenus => meatballMenus.forEach(async meatballMenu => {
-  const inPostHeader = await inject(testHeaderElement, [postHeaderSelector], meatballMenu);
+  const inPostHeader = await inject('testHeaderElement', [postHeaderSelector], meatballMenu);
   if (inPostHeader) {
     addPostMeatballItem(meatballMenu);
     return;
   }
-  const inBlogHeader = await inject(testHeaderElement, [blogHeaderSelector], meatballMenu);
+  const inBlogHeader = await inject('testHeaderElement', [blogHeaderSelector], meatballMenu);
   if (inBlogHeader) {
     addBlogMeatballItem(meatballMenu);
   }

--- a/src/util/mega_editor.js
+++ b/src/util/mega_editor.js
@@ -44,15 +44,5 @@ export const megaEdit = async function (postIds, options) {
     delete requestBody.tags;
   }
 
-  return inject(
-    async (resource, body) =>
-      fetch(resource, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
-        body
-      }).then(async response =>
-        response.ok ? response.json() : Promise.reject(await response.json())
-      ),
-    [`https://www.tumblr.com/${pathname}`, $.param(requestBody)]
-  );
+  return inject('doPostForm', [`https://www.tumblr.com/${pathname}`, $.param(requestBody)]);
 };

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -3,6 +3,7 @@ import { primaryBlogName, userBlogNames, adminBlogNames } from './user.js';
 
 const timelineObjectCache = new WeakMap();
 
+/*
 const unburyTimelineObject = () => {
   const postElement = document.currentScript.parentElement;
   const reactKey = Object.keys(postElement).find(key => key.startsWith('__reactFiber'));
@@ -17,6 +18,7 @@ const unburyTimelineObject = () => {
     }
   }
 };
+ */
 
 /**
  * @param {Element} postElement - An on-screen post
@@ -24,11 +26,12 @@ const unburyTimelineObject = () => {
  */
 export const timelineObject = async function (postElement) {
   if (!timelineObjectCache.has(postElement)) {
-    timelineObjectCache.set(postElement, inject(unburyTimelineObject, [], postElement));
+    timelineObjectCache.set(postElement, inject('unburyTimelineObject', [], postElement));
   }
   return timelineObjectCache.get(postElement);
 };
 
+/*
 const unburyBlog = () => {
   const element = document.currentScript.parentElement;
   const reactKey = Object.keys(element).find(key => key.startsWith('__reactFiber'));
@@ -43,12 +46,13 @@ const unburyBlog = () => {
     }
   }
 };
+ */
 
 /**
  * @param {Element} meatballMenu - An on-screen meatball menu element in a blog modal header or blog card
  * @returns {Promise<object>} - The post's buried blog or blogSettings property. Some blog data fields, such as "followed," are not available in blog cards.
  */
-export const blogData = async (meatballMenu) => inject(unburyBlog, [], meatballMenu);
+export const blogData = async (meatballMenu) => inject('unburyBlog', [], meatballMenu);
 
 export const isMyPost = async (postElement) => {
   const { blog, isSubmission, postAuthor } = await timelineObject(postElement);
@@ -70,6 +74,7 @@ export const isMyPost = async (postElement) => {
   return false;
 };
 
+/*
 const controlTagsInput = async ({ add, remove }) => {
   add = add.map(tag => tag.trim()).filter((tag, index, array) => array.indexOf(tag) === index);
 
@@ -91,6 +96,7 @@ const controlTagsInput = async ({ add, remove }) => {
     }
   }
 };
+ */
 
 /**
  * Manipulate post form tags
@@ -99,4 +105,4 @@ const controlTagsInput = async ({ add, remove }) => {
  * @param {string[]} [options.remove] - Tags to remove
  * @returns {Promise<void>} Resolves when finished
  */
-export const editPostFormTags = async ({ add = [], remove = [] }) => inject(controlTagsInput, [{ add, remove }]);
+export const editPostFormTags = async ({ add = [], remove = [] }) => inject('controlTagsInput', [{ add, remove }]);

--- a/src/util/tumblr_helpers.js
+++ b/src/util/tumblr_helpers.js
@@ -6,44 +6,7 @@ import { inject } from './inject.js';
  * @returns {Promise<Response|Error>} Resolves or rejects with result of window.tumblr.apiFetch()
  */
 export const apiFetch = async function (...args) {
-  return inject(
-    async (resource, init = {}) => {
-      // add XKit header to all API requests
-      init.headers ??= {};
-      init.headers['X-XKit'] = '1';
-
-      // convert all keys in the body to snake_case
-      if (init.body !== undefined) {
-        const objects = [init.body];
-
-        while (objects.length !== 0) {
-          const currentObjects = objects.splice(0);
-
-          currentObjects.forEach(obj => {
-            Object.keys(obj).forEach(key => {
-              const snakeCaseKey = key
-                .replace(/^[A-Z]/, match => match.toLowerCase())
-                .replace(/[A-Z]/g, match => `_${match.toLowerCase()}`);
-
-              if (snakeCaseKey !== key) {
-                obj[snakeCaseKey] = obj[key];
-                delete obj[key];
-              }
-            });
-          });
-
-          objects.push(
-            ...currentObjects
-              .flatMap(Object.values)
-              .filter(value => value instanceof Object)
-          );
-        }
-      }
-
-      return window.tumblr.apiFetch(resource, init);
-    },
-    args
-  );
+  return inject('doApiFetch', args);
 };
 
 /**
@@ -100,7 +63,7 @@ export const isNpfCompatible = postData => {
 };
 
 export const navigate = location =>
-  inject(location => window.tumblr.navigate(location), [location]);
+  inject('doNavigate', [location]);
 
 export const onClickNavigate = event => {
   if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;

--- a/src/util/tumblr_helpers.js
+++ b/src/util/tumblr_helpers.js
@@ -1,12 +1,13 @@
 import { inject } from './inject.js';
 
 /**
- * @param {...any} args - Arguments to pass to window.tumblr.apiFetch()
+ * @param {string} resource - path for the API route to fetch
+ * @param {object} [init] - fetch options
  * @see {@link https://github.com/tumblr/docs/blob/master/web-platform.md#apifetch}
  * @returns {Promise<Response|Error>} Resolves or rejects with result of window.tumblr.apiFetch()
  */
-export const apiFetch = async function (...args) {
-  return inject('doApiFetch', args);
+export const apiFetch = async function (resource, init = {}) {
+  return inject('doApiFetch', [resource, init]);
 };
 
 /**


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

So we know it can be done:

This is a functional MV3 port that works in both Chrome and Firefox without per-browser modification, i.e. slightly updated #921. There are a number of methods to do our main world script injection; this one uses bubbled custom events and puts all of the code in one file with a listener (simplest way to feature parity).

I had to append the target element as the last argument to the injected function unconditionally; this means injected functions can't have optional arguments. We could do other stuff: make it the first argument, change the signature to take an object of named fields, whatever.

The most interesting thing about this is that Firefox requires an explicit call to `cloneInto` when passing an object via `CustomEvent`, while Chrome does not; my understanding that the Firefox-specific Xray Vision stuff was all things that Chrome couldn't do and thus a cross-platform extension wouldn't need to use them. May make a https://github.com/w3c/webextensions issue about this or something, idk. 

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
no specific tests
