### PR TITLE
Tweaks: Fix following/mutuals activity label tweak

### DIFF
--- a/src/scripts/tweaks/hide_activity_mutuals.js
+++ b/src/scripts/tweaks/hide_activity_mutuals.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 
 const styleElement = buildStyle(`
-${keyToCss('activity')} ${keyToCss('generalLabelContainer')} {
+${keyToCss('activity')} ${keyToCss('followingBadgeContainer', 'mutualsBadgeContainer')} {
   display: none;
 }
 `);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes the "Hide following/mutuals indicators on notifications" tweak, which was broken by a CSS name change.

Resolves #1387.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that "following" and "mutuals" labels are hidden in the activity popup and activity page.

