### PR TITLE
No Recommended: Change blog and tag carousel selectors

### DIFF
--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -11,7 +11,7 @@ const styleElement = buildStyle(`
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');
-const blogCarouselSelector = `${listTimelineObjectSelector} ${keyToCss('blogCarousel')}`;
+const blogCarouselSelector = `${listTimelineObjectSelector} ${keyToCss('blogRecommendation')}`;
 
 const hideBlogCarousels = blogCarousels => blogCarousels
   .map(getTimelineItemWrapper)

--- a/src/scripts/no_recommended/hide_tag_carousels.js
+++ b/src/scripts/no_recommended/hide_tag_carousels.js
@@ -10,12 +10,12 @@ const styleElement = buildStyle(`
   [${hiddenAttribute}] > div img, [${hiddenAttribute}] > div canvas { visibility: hidden; }
 `);
 
-const tagCardCarouselItemSelector = keyToCss('tagCardCarouselItem');
+const tagCardSelector = keyToCss('tagCard');
 const listTimelineObjectSelector = keyToCss('listTimelineObject');
 const carouselWrapperSelector = `${listTimelineObjectSelector} ${keyToCss('carouselWrapper')}`;
 
 const hideTagCarousels = carouselWrappers => carouselWrappers
-  .filter(carouselWrapper => carouselWrapper.querySelector(tagCardCarouselItemSelector) !== null)
+  .filter(carouselWrapper => carouselWrapper.querySelector(tagCardSelector) !== null)
   .map(getTimelineItemWrapper)
   .forEach(timelineItem => {
     timelineItem.setAttribute(hiddenAttribute, '');


### PR DESCRIPTION
### Description
Fixes #1335 by changing the blog carousel and tag card selectors to match the current element classes
```js
const blogCarouselSelector = `${listTimelineObjectSelector} ${keyToCss('blogRecommendation')}`;
```
```js
const tagCardSelector = keyToCss('tagCard');
```

### Testing steps
- Enable the No Recommended feature and the two related preferences
- Scroll through the timeline

