### PR TITLE
Popup: add UI message on parse/restore failure

### DIFF
--- a/src/browser_action/backup.css
+++ b/src/browser_action/backup.css
@@ -89,7 +89,7 @@
   content: "Restore";
 }
 
-#restore-local.success {
+#restore-local:disabled {
   border: none;
 
   background-color: transparent;
@@ -97,19 +97,6 @@
   font-weight: bold;
 }
 
-#restore-local.failure {
-  border: none;
-
-  background-color: transparent;
-  color: #cf0000;
-  font-weight: bold;
-}
-
-#restore-local.success::before {
+#restore-local:disabled::before {
   content: "Successfully restored!";
 }
-
-#restore-local.failure::before {
-  content: "Failed to parse!";
-}
-

--- a/src/browser_action/backup.css
+++ b/src/browser_action/backup.css
@@ -85,11 +85,11 @@
   text-align: center;
 }
 
-#restore-local:enabled::before {
+#restore-local:empty::before {
   content: "Restore";
 }
 
-#restore-local:disabled {
+#restore-local.success {
   border: none;
 
   background-color: transparent;
@@ -97,6 +97,10 @@
   font-weight: bold;
 }
 
-#restore-local:disabled::before {
-  content: "Successfully restored!";
+#restore-local.failure {
+  border: none;
+
+  background-color: transparent;
+  color: #cf0000;
+  font-weight: bold;
 }

--- a/src/browser_action/backup.css
+++ b/src/browser_action/backup.css
@@ -89,7 +89,7 @@
   content: "Restore";
 }
 
-#restore-local:disabled {
+#restore-local.success {
   border: none;
 
   background-color: transparent;
@@ -97,6 +97,19 @@
   font-weight: bold;
 }
 
-#restore-local:disabled::before {
+#restore-local.failure {
+  border: none;
+
+  background-color: transparent;
+  color: #cf0000;
+  font-weight: bold;
+}
+
+#restore-local.success::before {
   content: "Successfully restored!";
 }
+
+#restore-local.failure::before {
+  content: "Failed to parse!";
+}
+

--- a/src/browser_action/render_backup.js
+++ b/src/browser_action/render_backup.js
@@ -54,21 +54,16 @@ const localRestore = async function () {
   const importText = localImportTextarea.value;
 
   try {
-    localRestoreButton.disabled = true;
-
     const parsedStorage = JSON.parse(importText);
     await browser.storage.local.set(parsedStorage);
 
-    localRestoreButton.classList.add('success');
+    localRestoreButton.disabled = true;
     localImportTextarea.value = '';
     document.querySelector('a[href="#configuration"]').classList.add('outdated');
-  } catch (exception) {
-    localRestoreButton.classList.add('failure');
-    console.error(exception);
-  } finally {
     await sleep(3000);
     localRestoreButton.disabled = false;
-    localRestoreButton.classList.remove('success', 'failure');
+  } catch (exception) {
+    console.error(exception);
   }
 };
 

--- a/src/browser_action/render_backup.js
+++ b/src/browser_action/render_backup.js
@@ -54,16 +54,21 @@ const localRestore = async function () {
   const importText = localImportTextarea.value;
 
   try {
+    localRestoreButton.disabled = true;
+
     const parsedStorage = JSON.parse(importText);
     await browser.storage.local.set(parsedStorage);
 
-    localRestoreButton.disabled = true;
+    localRestoreButton.classList.add('success');
     localImportTextarea.value = '';
     document.querySelector('a[href="#configuration"]').classList.add('outdated');
+  } catch (exception) {
+    localRestoreButton.classList.add('failure');
+    console.error(exception);
+  } finally {
     await sleep(3000);
     localRestoreButton.disabled = false;
-  } catch (exception) {
-    console.error(exception);
+    localRestoreButton.classList.remove('success', 'failure');
   }
 };
 

--- a/src/browser_action/render_backup.js
+++ b/src/browser_action/render_backup.js
@@ -54,16 +54,25 @@ const localRestore = async function () {
   const importText = localImportTextarea.value;
 
   try {
+    localRestoreButton.disabled = true;
+
     const parsedStorage = JSON.parse(importText);
     await browser.storage.local.set(parsedStorage);
 
-    localRestoreButton.disabled = true;
+    localRestoreButton.classList.add('success');
+    localRestoreButton.textContent = 'Successfully restored!';
     localImportTextarea.value = '';
     document.querySelector('a[href="#configuration"]').classList.add('outdated');
+  } catch (exception) {
+    localRestoreButton.classList.add('failure');
+    localRestoreButton.textContent =
+      exception instanceof SyntaxError ? 'Failed to parse backup contents!' : 'Failed to restore!';
+    console.error(exception);
+  } finally {
     await sleep(3000);
     localRestoreButton.disabled = false;
-  } catch (exception) {
-    console.error(exception);
+    localRestoreButton.classList.remove('success', 'failure');
+    localRestoreButton.textContent = '';
   }
 };
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds a red failure message when the user's attempt to restore a saved backup fails, e.g. because they have entered invalid JSON in the import text area.

See #1304.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Attempt to restore an invalid JSON string.
- Attempt to restore a valid backup.

Not sure how to trigger a failure of `browser.storage.local.set`. Go over a quota, I guess?


