### PR TITLE
Refactor: use `replaceChildren` pattern to create lists

### DIFF
--- a/src/browser_action/render_scripts.js
+++ b/src/browser_action/render_scripts.js
@@ -127,15 +127,13 @@ const renderPreferences = async function ({ scriptName, preferences, preferenceL
 };
 
 const renderScripts = async function () {
-  const scriptClones = [];
-  scriptsDiv.textContent = '';
-
   const installedScripts = await getInstalledScripts();
   const { enabledScripts = [], specialAccess = [] } = await browser.storage.local.get();
 
   const orderedEnabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName));
   const disabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName) === false);
 
+  const scriptClones = [];
   for (const scriptName of [...orderedEnabledScripts, ...disabledScripts]) {
     const url = getURL(`/scripts/${scriptName}.json`);
     const file = await fetch(url);
@@ -204,7 +202,7 @@ const renderScripts = async function () {
     scriptClones.push(scriptTemplateClone);
   }
 
-  scriptsDiv.append(...scriptClones);
+  scriptsDiv.replaceChildren(...scriptClones);
 };
 
 renderScripts();

--- a/src/scripts/postblock/options/index.js
+++ b/src/scripts/postblock/options/index.js
@@ -17,9 +17,7 @@ const renderBlockedPosts = async function () {
   const { [storageKey]: blockedPostRootIDs = [] } = await browser.storage.local.get(storageKey);
 
   postsBlockedCount.textContent = `${blockedPostRootIDs.length} blocked ${blockedPostRootIDs.length === 1 ? 'post' : 'posts'}`;
-  blockedPostList.textContent = '';
-
-  for (const blockedPostID of blockedPostRootIDs) {
+  blockedPostList.replaceChildren(...blockedPostRootIDs.map(blockedPostID => {
     const templateClone = blockedPostTemplate.content.cloneNode(true);
     const spanElement = templateClone.querySelector('span');
     const unblockButton = templateClone.querySelector('button');
@@ -28,8 +26,8 @@ const renderBlockedPosts = async function () {
     unblockButton.dataset.postId = blockedPostID;
     unblockButton.addEventListener('click', unblockPost);
 
-    blockedPostList.append(templateClone);
-  }
+    return templateClone;
+  }));
 };
 
 browser.storage.onChanged.addListener((changes, areaName) => {

--- a/src/scripts/quick_reblog.js
+++ b/src/scripts/quick_reblog.js
@@ -250,12 +250,12 @@ const processPosts = async function (postElements) {
 };
 
 const renderQuickTags = async function () {
-  quickTagsList.textContent = '';
-
   const { [quickTagsStorageKey]: tagBundles = [] } = await browser.storage.local.get(quickTagsStorageKey);
-  tagBundles.forEach(tagBundle => {
+
+  quickTagsList.replaceChildren(...tagBundles.map(tagBundle => {
     const bundleTags = tagBundle.tags.split(',').map(tag => tag.trim().toLowerCase());
     const bundleButton = dom('button', null, null, [tagBundle.title]);
+
     bundleButton.addEventListener('click', ({ currentTarget: { dataset } }) => {
       const checked = dataset.checked === 'true';
 
@@ -274,8 +274,8 @@ const renderQuickTags = async function () {
       dataset.checked = !checked;
     });
 
-    quickTagsList.appendChild(bundleButton);
-  });
+    return bundleButton;
+  }));
 };
 
 const updateQuickTags = (changes, areaName) => {

--- a/src/scripts/quick_tags/options/index.js
+++ b/src/scripts/quick_tags/options/index.js
@@ -70,7 +70,7 @@ const deleteBundle = async ({ currentTarget }) => {
 const renderBundles = async function () {
   const { [storageKey]: tagBundles = [] } = await browser.storage.local.get(storageKey);
 
-  bundlesList.append(...tagBundles.map(({ title, tags }, index) => {
+  bundlesList.replaceChildren(...tagBundles.map(({ title, tags }, index) => {
     const bundleTemplateClone = bundleTemplate.content.cloneNode(true);
 
     bundleTemplateClone.querySelector('.bundle').id = index;
@@ -92,7 +92,6 @@ const renderBundles = async function () {
 
 browser.storage.onChanged.addListener((changes, areaName) => {
   if (areaName === 'local' && Object.keys(changes).includes(storageKey)) {
-    bundlesList.textContent = '';
     renderBundles();
   }
 });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in https://github.com/AprilSylph/XKit-Rewritten/pull/677#discussion_r1582739158, there are a number of places where we could use `replaceChildren` to update a list's contents in the DOM all in one go, rather than emptying it, (often) waiting asynchronously for a preference fetch, then adding the desired elements in one-by-one.

The meaningful behavior change resulting from this is that if the code throws or the preference fetch stalls, the old elements are left in place rather than the list becoming blank, which may be a more confusing failure mode.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

