### PR TITLE
Tweaks: Fix carousel hiding affecting "your tags" tab

### DIFF
--- a/src/scripts/tweaks/caught_up_line.js
+++ b/src/scripts/tweaks/caught_up_line.js
@@ -16,7 +16,7 @@ const styleElement = buildStyle(`
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');
-const tagChicletCarouselLinkSelector = `${listTimelineObjectSelector} ${keyToCss('tagChicletLink')}`;
+const tagChicletCarouselLinkSelector = `[data-timeline="/v2/timeline/dashboard"] ${listTimelineObjectSelector} ${keyToCss('tagChicletLink')}`;
 
 const createCaughtUpLine = tagChicletCarouselItems => tagChicletCarouselItems
   .map(getTimelineItemWrapper)


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This prevents the caught up line tweak (officially `Turn the Changes/Shop/etc. links carousel into a separating line`) from affecting the carousel atop the "your tags" tab at https://www.tumblr.com/dashboard/hubs.

Specifying the dashboard in question seemed like the easiest way to do this, as there is very little that differentiates the carousel we want to hide from a followed tags carousel. They mostly seem to use the same rendering code; the API response that makes the thing we want to hide (I still call it the "you're caught up" carousel) has `objectType: "followed_tag_carousel_card"`.

Resolves #1375.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that the tweak in question still works on https://www.tumblr.com/ / https://www.tumblr.com/dashboard / https://www.tumblr.com/dashboard/following.
- Confirm that the tweak in question has no effect on https://www.tumblr.com/dashboard/hubs
