### PR TITLE
Add a little space to Tag Tracker label 

### DIFF
--- a/src/scripts/tag_tracking_plus.css
+++ b/src/scripts/tag_tracking_plus.css
@@ -5,7 +5,7 @@
   min-height: 36px;
   padding: 5px 10px;
   border-radius: 3px;
-  margin-top: 10px;
+  margin: 10px 10px 0 10px;
 
   background-color: rgba(var(--white-on-dark), 0.13);
   color: rgba(var(--white-on-dark), 0.6);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Addresses #1268 using CSS.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Open Tumblr with Tag Tracker+ enabled.
- Visually confirm that the space exists when there are no tags either unread or tracked.
