### PR TITLE
TimeFormat: Fix timestamps on mobile devices

### DIFF
--- a/src/scripts/timeformat.css
+++ b/src/scripts/timeformat.css
@@ -1,5 +1,5 @@
 [data-formatted-time] {
-  font-size: 0px;
+  font-size: 0px !important;
 }
 
 [data-formatted-time]::before {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Resolves #1391.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Reduce the browser viewport all the way (to the point where post bounding boxes touches the viewport edges and do not have rounded corners) or load XKit on a mobile device small enough to use this view and confirm that Timeformat works correctly on reblog trail item headers.

