### PR TITLE
Actions: Allow release note generation for old versions

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -3,8 +3,8 @@ name: Release Notes
 on:
   workflow_dispatch:
     inputs:
-      previousTag:
-        description: Previous tag
+      previousVersion:
+        description: 'optional: set previous version (i.e. v0.1.0)'
         type: string
         required: false
 
@@ -19,10 +19,10 @@ jobs:
           fetch-depth: 0
 
       - name: Create release notes
-        run: git log ${{ inputs.previousTag || '$(git describe --tags --abbrev=0)' }}..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ > release-notes.md
+        run: git log ${{ inputs.previousVersion || '$(git describe --tags --abbrev=0)' }}..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ > release-notes.md
 
       - name: Print release notes
-        run: git log ${{ inputs.previousTag || '$(git describe --tags --abbrev=0)' }}..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ > $GITHUB_STEP_SUMMARY
+        run: git log ${{ inputs.previousVersion || '$(git describe --tags --abbrev=0)' }}..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ > $GITHUB_STEP_SUMMARY
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,6 +1,12 @@
 name: Release Notes
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+    inputs:
+      previousTag:
+        description: Previous tag
+        type: string
+        required: false
 
 jobs:
   create:
@@ -13,10 +19,10 @@ jobs:
           fetch-depth: 0
 
       - name: Create release notes
-        run: git log $(git describe --tags --abbrev=0)..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ > release-notes.md
+        run: git log ${{ inputs.previousTag || '$(git describe --tags --abbrev=0)' }}..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ > release-notes.md
 
       - name: Print release notes
-        run: git log $(git describe --tags --abbrev=0)..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ > $GITHUB_STEP_SUMMARY
+        run: git log ${{ inputs.previousTag || '$(git describe --tags --abbrev=0)' }}..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ > $GITHUB_STEP_SUMMARY
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
     inputs:
       previousVersion:
-        description: 'optional: set previous version (i.e. v0.1.0)'
+        description: '[Optional] Starting ref (e.g. 8f462fa or v0.1.0)'
         type: string
         required: false
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Re: #1454

Adds an optional input to the release notes action allowing the user to specify the version to begin notes from.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Tested with a manual argument on the source fork: https://github.com/marcustyphoon/XKit-Rewritten/actions/runs/9070322977
Tested without a manual argument, very sloppily, on a branch of the source fork: https://github.com/marcustyphoon/XKit-Rewritten/actions/runs/9070372444

