### PR TITLE
Tweaks: Add tweak to hide mobile menu badge

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -98,6 +98,11 @@
       "label": "Hide the Activity notification badge",
       "default": false
     },
+    "hide_mobile_notification_badge": {
+      "type": "checkbox",
+      "label": "Hide the mobile menu notification badge",
+      "default": false
+    },
     "no_where_were_we": {
       "type": "checkbox",
       "label": "Hide the \"Now, where were we?\" button",

--- a/src/scripts/tweaks/hide_mobile_notification_badge.js
+++ b/src/scripts/tweaks/hide_mobile_notification_badge.js
@@ -1,0 +1,12 @@
+import { keyToCss } from '../../util/css_map.js';
+import { buildStyle } from '../../util/interface.js';
+import { translate } from '../../util/language_data.js';
+
+const styleElement = buildStyle(`
+button[aria-label="${translate('Menu')}"] ${keyToCss('notificationBadge')} {
+  display: none;
+}
+`);
+
+export const main = async () => document.documentElement.append(styleElement);
+export const clean = async () => styleElement.remove();


### PR DESCRIPTION
Alternative to #1393.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds a new tweak that hides the mobile menu's notification badge, which is shown if you have any activity notifications and/or any new posts on your timeline.

Given that we don't really have an easy way of only hiding it based on the state of one or the other*, this gives the user the choice. Adding another checkbox to essentially paper over a technical limitation feels kind of bad, though.

Resolves #1256.

*maybe? it would probably involve polling react context on an interval or something?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

