### PR TITLE
Tweaks: Hide mobile menu badge when it's ambiguous

### DIFF
--- a/src/scripts/tweaks/hide_activity_notification_badge.js
+++ b/src/scripts/tweaks/hide_activity_notification_badge.js
@@ -2,8 +2,11 @@ import { keyToCss } from '../../util/css_map.js';
 import { buildStyle } from '../../util/interface.js';
 import { translate } from '../../util/language_data.js';
 
+const activityButton = `button[aria-label="${translate('Activity')}"]`;
+const mobileMenuButton = `button[aria-label="${translate('Menu')}"]`;
+
 const styleElement = buildStyle(`
-button[aria-label="${translate('Activity')}"] ${keyToCss('notificationBadge')} {
+:is(${activityButton}, ${mobileMenuButton}) ${keyToCss('notificationBadge')} {
   display: none;
 }
 `);

--- a/src/scripts/tweaks/hide_following_notification_badge.js
+++ b/src/scripts/tweaks/hide_following_notification_badge.js
@@ -3,9 +3,10 @@ import { buildStyle } from '../../util/interface.js';
 import { translate } from '../../util/language_data.js';
 
 const followingHomeButton = `:is(li[title="${translate('Home')}"], button[aria-label="${translate('Home')}"], a[href="/dashboard/following"])`;
+const mobileMenuButton = `button[aria-label="${translate('Menu')}"]`;
 
 const styleElement = buildStyle(`
-${followingHomeButton} ${keyToCss('notificationBadge')} {
+:is(${followingHomeButton}, ${mobileMenuButton}) ${keyToCss('notificationBadge')} {
   display: none;
 }
 `);


### PR DESCRIPTION
Alternative: #1394.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This hides the mobile menu's notification badge, which is shown if you have any activity notifications and/or any new posts on your timeline, if you have the tweaks that hide either one enabled.

Given that we don't really have an easy way of only hiding it based on the state of one or the other*, I assume that this is what most people would want (?) but it's definitely not perfect.

Resolves #1256.

*maybe? it would probably involve polling react context on an interval or something?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

