### PR TITLE
AccessKit Visible Alt Text: Fix "imagen" appearing in Spanish

### DIFF
--- a/src/scripts/accesskit/visible_alt_text.js
+++ b/src/scripts/accesskit/visible_alt_text.js
@@ -34,7 +34,7 @@ const processImages = function (imageElements) {
     if (imageBlock.classList.contains(processedClass)) continue;
     imageBlock.classList.add(processedClass);
 
-    const isDefaultAltText = alt === translate('Image') || alt === 'image';
+    const isDefaultAltText = [translate('Image'), translate('Image').toLowerCase(), 'image'].includes(alt);
     const shouldShowCaption = mode === 'show' || !isDefaultAltText;
     if (!shouldShowCaption) continue;
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Fun fact: At time of posting, the default alt text of an image added to the editor when the UI language is set to Spanish is lowercase. `window.tumblr.languageData` doesn't have this variation, as the same key ("Image") corresponds to both case variations ("Imagen" / "imagen") and of course a javascript key-value object can only have one of them.

This means that the "only show image descriptions" alt text mode doesn't work in Spanish (and in general that we're relying on whoever does Tumblr's translations not to put different values in any case where multiple values correspond to a single key). This PR fixes this in the case of visible alt text and specifically cases differing.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Enable visible alt text and the `Only show image descriptions` option.
- Change the UI language to Spanish.
- Navigate to a post with an image without custom alt text. Confirm that no alt text appears.
