### PR TITLE
Control button util: Implement descriptive text

### DIFF
--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -233,7 +233,7 @@ popupForm.addEventListener('submit', processFormSubmit);
 postOptionPopupElement.addEventListener('click', processPostOptionBundleClick);
 
 export const main = async function () {
-  controlButtonTemplate = createControlButtonTemplate(symbolId, buttonClass);
+  controlButtonTemplate = createControlButtonTemplate(symbolId, buttonClass, 'Quick Tags');
 
   pageModifications.register(`${postSelector} footer ${controlIconSelector} a[href*="/edit/"]`, addControlButtons);
   registerPostOption('quick-tags', { symbolId, onclick: togglePostOptionPopupDisplay });

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -171,7 +171,7 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
 });
 
 export const main = async function () {
-  controlButtonTemplate = createControlButtonTemplate(symbolId, buttonClass);
+  controlButtonTemplate = createControlButtonTemplate(symbolId, buttonClass, 'Trim Reblogs');
   onNewPosts.addListener(processPosts);
 };
 

--- a/src/util/control_buttons.js
+++ b/src/util/control_buttons.js
@@ -8,11 +8,12 @@ $('.xkit-control-button-container').remove();
  * Create a button template that can be cloned with cloneControlButton() for inserting into the controls of a post.
  * @param {string} symbolId - The name of the RemixIcon to use
  * @param {string} buttonClass - An extra class to identify the extension that added the button
+ * @param {string} label - Descriptive text to be set as the button aria-label property and tooltip
  * @returns {HTMLDivElement} A button that can be cloned with cloneControlButton()
  */
-export const createControlButtonTemplate = function (symbolId, buttonClass) {
+export const createControlButtonTemplate = function (symbolId, buttonClass, label = '') {
   return dom('div', { class: `xkit-control-button-container ${buttonClass}` }, null, [
-    dom('button', { class: 'xkit-control-button' }, null, [
+    dom('button', { class: 'xkit-control-button', 'aria-label': label, title: label }, null, [
       dom('span', { class: 'xkit-control-button-inner', tabindex: '-1' }, null, [
         buildSvg(symbolId)
       ])


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds aria-labels and on-hover tooltips to our control buttons.

Resolves https://github.com/AprilSylph/XKit-Rewritten/issues/973.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Enable Quick Tags and/or Trim Reblogs. Mouse over the control buttons with the viewport width both greater and less than 990px and with touchscreen emulation turned on and off.

