### PR TITLE
Mutual checker notification filter

### DIFF
--- a/src/scripts/mutual_checker.css
+++ b/src/scripts/mutual_checker.css
@@ -7,7 +7,6 @@ svg.xkit-mutual-icon {
   margin-right: 0.5ch;
 }
 
-[data-notification-feed] [data-mutual-checker-hidden],
 [data-timeline="/v2/timeline/dashboard"] [data-mutual-checker-hidden] article {
   display: none;
 }

--- a/src/scripts/mutual_checker.css
+++ b/src/scripts/mutual_checker.css
@@ -1,12 +1,13 @@
 svg.xkit-mutual-icon {
   vertical-align: text-bottom;
 
-	height: 1.23em;
+  height: 1.23em;
   margin-top: 0;
   margin-left: 0;
-	margin-right: 0.5ch;
+  margin-right: 0.5ch;
 }
 
+[data-notification-feed] [data-mutual-checker-hidden],
 [data-timeline="/v2/timeline/dashboard"] [data-mutual-checker-hidden] article {
   display: none;
 }

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -12,8 +12,7 @@ const hiddenAttribute = 'data-mutual-checker-hidden';
 const mutualsClass = 'from-mutual';
 const postAttributionSelector = `header ${keyToCss('attribution')} > span:not(${keyToCss('reblogAttribution')}) a`;
 
-const styleElement = buildStyle();
-const buildCss = () => `${keyToCss('notification')}:not([data-mutuals]) { display: none !important; }`;
+const styleElement = buildStyle(`${keyToCss('notification')}:not([data-mutuals]) { display: none !important; }`);
 
 const regularPath = 'M593 500q0-45-22.5-64.5T500 416t-66.5 19-18.5 65 18.5 64.5T500 583t70.5-19 22.5-64zm-90 167q-44 0-83.5 18.5t-63 51T333 808v25h334v-25q0-39-22-71.5t-59.5-51T503 667zM166 168l14-90h558l12-78H180q-8 0-51 63l-42 63v209q-19 3-52 3t-33-3q-1 1 0 27 3 53 0 53l32-2q35-1 53 2v258H2l-3 40q-2 41 3 41 42 0 64-1 7-1 21 1v246h756q25 0 42-13 14-10 22-27 5-13 8-28l1-13V275q0-47-3-63-5-24-22.5-34T832 168H166zm667 752H167V754q17 0 38.5-6.5T241 730q16-12 16-26 0-21-33-28-19-4-57-4-3 0-1-51 2-37 1-36V421q88 0 90-48 1-20-33-30-24-6-57-6-4 0-2-44l2-43h635q14 0 22.5 11t8.5 26v543q0 5 4 26 5 30 5 42 1 22-9 22z';
 const aprilFoolsPath = 'M858 352q-6-14-8-35-2-12-4-38-3-38-6-54-7-28-22-43t-43-22q-16-3-54-6-26-2-38-4-21-2-34.5-8T619 124q-9-7-28-24-29-25-44-34-24-16-47-16t-47 16q-15 9-44 34-19 17-28 24-16 12-29.5 18t-34.5 8q-12 2-38 4-38 3-54 6-28 7-43 22t-22 43q-3 16-6 54-2 26-4 38-2 21-8 34.5T124 381q-7 9-24 28-25 29-34 44-16 24-16 47t16 47q9 15 34 44 17 19 24 28 12 16 18 29.5t8 34.5q2 12 4 38 3 38 6 54 7 28 22 43t43 22q16 3 54 6 26 2 38 4 21 2 34.5 8t29.5 18q9 7 28 24 29 25 44 34 24 16 47 16t47-16q15-9 44-34 19-17 28-24 16-12 29.5-18t34.5-8q12-2 38-4 38-3 54-6 28-7 43-22t22-43q3-16 6-54 2-26 4-38 2-21 8-34.5t18-29.5q7-9 24-28 25-29 34-44 16-24 16-47t-16-47q-9-15-34-44-17-19-24-28-12-16-18-29zm-119 62L550 706q-10 17-26.5 27T488 745l-11 1q-34 0-59-24L271 584q-26-25-27-60.5t23.5-61.5 60.5-27.5 62 23.5l71 67 132-204q20-30 55-38t65 11.5 37.5 54.5-11.5 65z';
@@ -27,10 +26,9 @@ let icon;
 
 const processNotifications = (notificationElements) => {
   notificationElements.forEach(async notificationElement => {
-    // Captures the current date wrapper element before async shenanigans.
     const notification = await notificationObject(notificationElement);
     if (notification) {
-      const { mutuals } = notification || undefined;
+      const { mutuals } = notification;
       if (mutuals) {
         notificationElement.dataset.mutuals = mutuals;
       }
@@ -102,7 +100,6 @@ export const main = async function () {
 
   onNewPosts.addListener(addIcons);
   if (showOnlyMutualNotifications) {
-    styleElement.textContent = buildCss();
     document.documentElement.append(styleElement);
     onNewNotifications.addListener(processNotifications);
   }

--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -1,4 +1,4 @@
-import { getTimelineItemWrapper, filterPostElements, getPopoverWrapper } from '../util/interface.js';
+import { buildStyle, getTimelineItemWrapper, filterPostElements, getPopoverWrapper } from '../util/interface.js';
 import { notificationObject, timelineObject } from '../util/react_props.js';
 import { apiFetch } from '../util/tumblr_helpers.js';
 import { primaryBlogName } from '../util/user.js';
@@ -12,6 +12,9 @@ const hiddenAttribute = 'data-mutual-checker-hidden';
 const mutualsClass = 'from-mutual';
 const postAttributionSelector = `header ${keyToCss('attribution')} > span:not(${keyToCss('reblogAttribution')}) a`;
 
+const styleElement = buildStyle();
+const buildCss = () => `${keyToCss('notification')}:not([data-mutuals]) { display: none !important; }`;
+
 const regularPath = 'M593 500q0-45-22.5-64.5T500 416t-66.5 19-18.5 65 18.5 64.5T500 583t70.5-19 22.5-64zm-90 167q-44 0-83.5 18.5t-63 51T333 808v25h334v-25q0-39-22-71.5t-59.5-51T503 667zM166 168l14-90h558l12-78H180q-8 0-51 63l-42 63v209q-19 3-52 3t-33-3q-1 1 0 27 3 53 0 53l32-2q35-1 53 2v258H2l-3 40q-2 41 3 41 42 0 64-1 7-1 21 1v246h756q25 0 42-13 14-10 22-27 5-13 8-28l1-13V275q0-47-3-63-5-24-22.5-34T832 168H166zm667 752H167V754q17 0 38.5-6.5T241 730q16-12 16-26 0-21-33-28-19-4-57-4-3 0-1-51 2-37 1-36V421q88 0 90-48 1-20-33-30-24-6-57-6-4 0-2-44l2-43h635q14 0 22.5 11t8.5 26v543q0 5 4 26 5 30 5 42 1 22-9 22z';
 const aprilFoolsPath = 'M858 352q-6-14-8-35-2-12-4-38-3-38-6-54-7-28-22-43t-43-22q-16-3-54-6-26-2-38-4-21-2-34.5-8T619 124q-9-7-28-24-29-25-44-34-24-16-47-16t-47 16q-15 9-44 34-19 17-28 24-16 12-29.5 18t-34.5 8q-12 2-38 4-38 3-54 6-28 7-43 22t-22 43q-3 16-6 54-2 26-4 38-2 21-8 34.5T124 381q-7 9-24 28-25 29-34 44-16 24-16 47t16 47q9 15 34 44 17 19 24 28 12 16 18 29.5t8 34.5q2 12 4 38 3 38 6 54 7 28 22 43t43 22q16 3 54 6 26 2 38 4 21 2 34.5 8t29.5 18q9 7 28 24 29 25 44 34 24 16 47 16t47-16q15-9 44-34 19-17 28-24 16-12 29.5-18t34.5-8q12-2 38-4 38-3 54-6 28-7 43-22t22-43q3-16 6-54 2-26 4-38 2-21 8-34.5t18-29.5q7-9 24-28 25-29 34-44 16-24 16-47t-16-47q-9-15-34-44-17-19-24-28-12-16-18-29zm-119 62L550 706q-10 17-26.5 27T488 745l-11 1q-34 0-59-24L271 584q-26-25-27-60.5t23.5-61.5 60.5-27.5 62 23.5l71 67 132-204q20-30 55-38t65 11.5 37.5 54.5-11.5 65z';
 
@@ -23,30 +26,15 @@ let showOnlyMutualNotifications;
 let icon;
 
 const processNotifications = (notificationElements) => {
-  // Unbury the notification feed hackily for better CSS selection.
-  const notificationFeedContainer = notificationElements[0].parentElement.parentElement;
-  notificationFeedContainer.setAttribute('data-notification-feed', '');
-  let lastDateWrapperElement;
-  [...notificationFeedContainer.children].forEach(notifcationWrapperElement => {
-    notifcationWrapperElement.setAttribute(hiddenAttribute, '');
-    [...notifcationWrapperElement.children].forEach(async notificationElement => {
-      // Captures the current date wrapper element before async shenanigans.
-      const currDateWrapperElement = lastDateWrapperElement;
-      const notification = await notificationObject(notificationElement);
-      if (notification) {
-        const { mutuals } = notification || undefined;
-        if (!mutuals) {
-          notificationElement.setAttribute(hiddenAttribute, '');
-        } else {
-          // Unhides the date and wrapper of a visible notification.
-          notifcationWrapperElement.removeAttribute(hiddenAttribute);
-          currDateWrapperElement?.removeAttribute(hiddenAttribute);
-        }
-      } else {
-        // Keep track of the wrapper with a date in it.
-        lastDateWrapperElement = notifcationWrapperElement;
+  notificationElements.forEach(async notificationElement => {
+    // Captures the current date wrapper element before async shenanigans.
+    const notification = await notificationObject(notificationElement);
+    if (notification) {
+      const { mutuals } = notification || undefined;
+      if (mutuals) {
+        notificationElement.dataset.mutuals = mutuals;
       }
-    });
+    }
   });
 };
 
@@ -114,6 +102,8 @@ export const main = async function () {
 
   onNewPosts.addListener(addIcons);
   if (showOnlyMutualNotifications) {
+    styleElement.textContent = buildCss();
+    document.documentElement.append(styleElement);
     onNewNotifications.addListener(processNotifications);
   }
 };
@@ -121,6 +111,7 @@ export const main = async function () {
 export const clean = async function () {
   onNewPosts.removeListener(addIcons);
   if (showOnlyMutualNotifications) {
+    styleElement.remove();
     onNewNotifications.removeListener(processNotifications);
   }
 

--- a/src/scripts/mutual_checker.json
+++ b/src/scripts/mutual_checker.json
@@ -12,6 +12,11 @@
       "type": "checkbox",
       "label": "Only show posts from mutuals on the dashboard",
       "default": false
+    },
+    "showOnlyMutualNotifications": {
+      "type": "checkbox",
+      "label": "Only show notifications from mutuals in the activity feed",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Addresses #1301 by adding a new option to only show notifications from mutuals. Added common functionality (ie: unburying notifications) to utils that may be useful to other activity page features such as Notification Block. 

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Open Tumblr with Mutual Checker and notification filter enabled.
- Navigate to the activity page or trigger the popup.
- Ensure that there are no errors in console and that only mutual notifications pop up.

I'm new to contributing to open source so any and all kind feedback is welcomed!