### PR TITLE
Fix Communities compatibility via props override

### DIFF
--- a/src/util/react_props.js
+++ b/src/util/react_props.js
@@ -25,7 +25,14 @@ const unburyTimelineObject = () => {
  */
 export const timelineObject = async function (postElement) {
   if (!timelineObjectCache.has(postElement)) {
-    timelineObjectCache.set(postElement, inject(unburyTimelineObject, [], postElement));
+    timelineObjectCache.set(
+      postElement,
+      inject(unburyTimelineObject, [], postElement).then(data =>
+        data && data.community && data.authorBlog
+          ? { ...data, blog: data.authorBlog, communityBlog: data.blog }
+          : data
+      )
+    );
   }
   return timelineObjectCache.get(postElement);
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

See discussion #1438 and issue #1441.

One of the ways to fix the discrepancy in behavior between posts in communities (which have an `authorBlog` field in their react prop data containing what would normally be in `blog`) is to simply replace the `blog` field's contents when we query for said data.

This is probably a bad idea for a number of reasons, such as future developer confusion and inconsistency between API calls (would need a helper there too, I guess) and react prop data queries. I only bring this up because, that I can tell, the Tumblr frontend seems to do this in some cases.

(This kind of brings into question why the fields actually are this way, but I can imagine a fair number of good reasons it has to be that way ¯\\\_(ツ)_/¯) 

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Enable Themed Posts on a communities page and confirm that posting users' blog colors appear.
- You know, other stuff, if we go forward with this method.
