### PR TITLE
Tweaks: Fix "Caught-up line" not appearing on mobile devices

### DIFF
--- a/src/scripts/tweaks/caught_up_line.js
+++ b/src/scripts/tweaks/caught_up_line.js
@@ -13,6 +13,13 @@ const styleElement = buildStyle(`
     overflow-y: hidden;
     border-top: 4px solid rgb(var(--white-on-dark));
   }
+
+  @media (max-width: 540px) {
+    [${borderAttribute}] > div {
+      margin-top: 2px;
+      border-bottom: 2px solid transparent;
+    }
+  }
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');

--- a/src/scripts/tweaks/caught_up_line.js
+++ b/src/scripts/tweaks/caught_up_line.js
@@ -13,13 +13,6 @@ const styleElement = buildStyle(`
     overflow-y: hidden;
     border-top: 4px solid rgb(var(--white-on-dark));
   }
-
-  @media (max-width: 540px) {
-    [${borderAttribute}] > div {
-      margin-top: 2px;
-      margin-bottom: 12px !important;
-    }
-  }
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');

--- a/src/scripts/tweaks/caught_up_line.js
+++ b/src/scripts/tweaks/caught_up_line.js
@@ -13,6 +13,13 @@ const styleElement = buildStyle(`
     overflow-y: hidden;
     border-top: 4px solid rgb(var(--white-on-dark));
   }
+
+  @media (max-width: 540px) {
+    [${borderAttribute}] > div {
+      margin-top: 2px;
+      margin-bottom: 12px !important;
+    }
+  }
 `);
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As per the linked issue, this fixes an issue where the ≤540px-width mobile layout caused the line indicator created by the `Turn the Changes/Shop/etc. links carousel into a separating line` tweak not to appear. This is due to the Tumblr frontend hiding timeline elements with less than a certain height value, and that value not changing with the reduced spacing when the layout changes.

This adds 2px of spacing above and below the line in this layout to fix this. (3px is the total required, but that wouldn't be symmetrical.)

Resolves #1398.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Open your dash with a viewport width of <540px (zooming in makes this easier on a desktop browser).
- Confirm that the affected tweak works and the visual spacing above and below the line indicator appears symmetrical.

