### PR TITLE
Tweaks: Remove unused tab bar CSS

### DIFF
--- a/src/scripts/tweaks/unsticky_tab_bar.js
+++ b/src/scripts/tweaks/unsticky_tab_bar.js
@@ -7,9 +7,6 @@ const styleElement = buildStyle(`
     top: 0 !important;
     transition: none !important;
   }
-  ${keyToCss('post')} ${keyToCss('stickyContainer')} > ${keyToCss('avatar')} {
-    --dashboard-tabs-header-height: 0px !important;
-  }
 `);
 
 export const main = async () => document.documentElement.append(styleElement);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

With the removal of floating sticky avatars, our CSS rule to adjust them for the unsticky tab bar tweak isn't needed.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- confirm that the unsticky tab bar tweak still works
