### PR TITLE
AccessKit: Rename regular-width scrollbars feature

### DIFF
--- a/src/scripts/accesskit.json
+++ b/src/scripts/accesskit.json
@@ -41,7 +41,7 @@
     },
     "normal_width_scrollbar": {
       "type": "checkbox",
-      "label": "Use regular-width scrollbars in Firefox",
+      "label": "Use regular-width scrollbars",
       "default": false
     },
     "visible_alt_text": {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

[Chrome 121 supports `scrollbar-width`](https://developer.chrome.com/blog/new-in-chrome-121), so the regular-width scrollbar feature applies to it and is thus no longer Firefox-specific. This removes the mention of Firefox from its checkbox.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

