### PR TITLE
TimeFormat: Don't format `<time>` elements outside of posts

### DIFF
--- a/src/scripts/timeformat.js
+++ b/src/scripts/timeformat.js
@@ -1,4 +1,5 @@
 import moment from '../lib/moment.js';
+import { keyToCss } from '../util/css_map.js';
 import { pageModifications } from '../util/mutations.js';
 import { getPreferences } from '../util/preferences.js';
 
@@ -41,7 +42,7 @@ const formatTimeElements = function (timeElements) {
 
 export const main = async function () {
   ({ format, displayRelative } = await getPreferences('timeformat'));
-  pageModifications.register('time[datetime]', formatTimeElements);
+  pageModifications.register(`${keyToCss('timestamp')}[datetime]`, formatTimeElements);
 };
 
 export const clean = async function () {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This makes Timeformat's selector more specific so that it doesn't affect `<time>` elements that it isn't supposed to.

Resolves #1289.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Enable TimeFormat.
- Confirm that the timestamp at the top of [tumblr.com/explore/answertime](https://www.tumblr.com/explore/answertime) is not affected.
- Confirm that the timestamps of posts on the dash and the radar post are still affected.

