### PR TITLE
Actions: Print release notes in code block 

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -20,6 +20,6 @@ jobs:
 
       - name: Print release notes
         run: |
-          echo "```md" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`md" >> $GITHUB_STEP_SUMMARY
           git log ${{ inputs.previousVersion || '$(git describe --tags --abbrev=0)' }}..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ >> $GITHUB_STEP_SUMMARY
-          echo "```" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -18,14 +18,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Create release notes
-        run: git log ${{ inputs.previousVersion || '$(git describe --tags --abbrev=0)' }}..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ > release-notes.md
-
       - name: Print release notes
-        run: git log ${{ inputs.previousVersion || '$(git describe --tags --abbrev=0)' }}..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ > $GITHUB_STEP_SUMMARY
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: release-notes
-          path: release-notes.md
+        run: |
+          echo "```md" >> $GITHUB_STEP_SUMMARY
+          git log ${{ inputs.previousVersion || '$(git describe --tags --abbrev=0)' }}..HEAD --reverse --pretty --format="- %h **%an** %s" --follow src/ >> $GITHUB_STEP_SUMMARY
+          echo "```" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
- Removes the previous artifact-based creation steps
- Wraps the output in a code block (with Markdown syntax formatting!)

Much more convenient. Allows release notes to be copied with a single click, without needing to download anything, and without even needing to scroll past anything.

Successful run: https://github.com/AprilSylph/XKit-Rewritten/actions/runs/9087088473

It seems that escaping the backticks is necessary. The [initial run](https://github.com/AprilSylph/XKit-Rewritten/actions/runs/9087008669) generated an empty file.