### PR TITLE
Tweaks: Remove unread post count from tab title

### DIFF
--- a/src/scripts/tweaks.json
+++ b/src/scripts/tweaks.json
@@ -90,7 +90,7 @@
     },
     "hide_following_notification_badge": {
       "type": "checkbox",
-      "label": "Hide the Home/Following unread badge",
+      "label": "Hide the Home/Following unread count",
       "default": false
     },
     "hide_activity_notification_badge": {

--- a/src/scripts/tweaks/hide_following_notification_badge.js
+++ b/src/scripts/tweaks/hide_following_notification_badge.js
@@ -1,14 +1,31 @@
 import { keyToCss } from '../../util/css_map.js';
+import { dom } from '../../util/dom.js';
 import { buildStyle } from '../../util/interface.js';
 import { translate } from '../../util/language_data.js';
+import { pageModifications } from '../../util/mutations.js';
 
 const followingHomeButton = `:is(li[title="${translate('Home')}"], button[aria-label="${translate('Home')}"], a[href="/dashboard/following"])`;
 
+const customTitleElement = dom('title', { 'data-xkit': true });
 const styleElement = buildStyle(`
 ${followingHomeButton} ${keyToCss('notificationBadge')} {
   display: none;
 }
 `);
 
-export const main = async () => document.documentElement.append(styleElement);
-export const clean = async () => styleElement.remove();
+const onTitleChanged = ([titleElement]) => {
+  const rawTitle = titleElement.textContent;
+  const newTitle = rawTitle.replace(/^\(\d{1,2}\) /, '');
+  customTitleElement.textContent = newTitle;
+};
+
+export const main = async () => {
+  pageModifications.register('head title:not([data-xkit])', onTitleChanged);
+  document.head.prepend(customTitleElement);
+  document.documentElement.append(styleElement);
+};
+
+export const clean = async () => {
+  customTitleElement.remove();
+  styleElement.remove();
+};

--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -1,6 +1,7 @@
 import { keyToCss } from './css_map.js';
 import { notificationSelector, postSelector } from './interface.js';
 const rootNode = document.getElementById('root');
+const headNode = document.querySelector('head');
 
 const addedNodesPool = [];
 let repaintQueued = false;
@@ -38,12 +39,16 @@ export const pageModifications = Object.freeze({
     if (!selector) return;
 
     if (modifierFunction.length === 0) {
-      const shouldRun = rootNode.querySelector(selector) !== null;
+      const shouldRun =
+        rootNode.querySelector(selector) !== null || headNode.querySelector(selector) !== null;
       if (shouldRun) modifierFunction();
       return;
     }
 
-    const matchingElements = [...rootNode.querySelectorAll(selector)];
+    const matchingElements = [
+      ...rootNode.querySelectorAll(selector),
+      ...headNode.querySelectorAll(selector)
+    ];
     if (matchingElements.length !== 0) {
       modifierFunction(matchingElements);
     }
@@ -106,3 +111,4 @@ const observer = new MutationObserver(mutations => {
 });
 
 observer.observe(rootNode, { childList: true, subtree: true });
+observer.observe(headNode, { childList: true, subtree: true });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As discussed and prototyped in the linked issue, this is April's code that adds functionality to the `Hide the Home/Following unread badge` tweak to also hide the unread post count in the browser tab title.

Resolves #1360.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

