### PR TITLE
Change carousel selector for the caught up line tweak

### DIFF
--- a/src/scripts/tweaks/caught_up_line.js
+++ b/src/scripts/tweaks/caught_up_line.js
@@ -16,7 +16,7 @@ const styleElement = buildStyle(`
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');
-const tagChicletCarouselItemSelector = `${listTimelineObjectSelector} ${keyToCss('tagChicletCarouselItem')}`;
+const tagChicletCarouselLinkSelector = `${listTimelineObjectSelector} ${keyToCss('tagChicletLink')}`;
 
 const createCaughtUpLine = tagChicletCarouselItems => tagChicletCarouselItems
   .map(getTimelineItemWrapper)
@@ -28,7 +28,7 @@ const createCaughtUpLine = tagChicletCarouselItems => tagChicletCarouselItems
 
 export const main = async function () {
   document.documentElement.append(styleElement);
-  pageModifications.register(tagChicletCarouselItemSelector, createCaughtUpLine);
+  pageModifications.register(tagChicletCarouselLinkSelector, createCaughtUpLine);
 };
 
 export const clean = async function () {


### PR DESCRIPTION
### Description
Fixes #1334 by changing the selector to match the current element classes 
```js
const tagChicletCarouselLinkSelector = `${listTimelineObjectSelector} ${keyToCss('tagChicletLink')}`;
```
![image](https://github.com/AprilSylph/XKit-Rewritten/assets/81981111/16f6e549-79be-449e-b35f-6e726af042bb)

### Testing steps
- Enable the Tweaks feature and the caught up line preference
- Click the home navigation icon twice to bring the caught up line to the top of the feed

