### PR TITLE
No Recommended: Reliably select blog carousels

### DIFF
--- a/src/scripts/no_recommended/hide_blog_carousels.js
+++ b/src/scripts/no_recommended/hide_blog_carousels.js
@@ -11,7 +11,7 @@ const styleElement = buildStyle(`
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');
-const blogCarouselSelector = `${listTimelineObjectSelector} ${keyToCss('blogRecommendation')}`;
+const blogCarouselSelector = `${listTimelineObjectSelector} ${keyToCss('blogLinkRecommendationWrapper')}`;
 
 const hideBlogCarousels = blogCarousels => blogCarousels
   .map(getTimelineItemWrapper)


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Resolves #1346.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that No Recommended's blog carousel hiding functionality works on the dashboard and on tag pages and doesn't hide tag recommendations (I did not do the latter; I can't find any)
- Confirm that No Recommended's blog carousel hiding functionality works on anywhere else blog recommendation carousels can appear, if any; I don't know the full list.

