### PR TITLE
Remove "Remove the sticky effect from post avatars" tweak

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -47,11 +47,6 @@
       "label": "Remove the sticky effect from the dashboard tab bar",
       "default": false
     },
-    "unsticky_post_avatars": {
-      "type": "checkbox",
-      "label": "Remove the sticky effect from post avatars",
-      "default": false
-    },
     "hide_mini_follow": {
       "type": "checkbox",
       "label": "Hide mini-follow buttons on posts",

--- a/src/scripts/tweaks/unsticky_post_avatars.js
+++ b/src/scripts/tweaks/unsticky_post_avatars.js
@@ -1,7 +1,0 @@
-import { keyToCss } from '../../util/css_map.js';
-import { buildStyle } from '../../util/interface.js';
-
-const styleElement = buildStyle(`${keyToCss('stickyContainer')} { height: auto !important; }`);
-
-export const main = async () => document.documentElement.append(styleElement);
-export const clean = async () => styleElement.remove();


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Fixes #1265 by removing the config in the JSON and removing the file. This doesn't address anything functional, just removes the option since the new official Tumblr layout doesn't have any sticky effect. (There's an issue to reinstate it though, #1310.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Open XKit Tweaks menu.
2. Ensure that there are no errors in console and that "Remove the sticky effect from post avatars" option is not in the menu.
