### PR TITLE
Modals: Make small buttons consistent width

### DIFF
--- a/src/content_scripts/modals.css
+++ b/src/content_scripts/modals.css
@@ -116,6 +116,7 @@
 
 #xkit-modal .buttons :is(a, button, input) {
   padding: 0.75ch 1.5ch;
+  min-width: 10ch;
   border: none;
   border-radius: 3px;
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Sets a minimum width on modal action buttons so that there isn't a slight asymmetry when exactly two small buttons are beside each other.

See: https://github.com/AprilSylph/XKit-Rewritten/pull/1279#issuecomment-2096317910


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

