### PR TITLE
Activity feed utils

### DIFF
--- a/src/util/interface.js
+++ b/src/util/interface.js
@@ -3,6 +3,7 @@ import { dom } from './dom.js';
 
 export const postSelector = '[tabindex="-1"][data-id]';
 export const blogViewSelector = '[style*="--blog-title-color"] *';
+export const notificationSelector = keyToCss('notification');
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');
 const cellSelector = keyToCss('cell');

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -1,5 +1,5 @@
 import { keyToCss } from './css_map.js';
-import { postSelector } from './interface.js';
+import { notificationSelector, postSelector } from './interface.js';
 const rootNode = document.getElementById('root');
 
 const addedNodesPool = [];
@@ -52,6 +52,11 @@ export const pageModifications = Object.freeze({
 
 export const onNewPosts = Object.freeze({
   addListener: callback => pageModifications.register(`${postSelector} article`, callback),
+  removeListener: callback => pageModifications.unregister(callback)
+});
+
+export const onNewNotifications = Object.freeze({
+  addListener: callback => pageModifications.register(notificationSelector, callback),
   removeListener: callback => pageModifications.unregister(callback)
 });
 

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -2,6 +2,7 @@ import { inject } from './inject.js';
 import { primaryBlogName, userBlogNames, adminBlogNames } from './user.js';
 
 const timelineObjectCache = new WeakMap();
+const notificationObjectCache = new WeakMap();
 
 const unburyTimelineObject = () => {
   const postElement = document.currentScript.parentElement;
@@ -42,6 +43,32 @@ const unburyBlog = () => {
       fiber = fiber.return;
     }
   }
+};
+
+const unburyNotification = async () => {
+  const notificationElement = document.currentScript.parentElement;
+  const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = notificationElement[reactKey];
+
+  while (fiber !== null) {
+    const { notification } = fiber.memoizedProps || {};
+    if (notification !== undefined) {
+      return notification;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+/**
+ * @param {Element} notificationElement - An on-screen notification
+ * @returns {Promise<object>} - The notification's buried notification property
+ */
+export const notificationObject = function (notificationElement) {
+  if (!notificationObjectCache.has(notificationElement)) {
+    notificationObjectCache.set(notificationElement, inject(unburyNotification, [], notificationElement));
+  }
+  return notificationObjectCache.get(notificationElement);
 };
 
 /**


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
More utils for the activity feed as suggested by #1303 and alters Notification Block to use the new utils. Facilitates future notification-based manipulation features, such as #1301.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Open Tumblr with Notification Blocker enabled.
- Use the UI to block original posts that has notifications.
- Navigate to the activity page or trigger the popup.
- Ensure that there are no new errors in console and that no notifications for the blocked posts pop up.

