### PR TITLE
Scroll to Bottom: Fix scrolling stopping after one page

### DIFF
--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -8,7 +8,7 @@ $(`[id="${scrollToBottomButtonId}"]`).remove();
 const activeClass = 'xkit-scroll-to-bottom-active';
 
 const loaderSelector = `
-${keyToCss('timeline', 'blogRows')} > ${keyToCss('loader')},
+${keyToCss('timeline', 'blogRows')} > ${keyToCss('loader', 'container')},
 ${keyToCss('notifications')} + ${keyToCss('loader')}
 `;
 const knightRiderLoaderSelector = `:is(${loaderSelector}) > ${keyToCss('knightRiderLoader')}`;

--- a/src/scripts/scroll_to_bottom.js
+++ b/src/scripts/scroll_to_bottom.js
@@ -8,7 +8,7 @@ $(`[id="${scrollToBottomButtonId}"]`).remove();
 const activeClass = 'xkit-scroll-to-bottom-active';
 
 const loaderSelector = `
-${keyToCss('timeline', 'blogRows')} > ${keyToCss('loader', 'container')},
+${keyToCss('timeline', 'blogRows')} > :last-child,
 ${keyToCss('notifications')} + ${keyToCss('loader')}
 `;
 const knightRiderLoaderSelector = `:is(${loaderSelector}) > ${keyToCss('knightRiderLoader')}`;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes Scroll to Bottom's loader selection code being out of date. The element containing the loader beneath a timeline now has CSS classes equivalent to `.container.condensed`.

Resolves #1286.

I don't love using "container" as a translated CSS class key because it has so many classnames associated with it, but oh well.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Use Scroll to Bottom on a dashboard, on a channel page, on the followers page of a blog, and the activity page. Confirm that it does not stop scrolling after the first page and does stop scrolling when it runs out of content.

(This continues to not work on the following page, as Tumblr does not show a loading element there.)