### PR TITLE
CleanFeed: Prevent text overlapping on small images

### DIFF
--- a/src/scripts/cleanfeed.css
+++ b/src/scripts/cleanfeed.css
@@ -12,8 +12,10 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  text-align: center;
   height: 100%;
   width: 100%;
+  line-height: 16px;
   overflow: hidden;
 
   background-color: rgb(var(--white));

--- a/src/scripts/cleanfeed.css
+++ b/src/scripts/cleanfeed.css
@@ -15,7 +15,7 @@
   text-align: center;
   height: 100%;
   width: 100%;
-  line-height: 1;
+  line-height: 1.5;
   overflow: hidden;
 
   background-color: rgb(var(--white));

--- a/src/scripts/cleanfeed.css
+++ b/src/scripts/cleanfeed.css
@@ -15,7 +15,7 @@
   text-align: center;
   height: 100%;
   width: 100%;
-  line-height: 16px;
+  line-height: 1;
   overflow: hidden;
 
   background-color: rgb(var(--white));


### PR DESCRIPTION
### Description
Prevents the "Hidden by CleanFeed" text from overlapping on certain small images, as can be seen [here](https://www.tumblr.com/meowlgbt/733113897690775552/kitty-can-be-doggy-as-a-treat).
Resolves #1324.


### Testing steps
Enable CleanFeed, add the blog in the post above to the filter list, and view the image cover

