### PR TITLE
Mutual Checker: Fix icon insertion on mobile devices

### DIFF
--- a/src/scripts/mutual_checker.js
+++ b/src/scripts/mutual_checker.js
@@ -10,7 +10,7 @@ import { getPreferences } from '../util/preferences.js';
 const mutualIconClass = 'xkit-mutual-icon';
 const hiddenAttribute = 'data-mutual-checker-hidden';
 const mutualsClass = 'from-mutual';
-const postAttributionSelector = `header ${keyToCss('attribution')} > span:not(${keyToCss('reblogAttribution')}) a`;
+const postAttributionSelector = `header ${keyToCss('attribution')} a:not(${keyToCss('reblogAttribution', 'rebloggedFromName')} *)`;
 
 const styleElement = buildStyle(`${keyToCss('notification')}:not([data-mutuals]) { display: none !important; }`);
 

--- a/src/util/interface.js
+++ b/src/util/interface.js
@@ -22,14 +22,12 @@ export const getTimelineItemWrapper = element =>
   element.closest(cellSelector) || element.closest(listTimelineObjectSelector);
 
 /**
- * @param {Element} element Element within a popover wrapper
- * @returns {Element | null} The outermost popover wrapper
+ * @param {Element} element - Element that may be within a popover wrapper
+ * @returns {Element} The outermost popover wrapper or the element
  */
 export const getPopoverWrapper = element => {
   const closestWrapper = element.closest(targetWrapperSelector);
-  return closestWrapper?.parentElement?.matches(targetWrapperSelector)
-    ? closestWrapper.parentElement
-    : closestWrapper;
+  return closestWrapper?.parentElement?.closest(targetWrapperSelector) ?? closestWrapper ?? element;
 };
 
 /**

--- a/src/util/interface.js
+++ b/src/util/interface.js
@@ -26,11 +26,8 @@ export const getTimelineItemWrapper = element =>
  * @returns {Element} The outermost popover wrapper or the element
  */
 export const getPopoverWrapper = element => {
-  let result = element;
-  while (result.parentElement.closest(targetWrapperSelector)) {
-    result = result.parentElement.closest(targetWrapperSelector);
-  }
-  return result;
+  const closestWrapper = element.closest(targetWrapperSelector);
+  return closestWrapper?.parentElement?.closest(targetWrapperSelector) ?? closestWrapper ?? element;
 };
 
 /**

--- a/src/util/interface.js
+++ b/src/util/interface.js
@@ -26,8 +26,11 @@ export const getTimelineItemWrapper = element =>
  * @returns {Element} The outermost popover wrapper or the element
  */
 export const getPopoverWrapper = element => {
-  const closestWrapper = element.closest(targetWrapperSelector);
-  return closestWrapper?.parentElement?.closest(targetWrapperSelector) ?? closestWrapper ?? element;
+  let result = element;
+  while (result.parentElement.closest(targetWrapperSelector)) {
+    result = result.parentElement.closest(targetWrapperSelector);
+  }
+  return result;
 };
 
 /**


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in the linked issue, Mutual Checker does not insert icons when the page viewport width is ≤540px. (Icons will persist when the page is narrowed through this boundary, though.) This is because the code added in #1239 assumes that a popover wrapper exists.

This fixes this issue by:
 - Improving `postAttributionSelector` using a complex selector list in `:not()`, which correctly semantically represents "element that does not have a certain parent" without relying on a certain element existing instead. I have no idea why this pattern is not documented on MDN, by the way.
 - Defaulting to the element itself in `getPopoverWrapper` if the target element isn't surrounded in a popover wrapper, which the mobile-mode attribution isn't.

Resolves #1405.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Open your dash with a wide viewport width. Find a post from a mutual with a mutual icon.
- Resize your browser viewport to <540px wide (zooming in makes this easier on a desktop browser). Confirm that the mutual icon is still there. (This was fine before this PR.)

- With your browser viewport <540px wide, open your dash and find a post from a mutual. Confirm that it has a mutual icon.
- Resize your browser viewport to a wide viewport width. Confirm that the mutual icon is still there.

