### PR TITLE
Mega-edit util: Remove unnecessary inject()

### DIFF
--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -163,7 +163,7 @@ const addTagsToPost = async function ({ postElement, inputTags = [] }) {
 
   tags.push(...tagsToAdd);
 
-  if (isNpfCompatible(postData)) {
+  if (false) {
     const { response: { displayText } } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}`, {
       method: 'PUT',
       body: {

--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -163,7 +163,7 @@ const addTagsToPost = async function ({ postElement, inputTags = [] }) {
 
   tags.push(...tagsToAdd);
 
-  if (false) {
+  if (isNpfCompatible(postData)) {
     const { response: { displayText } } = await apiFetch(`/v2/blog/${uuid}/posts/${postId}`, {
       method: 'PUT',
       body: {

--- a/src/util/mega_editor.js
+++ b/src/util/mega_editor.js
@@ -1,5 +1,3 @@
-import { inject } from './inject.js';
-
 let formKey;
 
 const pathnames = {
@@ -44,15 +42,11 @@ export const megaEdit = async function (postIds, options) {
     delete requestBody.tags;
   }
 
-  return inject(
-    async (resource, body) =>
-      fetch(resource, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
-        body
-      }).then(async response =>
-        response.ok ? response.json() : Promise.reject(await response.json())
-      ),
-    [`https://www.tumblr.com/${pathname}`, $.param(requestBody)]
+  await fetch(`https://www.tumblr.com/${pathname}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
+    body: $.param(requestBody)
+  }).then(async response =>
+    response.ok ? response.json() : Promise.reject(await response.json())
   );
 };

--- a/src/util/mega_editor.js
+++ b/src/util/mega_editor.js
@@ -42,7 +42,7 @@ export const megaEdit = async function (postIds, options) {
     delete requestBody.tags;
   }
 
-  await fetch(`https://www.tumblr.com/${pathname}`, {
+  return fetch(`https://www.tumblr.com/${pathname}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8' },
     body: $.param(requestBody)


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Uhhhh... silly question: do we actually need this to be injected? That I can tell, Tumblr doesn't modify/instrument window.fetch(), and if this fails, having it potentially pop up in Sentry logs seems like all downside.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Either:
 - Unrevert the test commit
 - Confirm quick tags still works

Or:
 - Confirm tag replacer still works
