### PR TITLE
No Recommended: Fix blog sidebar/radar hiding

### DIFF
--- a/src/scripts/no_recommended/hide_radar.js
+++ b/src/scripts/no_recommended/hide_radar.js
@@ -9,11 +9,11 @@ const styleElement = buildStyle(`[${hiddenAttribute}] { display: none; }`);
 const checkForRadar = function (sidebarTitles) {
   sidebarTitles
     .filter(h1 => h1.textContent === translate('Radar'))
-    .forEach(h1 => h1.parentNode.setAttribute(hiddenAttribute, ''));
+    .forEach(h1 => h1.closest('aside > *').setAttribute(hiddenAttribute, ''));
 };
 
 export const main = async function () {
-  pageModifications.register('aside > div > h1', checkForRadar);
+  pageModifications.register('aside h1', checkForRadar);
   document.documentElement.append(styleElement);
 };
 

--- a/src/scripts/no_recommended/hide_recommended_blogs.js
+++ b/src/scripts/no_recommended/hide_recommended_blogs.js
@@ -10,13 +10,13 @@ const styleElement = buildStyle(`[${hiddenAttribute}] { display: none; }`);
 const hideDashboardRecommended = function (sidebarTitles) {
   sidebarTitles
     .filter(h1 => h1.textContent === translate('Check out these blogs'))
-    .forEach(h1 => h1.parentNode.setAttribute(hiddenAttribute, ''));
+    .forEach(h1 => h1.closest('aside > *').setAttribute(hiddenAttribute, ''));
 };
 
 const hideTagPageRecommended = topBlogsLists => topBlogsLists.forEach(ul => ul.setAttribute(hiddenAttribute, ''));
 
 export const main = async function () {
-  pageModifications.register('aside > div > h1', hideDashboardRecommended);
+  pageModifications.register('aside h1', hideDashboardRecommended);
 
   const topBlogsSelector = `${keyToCss('desktopContainer')} > ${keyToCss('recommendedBlogs')}`;
   pageModifications.register(topBlogsSelector, hideTagPageRecommended);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Fixes the No Recommended options to hide the recommended blogs sidebar item and the radar.

Resolves #1316.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Enable No Recommended.

- Toggle the "Hide recommended blogs in the sidebar" option and confirm that it functions correctly (including on tagged pages, the code for which was not changed).
- Toggle the "Hide the Tumblr Radar" option and confirm that it functions correctly.