### PR TITLE
AccessKit Disable Gifs: Fix unexpected mini labels (minor)

### DIFF
--- a/src/scripts/accesskit/disable_gifs.js
+++ b/src/scripts/accesskit/disable_gifs.js
@@ -18,7 +18,7 @@ const pauseGif = function (gifElement) {
     canvas.getContext('2d').drawImage(image, 0, 0);
 
     const gifLabel = document.createElement('p');
-    gifLabel.className = gifElement.clientWidth < 150
+    gifLabel.className = gifElement.clientWidth && gifElement.clientWidth < 150
       ? 'xkit-paused-gif-label mini'
       : 'xkit-paused-gif-label';
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

A race condition can occur that causes AccessKit Disable Gifs to use miniature labels on images in a post that are the regular, full size. This happens when the post is hidden, e.g. by another XKit script, before Disable Gifs gets to process it. When the user unhides the post later (e.g. by toggling Show Originals to "all posts"), the label is visible.

This adjustment only tries to make the label miniature if `gifElement.clientWidth` exists and is nonzero. (It might be possible to trigger the wrong behavior in reverse, by loading a post with multiple gifs side by side in the masonry/grid view in a hidden state and then revealing it to now have labels that are too big, but I'm not sure we even have a script that hides posts in masonry and even if that does happen it's probably not noticeable.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- confirm basic Disable Gifs functionality (one could also test the actual fix, but there's only like a 50/50 chance of the behavior happening without the fix and it's some work to set up)
