### PR TITLE
No Recommended: Reliably select blog carousels via react props

### DIFF
--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -11,13 +11,13 @@ const styleElement = buildStyle(`
   [${hiddenAttribute}] > div :is(img, video, canvas) { display: none }
 `);
 
-const blogCarouselSelector = `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')}`;
+const carouselSelector = `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')}`;
 
-const hideBlogCarousels = blogCarousels =>
-  blogCarousels.forEach(async blogCarousel => {
-    const { elements } = await timelineObject(blogCarousel);
+const hideBlogCarousels = carousels =>
+  carousels.forEach(async carousel => {
+    const { elements } = await timelineObject(carousel);
     if (elements.some(({ objectType }) => objectType === 'blog')) {
-      const timelineItem = getTimelineItemWrapper(blogCarousel);
+      const timelineItem = getTimelineItemWrapper(carousel);
       if (timelineItem.previousElementSibling.querySelector(keyToCss('titleObject'))) {
         timelineItem.setAttribute(hiddenAttribute, '');
         timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
@@ -27,7 +27,7 @@ const hideBlogCarousels = blogCarousels =>
 
 export const main = async function () {
   document.documentElement.append(styleElement);
-  pageModifications.register(blogCarouselSelector, hideBlogCarousels);
+  pageModifications.register(carouselSelector, hideBlogCarousels);
 };
 
 export const clean = async function () {

--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -5,15 +5,10 @@ import { timelineObject } from '../../util/react_props.js';
 
 const hiddenAttribute = 'data-no-recommended-blog-carousels-hidden';
 
-/*
 const styleElement = buildStyle(`
   [${hiddenAttribute}] { position: relative; }
   [${hiddenAttribute}] > div { visibility: hidden; position: absolute; max-width: 100%; }
   [${hiddenAttribute}] > div :is(img, video, canvas) { display: none }
-`);
-*/
-const styleElement = buildStyle(`
-  [${hiddenAttribute}] { outline: 4px solid red; }
 `);
 
 const blogCarouselSelector = `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')}`;

--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -5,10 +5,15 @@ import { timelineObject } from '../../util/react_props.js';
 
 const hiddenAttribute = 'data-no-recommended-blog-carousels-hidden';
 
+/*
 const styleElement = buildStyle(`
   [${hiddenAttribute}] { position: relative; }
   [${hiddenAttribute}] > div { visibility: hidden; position: absolute; max-width: 100%; }
   [${hiddenAttribute}] > div :is(img, video, canvas) { display: none }
+`);
+*/
+const styleElement = buildStyle(`
+  [${hiddenAttribute}] { outline: 4px solid red; }
 `);
 
 const blogCarouselSelector = `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')}`;

--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -1,6 +1,7 @@
 import { keyToCss } from '../../util/css_map.js';
 import { buildStyle, getTimelineItemWrapper } from '../../util/interface.js';
 import { pageModifications } from '../../util/mutations.js';
+import { timelineObject } from '../../util/react_props.js';
 
 const hiddenAttribute = 'data-no-recommended-blog-carousels-hidden';
 
@@ -10,17 +11,18 @@ const styleElement = buildStyle(`
   [${hiddenAttribute}] > div :is(img, video, canvas) { display: none }
 `);
 
-const listTimelineObjectSelector = keyToCss('listTimelineObject');
-const blogCarouselSelector = `${listTimelineObjectSelector} ${keyToCss('blogRecommendation')}`;
+const blogCarouselSelector = `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')}`;
 
-const hideBlogCarousels = blogCarousels => blogCarousels
-  .map(getTimelineItemWrapper)
-  .filter(timelineItem =>
-    timelineItem.previousElementSibling.querySelector(keyToCss('titleObject'))
-  )
-  .forEach(timelineItem => {
-    timelineItem.setAttribute(hiddenAttribute, '');
-    timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
+const hideBlogCarousels = blogCarousels =>
+  blogCarousels.forEach(async blogCarousel => {
+    const { elements } = await timelineObject(blogCarousel);
+    if (elements.some(({ objectType }) => objectType === 'blog')) {
+      const timelineItem = getTimelineItemWrapper(blogCarousel);
+      if (timelineItem.previousElementSibling.querySelector(keyToCss('titleObject'))) {
+        timelineItem.setAttribute(hiddenAttribute, '');
+        timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
+      }
+    }
   });
 
 export const main = async function () {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Enough classname targeting.

This uses our `timelineObject` utility to read the react internal data of recommendation carousels, reliably identifying those which are blog recommendations (as opposed to tag recommendations). This is, of course, fragile to changes in the underlying API data, but it seems better than trying to target a classname, ~~since there aren't any unique "blog recommendation"y ones in this element.~~

Resolves #1346.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Optionally unrevert the test commit for visibility
- Confirm that No Recommended's blog carousel hiding functionality works on the dashboard and on tag pages and doesn't hide tag recommendations (I did not do the latter; I can't find any)
- Confirm that No Recommended's blog carousel hiding functionality works on anywhere else blog recommendation carousels can appear, if any; I don't know the full list.