### PR TITLE
Improve inject reliability on webkit

### DIFF
--- a/src/util/inject.js
+++ b/src/util/inject.js
@@ -38,9 +38,11 @@ export const inject = async (func, args = [], target = document.documentElement)
         if (mutations.some(({ attributeName }) => attributeName === 'data-result')) {
           observer.disconnect();
           resolve(JSON.parse(script.dataset.result));
+          script.remove();
         } else if (mutations.some(({ attributeName }) => attributeName === 'data-exception')) {
           observer.disconnect();
           reject(JSON.parse(script.dataset.exception));
+          script.remove();
         }
       });
 
@@ -49,7 +51,6 @@ export const inject = async (func, args = [], target = document.documentElement)
         attributeFilter: ['data-result', 'data-exception']
       });
       target.append(script);
-      script.remove();
     });
   } else {
     target.append(script);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

In short, this leaves our injected script elements in the DOM while they're pending and being observed-by-a-mutation-observer, rather than appending-and-immediately-removing them.

Of course, we don't officially support every browser, but there are lots of ways to install web extensions. I've been running a dev branch of XKit Rewritten in Safari for a few days and sometimes things just wouldn't load. This seems? to help? I'll have to do more testing to be sure.

(Frankly I'm even less sure how the old way could lead to inconsistent behavior—surely it should either always work or never work, unless there's some window of n milliseconds in which Webkit still registers event listeners on things removed from the DOM? Yeah, no idea.)

Aside: now I'm extremely curious if #920 works.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- confirm basic functionality
