### PR TITLE
Show Originals: Add option to hide only reblogs you follow

### DIFF
--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -15,6 +15,7 @@ const includeFiltered = true;
 
 let showOwnReblogs;
 let showReblogsWithContributedContent;
+let showReblogsOfNotFollowing;
 let whitelist;
 let disabledBlogs;
 
@@ -99,12 +100,13 @@ const processPosts = async function (postElements) {
 
   filterPostElements(postElements, { includeFiltered })
     .forEach(async postElement => {
-      const { rebloggedRootId, content, blogName } = await timelineObject(postElement);
+      const { rebloggedRootId, content, blogName, rebloggedFromFollowing } = await timelineObject(postElement);
       const myPost = await isMyPost(postElement);
 
       if (!rebloggedRootId) { return; }
       if (showOwnReblogs && myPost) { return; }
       if (showReblogsWithContributedContent && content.length > 0) { return; }
+      if (showReblogsOfNotFollowing && !rebloggedFromFollowing) { return; }
       if (whitelist.includes(blogName)) { return; }
 
       getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
@@ -116,6 +118,7 @@ export const main = async function () {
   ({
     showOwnReblogs,
     showReblogsWithContributedContent,
+    showReblogsOfNotFollowing,
     whitelistedUsernames
   } = await getPreferences('show_originals'));
 

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -106,13 +106,8 @@ const processPosts = async function (postElements) {
       if (!rebloggedRootId) { return; }
       if (showOwnReblogs && myPost) { return; }
       if (showReblogsWithContributedContent && content.length > 0) { return; }
-      if (showReblogsOfNotFollowing && !rebloggedFromFollowing) {
-        getTimelineItemWrapper(postElement).style.outline = '4px solid green';
-        return;
-      }
+      if (showReblogsOfNotFollowing && !rebloggedFromFollowing) { return; }
       if (whitelist.includes(blogName)) { return; }
-
-      getTimelineItemWrapper(postElement).style.outline = '4px solid red';
 
       getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
     });

--- a/src/scripts/show_originals.js
+++ b/src/scripts/show_originals.js
@@ -106,8 +106,13 @@ const processPosts = async function (postElements) {
       if (!rebloggedRootId) { return; }
       if (showOwnReblogs && myPost) { return; }
       if (showReblogsWithContributedContent && content.length > 0) { return; }
-      if (showReblogsOfNotFollowing && !rebloggedFromFollowing) { return; }
+      if (showReblogsOfNotFollowing && !rebloggedFromFollowing) {
+        getTimelineItemWrapper(postElement).style.outline = '4px solid green';
+        return;
+      }
       if (whitelist.includes(blogName)) { return; }
+
+      getTimelineItemWrapper(postElement).style.outline = '4px solid red';
 
       getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
     });

--- a/src/scripts/show_originals.json
+++ b/src/scripts/show_originals.json
@@ -20,7 +20,7 @@
     },
     "showReblogsOfNotFollowing": {
       "type": "checkbox",
-      "label": "Always show reblogs of accounts you don't follow",
+      "label": "Always show reblogs of blogs I don't follow",
       "default": false
     },
     "whitelistedUsernames": {

--- a/src/scripts/show_originals.json
+++ b/src/scripts/show_originals.json
@@ -18,6 +18,11 @@
       "label": "Always show reblogs with contributed content",
       "default": false
     },
+    "showReblogsOfNotFollowing": {
+      "type": "checkbox",
+      "label": "Always show reblogs of accounts you don't follow",
+      "default": false
+    },
     "whitelistedUsernames": {
       "type": "textarea",
       "label": "Always show reblogs from these blogs (comma-separated)",


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As per the linked issue, this adds an option to Show Originals that shows reblogs if you don't follow the account that's being reblogged. This makes it into a "my friends all reblog each other and I don't really need to see the same content a bunch of times" filter.

Tried it out myself and I can definitely see the appeal, though my dash is mostly people who don't know each other and so most of the content is new to me.

Resolves #1386.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
If desired, unrevert the test commit, enable Show Originals and both "always show reblogs" options, go to the "all posts" tab, and observe that reblogs that you wouldn't expect to see on your dash twice are highlighted green, while self reblogs and reblogs of other users you follow are highlighted red.
