### PR TITLE
Quick Tags: Preserve tags when scrolling

### DIFF
--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -2,6 +2,7 @@ import { cloneControlButton, createControlButtonTemplate } from '../util/control
 import { keyToCss } from '../util/css_map.js';
 import { dom } from '../util/dom.js';
 import { filterPostElements, getTimelineItemWrapper, postSelector } from '../util/interface.js';
+import { translate } from '../util/language_data.js';
 import { megaEdit } from '../util/mega_editor.js';
 import { showErrorModal } from '../util/modals.js';
 import { onNewPosts, pageModifications } from '../util/mutations.js';
@@ -228,7 +229,7 @@ const processPosts = postElements => filterPostElements(postElements).forEach(po
   const existingButton = postElement.querySelector(`.${buttonClass}`);
   if (existingButton !== null) { return; }
 
-  const editButton = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"]`);
+  const editButton = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"][aria-label=${translate('Edit')}]`);
   if (!editButton) { return; }
 
   const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: togglePopupDisplay });

--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -1,10 +1,10 @@
 import { cloneControlButton, createControlButtonTemplate } from '../util/control_buttons.js';
 import { keyToCss } from '../util/css_map.js';
 import { dom } from '../util/dom.js';
-import { postSelector } from '../util/interface.js';
+import { filterPostElements, getTimelineItemWrapper, postSelector } from '../util/interface.js';
 import { megaEdit } from '../util/mega_editor.js';
 import { showErrorModal } from '../util/modals.js';
-import { pageModifications } from '../util/mutations.js';
+import { onNewPosts, pageModifications } from '../util/mutations.js';
 import { notify } from '../util/notifications.js';
 import { registerPostOption, unregisterPostOption } from '../util/post_actions.js';
 import { getPreferences } from '../util/preferences.js';
@@ -57,6 +57,8 @@ popupForm.appendChild(popupInput);
 const postOptionPopupElement = dom('div', { id: 'quick-tags-post-option' });
 
 const storageKey = 'quick_tags.preferences.tagBundles';
+
+let editedTagsMap = new WeakMap();
 
 const populatePopups = async function () {
   popupElement.textContent = '';
@@ -175,6 +177,11 @@ const addTagsToPost = async function ({ postElement, inputTags = [] }) {
     notify(`Edited legacy post on ${blogName}`);
   }
 
+  editedTagsMap.set(getTimelineItemWrapper(postElement), tags);
+  addFakeTagsToFooter(postElement, tags);
+};
+
+const addFakeTagsToFooter = (postElement, tags) => {
   const tagsElement = dom('div', { class: tagsClass });
 
   const innerTagsDiv = document.createElement('div');
@@ -214,15 +221,20 @@ const processPostOptionBundleClick = function ({ target }) {
   editPostFormTags({ add: bundleTags });
 };
 
-const addControlButtons = function (editButtons) {
-  editButtons
-    .filter(editButton => editButton.matches(`.${buttonClass} ~ div a[href*="/edit/"]`) === false)
-    .forEach(editButton => {
-      const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: togglePopupDisplay });
-      const controlIcon = editButton.closest(controlIconSelector);
-      controlIcon.before(clonedControlButton);
-    });
-};
+const processPosts = postElements => filterPostElements(postElements).forEach(postElement => {
+  const tags = editedTagsMap.get(getTimelineItemWrapper(postElement));
+  tags && addFakeTagsToFooter(postElement, tags);
+
+  const existingButton = postElement.querySelector(`.${buttonClass}`);
+  if (existingButton !== null) { return; }
+
+  const editButton = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"]`);
+  if (!editButton) { return; }
+
+  const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: togglePopupDisplay });
+  const controlIcon = editButton.closest(controlIconSelector);
+  controlIcon.before(clonedControlButton);
+});
 
 popupElement.addEventListener('click', processBundleClick);
 popupForm.addEventListener('submit', processFormSubmit);
@@ -231,7 +243,7 @@ postOptionPopupElement.addEventListener('click', processPostOptionBundleClick);
 export const main = async function () {
   controlButtonTemplate = createControlButtonTemplate(symbolId, buttonClass, 'Quick Tags');
 
-  pageModifications.register(`${postSelector} footer ${controlIconSelector} a[href*="/edit/"]`, addControlButtons);
+  onNewPosts.addListener(processPosts);
   registerPostOption('quick-tags', { symbolId, onclick: togglePostOptionPopupDisplay });
 
   populatePopups();
@@ -243,7 +255,7 @@ export const main = async function () {
 };
 
 export const clean = async function () {
-  pageModifications.unregister(addControlButtons);
+  onNewPosts.removeListener(processPosts);
   pageModifications.unregister(processPostForm);
   popupElement.remove();
 
@@ -252,6 +264,8 @@ export const clean = async function () {
   $(`.${buttonClass}`).remove();
   $(`.${excludeClass}`).removeClass(excludeClass);
   $(`.${tagsClass}`).remove();
+
+  editedTagsMap = new WeakMap();
 };
 
 export const stylesheet = true;


### PR DESCRIPTION
> This would be a lot of work to fix any way that I can think of and is fairly minor, so my guess is that we won't fix it

Eh, it wasn't actually _that_ many lines of code.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This:

- Uses Trim Reblogs' button-adding code in Quick Tags
- Extracts the "add fake tags" code into a function and re-applies it to posts when an edited post is added back to the page by the "virtual scroller" code.

Resolves #1380.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Add tags to a post with Quick Tags
- Scroll away until the post disappears, then scroll back
- Confirm that the post still appears to have the added tags
- Edit the post with the normal Tumblr editor, changing its tags again
- Scroll away until the post disappears, then scroll back
- Confirm that no erroneous changes persist on the post
