### PR TITLE
Fix no user colors not applying to text in the editor

### DIFF
--- a/src/scripts/accesskit.css
+++ b/src/scripts/accesskit.css
@@ -50,7 +50,9 @@ body.accesskit-blue-links article a[target="_blank"][href^="https://href.li/"] {
   color: rgb(var(--accent));
 }
 
-body.accesskit-no-user-colours article span[style^="color"] {
+body.accesskit-no-user-colours article span[style^="color"],
+body.accesskit-no-user-colours [data-testid="blocks-reblog-trail"] span[style^="color"],
+body.accesskit-no-user-colours [data-testid="blocks-ask"] span[style^="color"] {
   color: inherit !important;
 }
 


### PR DESCRIPTION
### Description
Fixes #1093 by hiding user-set colors for trail items and asks in the editor.


### Testing steps
- Enable AccessKit and the remove user-set colors preference
- Open a post with user-set colors in the post editor
- Open an ask with user-set colors in the post editor

