### PR TITLE
Manifest V3-compatible injection demo

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -77,8 +77,18 @@
     return installedScripts;
   };
 
+  const initPageContext = () => {
+    const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
+    const script = document.createElement('script');
+    script.nonce = nonce;
+    script.src = browser.runtime.getURL('/page_context.js');
+    document.documentElement.append(script);
+  };
+
   const init = async function () {
     $('style.xkit').remove();
+
+    initPageContext();
 
     browser.storage.onChanged.addListener(onStorageChanged);
 

--- a/src/page_context.js
+++ b/src/page_context.js
@@ -1,0 +1,34 @@
+'use strict';
+
+{
+  const fileCache = {};
+
+  document.documentElement.addEventListener('xkitinjectionrequest', async event => {
+    const { detail, target } = event;
+    const { id, path, args } = JSON.parse(detail);
+
+    try {
+      fileCache[path] ??= await import(path);
+      const func = fileCache[path].default;
+
+      const result = await func(...args, target);
+      target.dispatchEvent(
+        new CustomEvent('xkitinjectionresponse', { detail: JSON.stringify({ id, result }) })
+      );
+    } catch (exception) {
+      target.dispatchEvent(
+        new CustomEvent('xkitinjectionresponse', {
+          detail: JSON.stringify({
+            id,
+            exception: {
+              message: exception.message,
+              name: exception.name,
+              stack: exception.stack,
+              ...exception
+            }
+          })
+        })
+      );
+    }
+  });
+}

--- a/src/scripts/quote_replies.js
+++ b/src/scripts/quote_replies.js
@@ -23,6 +23,7 @@ let originalPostTag;
 let tagReplyingBlog;
 let newTab;
 
+/*
 const getNotificationProps = function () {
   const notificationElement = document.currentScript.parentElement;
   const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
@@ -37,9 +38,10 @@ const getNotificationProps = function () {
     }
   }
 };
+ */
 
 const processNotifications = notifications => notifications.forEach(async notification => {
-  const { notification: notificationProps, tumblelogName } = await inject(getNotificationProps, [], notification);
+  const { notification: notificationProps, tumblelogName } = await inject('/scripts/quote_replies_injected.js', [], notification);
 
   if (!['reply', 'note_mention'].includes(notificationProps.type)) return;
 

--- a/src/scripts/quote_replies_injected.js
+++ b/src/scripts/quote_replies_injected.js
@@ -1,0 +1,15 @@
+const getNotificationProps = function (notificationElement) {
+  const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = notificationElement[reactKey];
+
+  while (fiber !== null) {
+    const { notification } = fiber.memoizedProps || {};
+    if (notification !== undefined) {
+      return notification;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+export default getNotificationProps;

--- a/src/util/css_map.js
+++ b/src/util/css_map.js
@@ -1,6 +1,6 @@
 import { inject } from './inject.js';
 
-export const cssMap = await inject(async () => window.tumblr.getCssMap());
+export const cssMap = await inject('/util/injected_get_css_map.js');
 
 /**
  * @param {...string} keys - One or more element source names

--- a/src/util/injected_api_fetch.js
+++ b/src/util/injected_api_fetch.js
@@ -1,0 +1,37 @@
+const doApiFetch = async (resource, init) => {
+  // add XKit header to all API requests
+  init.headers ??= {};
+  init.headers['X-XKit'] = '1';
+
+  // convert all keys in the body to snake_case
+  if (init.body !== undefined) {
+    const objects = [init.body];
+
+    while (objects.length !== 0) {
+      const currentObjects = objects.splice(0);
+
+      currentObjects.forEach(obj => {
+        Object.keys(obj).forEach(key => {
+          const snakeCaseKey = key
+            .replace(/^[A-Z]/, match => match.toLowerCase())
+            .replace(/[A-Z]/g, match => `_${match.toLowerCase()}`);
+
+          if (snakeCaseKey !== key) {
+            obj[snakeCaseKey] = obj[key];
+            delete obj[key];
+          }
+        });
+      });
+
+      objects.push(
+        ...currentObjects
+          .flatMap(Object.values)
+          .filter(value => value instanceof Object)
+      );
+    }
+  }
+
+  return window.tumblr.apiFetch(resource, init);
+};
+
+export default doApiFetch;

--- a/src/util/injected_control_tags_input.js
+++ b/src/util/injected_control_tags_input.js
@@ -1,0 +1,23 @@
+const controlTagsInput = async ({ add, remove }) => {
+  add = add.map(tag => tag.trim()).filter((tag, index, array) => array.indexOf(tag) === index);
+
+  const selectedTagsElement = document.getElementById('selected-tags');
+  if (!selectedTagsElement) { return; }
+
+  const reactKey = Object.keys(selectedTagsElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = selectedTagsElement[reactKey];
+
+  while (fiber !== null) {
+    let tags = fiber.stateNode?.state?.tags;
+    if (Array.isArray(tags)) {
+      tags.push(...add.filter(tag => tags.includes(tag) === false));
+      tags = tags.filter(tag => remove.includes(tag) === false);
+      fiber.stateNode.setState({ tags });
+      break;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+export default controlTagsInput;

--- a/src/util/injected_get_css_map.js
+++ b/src/util/injected_get_css_map.js
@@ -1,0 +1,1 @@
+export default () => window.tumblr.getCssMap();

--- a/src/util/injected_get_language_data.js
+++ b/src/util/injected_get_language_data.js
@@ -1,0 +1,1 @@
+export default () => window.tumblr.languageData;

--- a/src/util/injected_navigate.js
+++ b/src/util/injected_navigate.js
@@ -1,0 +1,1 @@
+export default location => window.tumblr.navigate(location);

--- a/src/util/injected_post_form_request.js
+++ b/src/util/injected_post_form_request.js
@@ -1,0 +1,10 @@
+const doPostFormRequest = async (resource, body) =>
+  fetch(resource, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+    body
+  }).then(async response =>
+    response.ok ? response.json() : Promise.reject(await response.json())
+  );
+
+export default doPostFormRequest;

--- a/src/util/injected_test_header_element.js
+++ b/src/util/injected_test_header_element.js
@@ -1,0 +1,14 @@
+const testHeaderElement = (selector, menuElement) => {
+  const reactKey = Object.keys(menuElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = menuElement[reactKey];
+
+  while (fiber !== null) {
+    if (fiber.elementType === 'header') {
+      return fiber.stateNode.matches(selector);
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+export default testHeaderElement;

--- a/src/util/injected_unbury_blog.js
+++ b/src/util/injected_unbury_blog.js
@@ -1,0 +1,15 @@
+const unburyBlog = (element) => {
+  const reactKey = Object.keys(element).find(key => key.startsWith('__reactFiber'));
+  let fiber = element[reactKey];
+
+  while (fiber !== null) {
+    const { blog, blogSettings } = fiber.memoizedProps || {};
+    if (blog ?? blogSettings) {
+      return blog ?? blogSettings;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+export default unburyBlog;

--- a/src/util/injected_unbury_notification.js
+++ b/src/util/injected_unbury_notification.js
@@ -1,0 +1,16 @@
+const unburyNotification = async () => {
+  const notificationElement = document.currentScript.parentElement;
+  const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = notificationElement[reactKey];
+
+  while (fiber !== null) {
+    const { notification } = fiber.memoizedProps || {};
+    if (notification !== undefined) {
+      return notification;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+export default unburyNotification;

--- a/src/util/injected_unbury_timeline_object.js
+++ b/src/util/injected_unbury_timeline_object.js
@@ -1,0 +1,15 @@
+const unburyTimelineObject = (postElement) => {
+  const reactKey = Object.keys(postElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = postElement[reactKey];
+
+  while (fiber !== null) {
+    const { timelineObject } = fiber.memoizedProps || {};
+    if (timelineObject !== undefined) {
+      return timelineObject;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+};
+
+export default unburyTimelineObject;

--- a/src/util/language_data.js
+++ b/src/util/language_data.js
@@ -1,6 +1,6 @@
 import { inject } from './inject.js';
 
-export const languageData = await inject(() => window.tumblr.languageData);
+export const languageData = await inject('/util/injected_get_language_data.js');
 
 /**
  * @param {string} rootString - The English string to translate

--- a/src/util/meatballs.js
+++ b/src/util/meatballs.js
@@ -8,6 +8,7 @@ import { blogData, timelineObject } from './react_props.js';
 const postHeaderSelector = `${postSelector} article > header`;
 const blogHeaderSelector = `[style*="--blog-title-color"] > div > div > header, ${keyToCss('blogCardHeaderBar')}`;
 
+/*
 const testHeaderElement = (selector) => {
   const menuElement = document.currentScript.parentElement;
   const reactKey = Object.keys(menuElement).find(key => key.startsWith('__reactFiber'));
@@ -21,6 +22,7 @@ const testHeaderElement = (selector) => {
     }
   }
 };
+ */
 
 const meatballItems = {};
 const blogMeatballItems = {};
@@ -62,12 +64,12 @@ export const unregisterBlogMeatballItem = id => {
 };
 
 const addMeatballItems = meatballMenus => meatballMenus.forEach(async meatballMenu => {
-  const inPostHeader = await inject(testHeaderElement, [postHeaderSelector], meatballMenu);
+  const inPostHeader = await inject('/util/injected_test_header_element.js', [postHeaderSelector], meatballMenu);
   if (inPostHeader) {
     addPostMeatballItem(meatballMenu);
     return;
   }
-  const inBlogHeader = await inject(testHeaderElement, [blogHeaderSelector], meatballMenu);
+  const inBlogHeader = await inject('/util/injected_test_header_element.js', [blogHeaderSelector], meatballMenu);
   if (inBlogHeader) {
     addBlogMeatballItem(meatballMenu);
   }

--- a/src/util/mega_editor.js
+++ b/src/util/mega_editor.js
@@ -44,15 +44,5 @@ export const megaEdit = async function (postIds, options) {
     delete requestBody.tags;
   }
 
-  return inject(
-    async (resource, body) =>
-      fetch(resource, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
-        body
-      }).then(async response =>
-        response.ok ? response.json() : Promise.reject(await response.json())
-      ),
-    [`https://www.tumblr.com/${pathname}`, $.param(requestBody)]
-  );
+  return inject('/util/injected_post_form_request.js', [`https://www.tumblr.com/${pathname}`, $.param(requestBody)]);
 };

--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -4,6 +4,7 @@ import { primaryBlogName, userBlogNames, adminBlogNames } from './user.js';
 const timelineObjectCache = new WeakMap();
 const notificationObjectCache = new WeakMap();
 
+/*
 const unburyTimelineObject = () => {
   const postElement = document.currentScript.parentElement;
   const reactKey = Object.keys(postElement).find(key => key.startsWith('__reactFiber'));
@@ -18,6 +19,7 @@ const unburyTimelineObject = () => {
     }
   }
 };
+ */
 
 /**
  * @param {Element} postElement - An on-screen post
@@ -25,11 +27,12 @@ const unburyTimelineObject = () => {
  */
 export const timelineObject = async function (postElement) {
   if (!timelineObjectCache.has(postElement)) {
-    timelineObjectCache.set(postElement, inject(unburyTimelineObject, [], postElement));
+    timelineObjectCache.set(postElement, inject('/util/injected_unbury_timeline_object.js', [], postElement));
   }
   return timelineObjectCache.get(postElement);
 };
 
+/*
 const unburyBlog = () => {
   const element = document.currentScript.parentElement;
   const reactKey = Object.keys(element).find(key => key.startsWith('__reactFiber'));
@@ -44,7 +47,9 @@ const unburyBlog = () => {
     }
   }
 };
+ */
 
+/*
 const unburyNotification = async () => {
   const notificationElement = document.currentScript.parentElement;
   const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
@@ -59,6 +64,7 @@ const unburyNotification = async () => {
     }
   }
 };
+*/
 
 /**
  * @param {Element} notificationElement - An on-screen notification
@@ -66,7 +72,7 @@ const unburyNotification = async () => {
  */
 export const notificationObject = function (notificationElement) {
   if (!notificationObjectCache.has(notificationElement)) {
-    notificationObjectCache.set(notificationElement, inject(unburyNotification, [], notificationElement));
+    notificationObjectCache.set(notificationElement, inject('/util/injected_unbury_notification.js', [], notificationElement));
   }
   return notificationObjectCache.get(notificationElement);
 };
@@ -75,7 +81,7 @@ export const notificationObject = function (notificationElement) {
  * @param {Element} meatballMenu - An on-screen meatball menu element in a blog modal header or blog card
  * @returns {Promise<object>} - The post's buried blog or blogSettings property. Some blog data fields, such as "followed," are not available in blog cards.
  */
-export const blogData = async (meatballMenu) => inject(unburyBlog, [], meatballMenu);
+export const blogData = async (meatballMenu) => inject('/util/injected_unbury_blog.js', [], meatballMenu);
 
 export const isMyPost = async (postElement) => {
   const { blog, isSubmission, postAuthor } = await timelineObject(postElement);
@@ -97,6 +103,7 @@ export const isMyPost = async (postElement) => {
   return false;
 };
 
+/*
 const controlTagsInput = async ({ add, remove }) => {
   add = add.map(tag => tag.trim()).filter((tag, index, array) => array.indexOf(tag) === index);
 
@@ -118,6 +125,7 @@ const controlTagsInput = async ({ add, remove }) => {
     }
   }
 };
+ */
 
 /**
  * Manipulate post form tags
@@ -126,4 +134,4 @@ const controlTagsInput = async ({ add, remove }) => {
  * @param {string[]} [options.remove] - Tags to remove
  * @returns {Promise<void>} Resolves when finished
  */
-export const editPostFormTags = async ({ add = [], remove = [] }) => inject(controlTagsInput, [{ add, remove }]);
+export const editPostFormTags = async ({ add = [], remove = [] }) => inject('/util/injected_control_tags_input.js', [{ add, remove }]);

--- a/src/util/tumblr_helpers.js
+++ b/src/util/tumblr_helpers.js
@@ -1,11 +1,13 @@
 import { inject } from './inject.js';
 
 /**
- * @param {...any} args - Arguments to pass to window.tumblr.apiFetch()
+ * @param {string} resource - path for the API route to fetch
+ * @param {object} [init] - fetch options
  * @see {@link https://github.com/tumblr/docs/blob/master/web-platform.md#apifetch}
  * @returns {Promise<Response|Error>} Resolves or rejects with result of window.tumblr.apiFetch()
  */
-export const apiFetch = async function (...args) {
+export const apiFetch = async function (resource, init = {}) {
+  /*
   return inject(
     async (resource, init = {}) => {
       // add XKit header to all API requests
@@ -44,6 +46,9 @@ export const apiFetch = async function (...args) {
     },
     args
   );
+  */
+
+  return inject('/util/injected_api_fetch.js', [resource, init]);
 };
 
 /**
@@ -100,7 +105,7 @@ export const isNpfCompatible = postData => {
 };
 
 export const navigate = location =>
-  inject(location => window.tumblr.navigate(location), [location]);
+  inject('/util/injected_navigate.js', [location]);
 
 export const onClickNavigate = event => {
   if (event.ctrlKey || event.metaKey || event.altKey || event.shiftKey) return;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This is a functional MV3 port (without the change to manifest.json) that works in both Chrome and Firefox without per-browser modification, i.e. slightly updated #921. There are a number of methods to do our main world script injection; this one uses bubbled custom events and moves the imported function bodies into their own files, using a cached dynamic import to load them for performance (this should be compared against simply setting a script element's `src` property, for example).

I had to append the target element as the last argument to the injected function unconditionally; this means injected functions can't have optional arguments. We could do other stuff: make it the first argument, change the signature to take an object of named fields, whatever.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
to write
