### PR TITLE
Move wiki content source into repository

### DIFF
--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -2,7 +2,7 @@ name: Sync wiki content
 on:
   push:
     branches:
-      - main
+      - master
     paths:
       - wiki/**
       - .github/workflows/sync-wiki.yml

--- a/.github/workflows/sync-wiki.yml
+++ b/.github/workflows/sync-wiki.yml
@@ -1,0 +1,25 @@
+name: Sync wiki content
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - wiki/**
+      - .github/workflows/sync-wiki.yml
+  workflow_dispatch:
+
+concurrency:
+  group: sync-wiki
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  sync-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          ignore: README.md

--- a/wiki/Excluded-features.md
+++ b/wiki/Excluded-features.md
@@ -1,0 +1,46 @@
+Some XKit 7 extensions will not be implemented as features in XKit Rewritten. Their titles, and the rationale to exclude them, are listed here.
+
+---
+
+## Blacklist
+> Clean your dash
+
+This XKit 7 extension allowed you to block posts based on the terms specified in the extension's settings. However, it has been superceded by Tumblr's own blocking features:
+- [Post content filtering](https://tumblr.zendesk.com/hc/articles/360046752174-Post-content-filtering)
+- [Tag filtering](https://tumblr.zendesk.com/hc/articles/115015814708-Tag-filtering), which also checks the original post's tags
+- [Blocking users](https://tumblr.zendesk.com/hc/articles/231877648-Blocking-users), which now also hides posts on your dashboard if you've blocked the original post author
+
+## Blog Tracker
+> Track people like tags
+
+This XKit 7 extension added a sidebar section to pages with a list of user-specified blogs, and an unread count on each one. Since the creation of this extension, Tumblr has added the ability to subscribe to blogs, which provides push notifications for new posts (on mobile) and creates a dedicated "[Your Blog Subscriptions](https://www.tumblr.com/timeline/blog_subscriptions)" timeline on the new web client. Alternatively, it is possible to use an RSS reader client, such as [Mozilla Thunderbird](https://www.thunderbird.net/), to subscribe to public blogs' RSS feeds (available via adding `/rss` to the end of a Tumblr URL, e.g. `https://april.tumblr.com/rss`).
+
+## Bookmarker
+> Dashboard Time Machine
+
+This XKit 7 extension added a bookmark button to posts and a sidebar section which allowed skipping to that post again on your dashboard. However, it never worked perfectly due to Tumblr's issues with dashboard pagination over long stretches of time, and Tumblr has since implemented a ["Now, where were we?" button](https://changes.tumblr.com/post/625181787053867008/friday-july-31st-2020) for short-term place-keeping.
+
+## Post Archiver
+> Never lose a post again.
+
+This XKit 7 extension saved entire posts to the browser addon's storage to be viewed again later. However, saving such potentially massive amounts of data is better suited to services designed to do so, such as [Pocket](https://getpocket.com/).
+
+## Reblog Display Options
+> Adds different styles to the new reblog layout, including the "classic" nested look.
+
+This XKit 7 extension's main use, as suggested by its description, was to revert the look of the reblog trail to the forum-like blockquotes-within-blockquotes style. The difficulty of maintaining such a feature to work with Tumblr's Neue Post Format (where all post media exists inside the reblog trail, not on top of it) far outweighs the actual value provided by such a feature, which is assumed to be primarily, if not exclusively, nostalgia value.
+
+## Separator
+> Where were we again?
+
+This XKit 7 extension's behaviour was essentially built into the new Tumblr dashboard on [Friday, November 13th, 2020](https://changes.tumblr.com/post/634699268683448320/friday-november-13th-2020).
+
+## Themes
+> Themes for your dashboard
+
+This XKit 7 extension provided several dashboard-wide restyles. However, the themes themselves received very little maintenance, and theming the dashboard ultimately became more difficult on Tumblr's React-based web client, since it uses obfuscated classnames on elements.
+
+## Unreverse
+> Places the post buttons on top
+
+This XKit 7 extension existed purely for nostalgia value, and was never truly supported.

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -1,0 +1,356 @@
+XKit Rewritten is a bundled collection of scripts, none of which are enabled by default. This page details the behaviour of each one.
+
+---
+
+## AccessKit
+> Accessibility options for Tumblr
+
+This script is a collection of accessibility tweaks for the Tumblr dashboard. With all options disabled, it does nothing.
+
+Available preferences:
+- Toggle: **Pause GIFs until they are hovered over**
+- Toggle: **De-animate the Changes/Shop/etc. links carousel**
+- Toggle: **Disable layout element animations**
+- Toggle: **Make links in posts blue**
+- Toggle: **Remove user-set colours from text in posts**
+- Toggle: **Remove user-set fonts from text in posts**
+- Toggle: **Use regular-width scrollbars**
+- Toggle: **Move alt text to captions below images**
+- Selection: **Alt text mode**
+  - Option: **Show all alt text** (default)
+  - Option: **Only show image descriptions**
+
+## Anti-Capitalism
+> Hide advertisement containers
+
+This script hides ad containers and the "Sponsored" section in the sidebar. While it *hides* ads, it does not *block* anything; it is intended to be complimentary to [Tumblr Ad-Free Browsing](https://www.tumblr.com/settings/ad-free-browsing) or a wide-spectrum blocker such as [uBlock Origin](https://github.com/gorhill/ublock#readme).
+
+## Classic Search
+> Go to tagged pages easily
+
+This script changes the behaviour of Tumblr's search bar to go to `/tagged/` pages by default, rather than `/search/`. It does not change the behaviour of the dropdown that appears when typing, or any of its items.
+
+Available preferences:
+- Toggle: **Open tagged pages in a new tab**
+
+## CleanFeed
+> Browse safely in public
+
+This script hides visual media (images and video) on posts until the media is hovered over.
+
+Available preferences:
+- Selection: **Hide media from:**
+  - Option: **mature posts & blogs** (default)
+  - Option: **all posts**
+- Text field: **Treat these blogs as mature (comma-separated)**
+- Text field: **Treat these tags as mature (comma-separated)**
+
+## Collapsed Queue
+> Shorten posts in your queue
+
+This script limits the height of posts on queue pages - making the post content scrollable - to make it easier to rearrange the queue post order.
+
+Available preferences:
+- Toggle: **Run on the queue page**
+- Toggle: **Run on the drafts page**
+
+## Hide Avatars
+
+This script makes user avatars invisible on a username basis.
+
+Available preferences:
+- Text field: **Usernames (comma-separated)**
+
+## Limit Checker
+> Check post limit and more
+
+This script adds a button to the sidebar which, when clicked, will fetch your account's action limit data and display it to you in a table. This includes everything with a per-day per-account limit, such as new posts, new blogs, and uploaded media.
+
+## Mass Deleter
+> Delete drafts or clear your queue
+
+This script adds a button to the sidebar on your blogs' drafts and queue pages.
+
+On drafts pages, clicking the button will prompt you to enter a date to delete drafts up to. Once confirmed, all drafts on that blog will be gathered, and qualifying drafts will then be deleted in batches of 100.
+
+On queue pages, clicking the button will ask to confirm that you want to clear your queue. If confirmed, all queued posts on that blog will be gathered, and then deleted in batches of 100. While scheduled posts do appear on the queue page, they are ignored.
+
+## Mass Privater
+> Unpublish posts by time range or tag
+
+This script adds a button to the sidebar on your blogs' admin views which, when clicked, will prompt you to enter criteria for which posts you would like to make private. You can choose which blog to affect, a "before" date/time, and optionally enter tags to query by.
+
+There is a confirmation prompt after you submit your criteria, allowing you to double-check your choices.
+
+If confirmed, all published posts matching your criteria will be fetched via the Tumblr API, and then made private in batches of 100.
+
+## Mass Unliker
+> Clear your likes
+
+This script adds a button to the sidebar on the Likes page which, when clicked, prompts you to clear your likes. If confirmed, all your likes will be fetched via the Tumblr API and then unliked one at a time, at a maximum rate of 1 per second.
+
+Because the fetch process is not perfect, this utility may have to be run multiple times to truly clear an account's likes. Additionally, due to how Tumblr counts likes, you may not end up with a like count of zero, even if your likes page becomes devoid of posts.
+
+## Mirror Posts
+> Back up posts to public archives
+
+This script adds a "Mirror this post" button to posts' meatball menus. Clicking it will open a modal which allows you to choose between backing the post up via archive.today or the WayBack Machine.
+
+## Mutual Checker
+> See who follows you back
+
+This script adds an icon in front of the post author's username on posts if the user is both followed by you and follows your primary blog.
+
+Available preferences:
+- Toggle: **Only show posts from mutuals on the dashboard**
+- Toggle: **Only show notifications from mutuals in the activity feed**
+
+## No Recommended
+> Focus only on what you follow
+
+This script is a collection of options for removing recommended content. With all options disabled, it does nothing.
+
+To hide posts from your followed tags, disable "Include followed tag posts" in your [dashboard settings](https://www.tumblr.com/settings/dashboard).
+
+Available preferences:
+- Toggle: **Hide experimental types of recommended posts**
+- Toggle: **Hide the answertime banner**
+- Toggle: **Hide recommended blogs between posts**
+- Toggle: **Hide recommended tags between posts**
+- Toggle: **Hide related posts in the photo lightbox**
+- Toggle: **Hide recommended blogs in the sidebar**
+- Toggle: **Hide recommended blogs in the blog view sidebar**
+- Toggle: **Hide the Tumblr Radar**
+
+## NotificationBlock
+> Block a post's notifications
+
+This script adds a "Block notifications" button to your posts' meatball menus. Blocking a post's notifications will hide all notifications for all instances of that post on your activity page, with no indication they were hidden. To unblock a post's notifications, find the post again and use the "Unblock notifications" meatball menu button.
+
+## Open In Tabs
+> Open links and blogs in new tabs
+
+This script disables the on-dashboard blog view and instead opens all links that could even roughly be considered "external" in a new tab.
+
+## Painter
+> Add colour to your dashboard posts
+
+This script adds coloured borders to posts depending on the criteria the post fits.
+
+Available preferences:
+- Colour: **Own post colour**
+- Colour: **Original post colour**
+- Colour: **Reblogged post colour**
+- Colour: **Liked post colour**
+- Colour: **Tag highlighting colour**
+- Text field: **Tags to highlight (comma separated)**
+- Toggle: **Also highlight for tags on source posts**
+
+## Panorama
+> Widescreen dashboard
+
+This script changes the layout of the Tumblr web interface to fill all available horizontal space. It only takes effect on the site's desktop layout.
+
+## PostBlock
+> Disappear all instances of a post
+
+This script adds a "Block this post" button to posts' meatball menus. Blocking a post will hide all instances of it, including reblogs, with no indication.
+
+Available preferences:
+- Embedded page: **Manage blocked posts** – Displays your blocked post IDs (listed oldest-first) with per-ID unblock buttons.
+
+## Quick Reblog
+
+This script adds a small post form next to reblog buttons on posts, when the reblog button is hovered over.
+
+Available preferences:
+- Selection: **Popup position**
+  - Option: **Above reblog button**
+  - Option: **Below reblog button** (default)
+- Toggle: **Show the blog selector** – If disabled, always uses your primary blog
+- Toggle: **Remember the last selected blog in the popup**
+- Toggle: **Show the comment field**
+- Toggle: **Enable integration with Quick Tags** – Shows tag bundle shortcuts using data from *Quick Tags*
+- Toggle: **Show the tags field**
+- Toggle: **Suggest tags from the post being reblogged** - If enabled, suggests tags when typing in the tags field; the post's tags, post author, original post author, and post type will be suggested
+- Text field: **Reblog tag** - If set, automatically tags all posts reblogged through Quick Reblog with this tag
+- Text field: **Queue tag** - If set, automatically tags all posts queued through Quick Reblog with this tag
+- Toggle: **Remember which posts I've already reblogged** – If enabled, registers root post IDs when reblogging posts, and turns the reblog button green on every instance of those posts
+- Selection: **Remember the last**
+  - Option: **100 posts**
+  - Option: **1,000 posts** (default)
+  - Option: **10,000 posts**
+
+## Quick Tags
+> Add tags to posts easily
+
+This script adds a button to your posts and the post editor which allows you to add bundles of tags in a single click.
+
+This script requires the beta post editor to be enabled for all its features to function.
+
+This script does not need to be enabled for *Quick Reblog* to use its data.
+
+Available preferences:
+- Text field: **Original post tag** - Set a tag to automatically add when creating a new post
+- Text field: **Answer tag** - Set a tag to automatically add when answering an ask
+- Toggle: **Automatically tag asker when answering**
+- Embedded page: **Manage tag bundles** – Allows you to define, edit, and delete bundles of tags
+
+## Quote Replies
+> Reply to reply notifications
+
+This script adds a button to each reply notification. When clicked, it will draft a new post quoting that reply, and then open the edit form for that draft.
+
+Optionally, you can set the script to instead open the draft in a new tab. This requires pop-ups from Tumblr to be allowed; if a new tab cannot be opened, the script will simply give you a notification that the draft was created.
+
+Available preferences:
+- Toggle: **Automatically tag the quoted user**
+- Toggle: **Open created posts in new tabs**
+
+## Scroll to Bottom
+> Load ALL the posts!
+
+This script adds a reverse version of Tumblr's scroll to top button. Clicking it will scroll the page down until there are no more posts to load, making it easy to load all posts on queue and drafts pages, provided endless scrolling is enabled.
+
+## Seen Posts
+> Dim the posts you've seen already
+
+This script remembers posts on the dashboard and adds a semi-transparent effect if the post has been seen before.
+
+Available preferences:
+- Toggle: **Only dim avatars on seen posts**
+- Toggle: **Hide seen posts from the dashboard**
+
+## Shorten Posts
+> Limit the length of posts on your dash
+
+This script limits the amount of vertical space that posts can each take up, and adds an "Expand" button to the bottom of shortened posts.
+
+Available preferences:
+- Toggle: **Show tags on shortened posts**
+- Selection: **Maximum post height**
+  - Option: **0.25x viewport height**
+  - Option: **0.5x viewport height**
+  - Option: **1x viewport height** (default)
+  - Option: **1.5x viewport height**
+  - Option: **2x viewport height**
+  - Option: **4x viewport height**
+
+## Show Originals
+> Hide reblogged posts by default
+
+This script adds controls to the top of the dashboard, the blog subscriptions timeline, and blog views which allow you to switch between viewing all posts or only original posts.
+
+Available preferences:
+- Toggle: **Always show my own reblogs**
+- Toggle: **Always show reblogs with contributed content**
+- Text field: **Always show reblogs from these blogs (comma-separated)**
+
+## Tag Replacer
+> Replace old tags in bulk
+
+This script adds a button to the sidebar which, when clicked, prompts you to replace a tag on a given blog.
+
+Only one tag can be replaced at a time. Any commas in the "remove this tag" field will be ignored.
+
+You can specify zero, one, or more tags to replace the tag with. It is possible to replace a tag with itself. You'll be given a summary of what will happen before you give the final confirmation.
+
+Once confirmed, all public published posts on the selected blog with the given tag will be fetched. Then, they will be processed in batches of 100 via the Mass Post Editor API. Since adding tags and deleting tags cannot be done simultaneously this way, replacing a tag will process the batch twice: first to add new tags, then to delete old tags.
+
+## Tag Tracking+
+> Unread counts on followed tags
+
+This script lists your followed tags in the sidebar with unread counts. On `/tagged/` pages for tags you follow, it will remember the newest post it's seen and use that to determine if posts are unread, so it will be inaccurate if you are not using the "Latest" view.
+
+Available preferences:
+- Selection: **Show unread counts**
+  - Option: **Both in search & sidebar** (default)
+  - Option: **Only in the search dropdown**
+  - Option: **Only in the sidebar**
+- Toggle: **Only show tags with new posts in the sidebar**
+
+## Themed Posts
+> Use users' theme colors for posts
+
+This script changes the palette of posts to match the blog's palette.
+
+Available preferences:
+- Toggle: **Theme every reblog trail item individually**
+- Toggle: **Enable theming on the blog view**
+- Text field: **Disable theming on these blogs (comma-separated)**
+- Selection: **Disabled/deleted blog theming**
+  - Option: **default/palette color** (default)
+  - Option: **inherit reblogging blog's theme**
+
+## TimeFormat
+> Reformat Tumblr's timestamps
+
+This script allows you to apply [Moment.js formatting](https://momentjs.com/docs/#/displaying/format/) to Tumblr's timestamps on posts, reblogs, and notes. You can enable Tumblr's timestamps in your [dashboard settings](https://www.tumblr.com/settings/dashboard).
+
+Available preferences:
+- Text field: **Format** - Moment.js formatting syntax. Uses ISO 8601 format if set to nothing.
+- Toggle: **Append relative time**
+
+## Trim Reblogs
+> Trim threads after posting or drafting
+
+This script adds a control button to your posts which allows removal of individual reblog trail items. (It does **not** appear in the editor.)
+
+When the button is clicked, a modal is opened that lets you pick which reblog trail items to remove. It will not allow trimming if the action would result in an empty post.
+
+Only posts stored in Tumblr's Neue Post Format (NPF) can be reliably trimmed. For the best results, the root post should be NPF, and at no point should your reblog (nor any of its ancestors in the reblog chain) have been edited using legacy methods.
+
+All posts made from the mobile Tumblr apps since ~2018 are NPF, as are all posts made with the [new post editor on web](https://tumblr.zendesk.com/hc/en-us/articles/360010901913-Using-the-Neue-Post-Format#webnpf). All reblogs of NPF posts are NPF by default, regardless of the method used. However, _editing_ a reblog of an NPF post using Tumblr's legacy post editor, or a previous version of XKit, will result in the post being stored in the legacy post format instead. Once a reblog is stored in the legacy post format, all downstream reblogs are also legacy.
+
+Asks can be trimmed, but trimmed asks will display incorrectly on blog themes.
+
+## Tweaks
+> Miscellaneous dashboard options
+
+This script is a collection of options which subtly change aspects of the Tumblr interface. It does nothing if none of its preferences are enabled.
+
+Available preferences:
+- Toggle: **Restore links to individual posts in the post header**
+- Toggle: **Use a slim layout for filtered posts**
+- Toggle: **Highlight contributed content on reblogs**
+- Toggle: **Show every line of tags by default**
+- Toggle: **Turn the Changes/Shop/etc. links carousel into a separating line**
+- Toggle: **Remove the coloured shadow from focused posts**
+- Toggle: **Remove the sticky effect from the dashboard tab bar**
+- Toggle: **Hide mini-follow buttons on posts**
+- Toggle: **Hide following/mutuals indicators on notifications**
+- Toggle: **Hide control button tooltips in the post footer**
+- Toggle: **Hide the "blaze" and "tip" button labels**
+- Toggle: **Hide filtered posts entirely**
+- Toggle: **Hide my own posts on the dashboard**
+- Toggle: **Hide posts that I've liked on the dashboard**
+- Toggle: **Hide my follower count where possible**
+- Toggle: **Hide the Home/Following unread count**
+- Toggle: **Hide the Activity notification badge**
+- Toggle: **Hide the "Now, where were we?" button**
+
+## Vanilla Audio
+> Use the browser's controls for audio posts
+
+This script hides the play button on audio blocks in posts, and inserts a browser-native audio player underneath. The appearance of this player varies between browsers.
+
+Available preferences:
+- Selection: **Default Volume**
+  - Option: **Muted**
+  - Option: **25%**
+  - Option: **50%**
+  - Option: **75%**
+  - Option: **100%** (default)
+
+## Vanilla Video
+> Use the browser's controls for video posts
+
+This script hides Tumblr's video player and inserts a browser-native video player in its place, with controls shown and autoplay disabled. The appearance of this player varies between browsers.
+
+Available preferences:
+- Selection: **Default Volume**
+  - Option: **Muted**
+  - Option: **25%**
+  - Option: **50%**
+  - Option: **75%**
+  - Option: **100%** (default)

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,19 @@
+Welcome to the XKit Rewritten user guide.
+
+**XKit Rewritten** is a browser extension which adds extra features to Tumblr's new React-based web client (codename: "Redpop"), which launched in April 2020. It is the successor to XKit 7 ("XKit"/"New XKit"), a userscript framework designed to target Tumblr's previous web interface (codename: "Prima").
+ 
+This project started in July 2020 and entered Beta in March 2021.
+
+## Frequently asked questions
+
+> **Do I need to remove New XKit to install XKit Rewritten?**
+
+No, you don't! The two should not conflict. If running them at the same time causes any problems, please [file a bug report](https://github.com/AprilSylph/XKit-Rewritten/issues/new?labels=bug&template=bug_report.yml) for it. That said, running New XKit features while also running their XKit Rewritten counterparts is not recommended for performance reasons.
+
+> **Where's Old Blue?**
+
+The pre-2019 Tumblr palette is available via the separate extension [Palettes for Tumblr](https://github.com/AprilSylph/Palettes-for-Tumblr#readme).
+
+> **Is Outbox coming back?**
+
+Outbox has been rebuilt as the separate extension [Outbox for Tumblr](https://github.com/AprilSylph/Outbox-for-Tumblr#readme).

--- a/wiki/Installation.md
+++ b/wiki/Installation.md
@@ -1,0 +1,26 @@
+## On desktop devices
+
+### Firefox
+
+Install from AMO: [XKit Rewritten | addons.mozilla.org](https://addons.mozilla.org/addon/xkit-rewritten/)
+
+### Chrome
+
+Install from the Chrome Web Store: [XKit Rewritten - Chrome Web Store](https://chrome.google.com/webstore/detail/xkit-rewritten/ehgbadgnkmeeldglkmnplolneidgpbcm)
+
+### Edge
+
+Install from the Chrome Web Store. For more information, see https://support.microsoft.com/en-us/help/4538971/.
+
+### Opera
+
+Install from the Chrome Web Store via [Install Chrome Extensions](https://addons.opera.com/en/extensions/details/install-chrome-extensions/).
+
+---
+
+## On mobile devices
+
+### Android
+
+- Kiwi Browser: install from the Chrome Web Store
+- Firefox (Beta or Nightly): see [this post on blog.mozilla.org](https://blog.mozilla.org/addons/2020/09/29/expanded-extension-support-in-firefox-for-android-nightly/) for instructions on creating and enabling a custom add-on collection (to skip the creation step, use the user ID `14681384` and collection name `Tumblr-Enhancements`).

--- a/wiki/README.md
+++ b/wiki/README.md
@@ -1,0 +1,1 @@
+This directory's contents are automatically synced to the repository's "Wiki" tab by the `sync-wiki` action.

--- a/wiki/Removed-features.md
+++ b/wiki/Removed-features.md
@@ -1,0 +1,23 @@
+Some scripts have been moved elsewhere, or removed for being obsolete.
+
+---
+
+## Audio Downloader
+> Download Tumblr-hosted audio
+
+This script added a download button underneath audio blocks to download the audio file. It was removed with the introduction of [Vanilla Audio](Features#vanilla-audio), since browser-native audio controls in Firefox and Chromium allow downloading.
+
+## Condensed Reblogs
+> Shorten the reblog trail
+
+This script would visually collapse the reblog trail in lieu of being able to remove trail items from the post itself. It was replaced with [Trim Reblogs](Features#trim-reblogs).
+
+## Disable GIFs
+> Pause GIFs until you hover over them
+
+This script's behaviour has been moved to an option in [AccessKit](Features#accesskit).
+
+## Old Blue
+> True low-contrast classic
+
+This script would override Tumblr's palette to resemble the colour scheme used prior to the January 2019 accessibility update. This palette is now included in the separate addon [Palettes for Tumblr](https://github.com/AprilSylph/Palettes-for-Tumblr#readme).

--- a/wiki/Usage.md
+++ b/wiki/Usage.md
@@ -1,0 +1,27 @@
+When you install the addon, its icon should be added to your browser toolbar. Click this icon to open the control panel and configure XKit to your needs. (On Chrome and derivative browsers, this may be hidden under a generic "Extensions" button.)
+
+Once you have the control panel open, there are three tabs: Configuration, Backup, and Links.
+
+## Configuration
+
+### Filters
+
+Typing into the search bar will automatically filter features to those containing matching text in their titles, descriptions, or preferences. To stop searching, simply clear the input.
+
+You can also filter to only features which are enabled, or only features which are disabled. You do not need to use the search input in order to use this dropdown.
+
+### Features
+
+To enable a feature, click the toggle button to the right of the feature's information. The effect on Tumblr should happen instantly if you have a Tumblr tab open and visible.
+
+To configure a feature, click on the feature's icon, information, or any of the white space containing it. This will open that feature's preferences, allowing further configuration. Some features do nothing until they are configured.
+
+## Backup
+
+### Export
+
+This section displays your current configuration, and provides buttons to copy it to the clipboard (Copy All) or to download it to file (Download).
+
+### Import
+
+This section consists of a textarea to paste previously copied or saved configuration into, and a Restore button which will loosely validate and save the provided data to your settings. This import tool only works with XKit Rewritten configuration data, and cannot read XKit 7 exports.

--- a/wiki/_Footer.md
+++ b/wiki/_Footer.md
@@ -1,0 +1,1 @@
+This wiki has restricted editing to collaborators only. To report any missing or unclear information, please [open a documentation issue](https://github.com/AprilSylph/XKit-Rewritten/issues/new?assignees=&labels=documentation&template=documentation_issue.yml).


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

You can't PR a github wiki even though they're repositories. I wondered if you could put the source of the wiki in the repository itself to fix this, and apparently you [kind of can](https://github.com/marcustyphoon/wiki-sync-test).

Requires a third-party github action. There are a bunch on the actions marketplace, none of which really stood out to me. Syncing changes back from the wiki to the repository seemed annoying, so this is a one-way sync (single source of truth). Drawback: you can't use the wiki editor anymore, which may provide a better editing experience than whatever one uses to edit .md files.

Is this a good idea? ¯\\\_(ツ)\_/¯ 

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
n/a, unless you want to fork the whole repo to an organization, merge this, then edit a file in the wiki folder.

Make sure this PR is up to date with the current wiki content if you merge it, though, naturally, otherwise it'll overwrite any changes between its creation/last update and the merge.