### PR TITLE
Experiment: Create navigation utility

### DIFF
--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -5,7 +5,6 @@ import { onNewPosts } from '../util/mutations.js';
 import { keyToCss } from '../util/css_map.js';
 import { translate } from '../util/language_data.js';
 import { userBlogs } from '../util/user.js';
-import { onNavigation } from '../util/on_navigation.js';
 
 const hiddenAttribute = 'data-show-originals-hidden';
 const lengthenedClass = 'xkit-show-originals-lengthened';
@@ -127,8 +126,6 @@ export const main = async function () {
   disabledBlogs = [...whitelist, ...showOwnReblogs ? nonGroupUserBlogs : []];
 
   onNewPosts.addListener(processPosts);
-
-  onNavigation.register(() => console.log('navigated to', location.href));
 };
 
 export const clean = async function () {

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -5,6 +5,7 @@ import { onNewPosts } from '../util/mutations.js';
 import { keyToCss } from '../util/css_map.js';
 import { translate } from '../util/language_data.js';
 import { userBlogs } from '../util/user.js';
+import { onNavigation } from '../util/on_navigation.js';
 
 const hiddenAttribute = 'data-show-originals-hidden';
 const lengthenedClass = 'xkit-show-originals-lengthened';
@@ -126,6 +127,8 @@ export const main = async function () {
   disabledBlogs = [...whitelist, ...showOwnReblogs ? nonGroupUserBlogs : []];
 
   onNewPosts.addListener(processPosts);
+
+  onNavigation.register(() => console.log('navigated to', location.href));
 };
 
 export const clean = async function () {

--- a/src/util/on_navigation.js
+++ b/src/util/on_navigation.js
@@ -1,3 +1,4 @@
+import { getRandomHexString } from './crypto.js';
 import { inject } from './inject.js';
 
 export const onNavigation = Object.freeze({
@@ -10,10 +11,13 @@ export const onNavigation = Object.freeze({
   }
 });
 
-addEventListener('navigation', () =>
+const eventName = `xkit-navigation-${getRandomHexString()}`;
+
+addEventListener(eventName, () =>
   onNavigation.listeners.forEach(callback => callback())
 );
 
-inject(() =>
-  window.tumblr.on('navigation', () => dispatchEvent(new CustomEvent('navigation')))
+inject(
+  eventName => window.tumblr.on('navigation', () => dispatchEvent(new CustomEvent(eventName))),
+  [eventName]
 );

--- a/src/util/on_navigation.js
+++ b/src/util/on_navigation.js
@@ -1,0 +1,19 @@
+import { inject } from './inject.js';
+
+export const onNavigation = Object.freeze({
+  listeners: new Set(),
+  register (callback) {
+    this.listeners.add(callback);
+  },
+  unregister (callback) {
+    this.listeners.delete(callback);
+  }
+});
+
+addEventListener('navigation', () =>
+  onNavigation.listeners.forEach(callback => callback())
+);
+
+inject(() =>
+  window.tumblr.on('navigation', () => dispatchEvent(new CustomEvent('navigation')))
+);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This implements a wrapper around window.tumblr.on('navigation') so that XKit Rewritten can subscribe to soft navigation events.

More elegant form of #453.

Potentially useful for simplifying logic where something must happen when a navigation event removes an element from the page (as one can't detect removals with `pageModifications`), but when using both one can't be sure of the order they're fired in and thus must be careful, presumably.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

