### PR TITLE
 Quick Tags/Trim Reblogs: Fix buttons in Russian and Hindi

### DIFF
--- a/src/scripts/quick_tags.js
+++ b/src/scripts/quick_tags.js
@@ -2,7 +2,6 @@ import { cloneControlButton, createControlButtonTemplate } from '../util/control
 import { keyToCss } from '../util/css_map.js';
 import { dom } from '../util/dom.js';
 import { filterPostElements, getTimelineItemWrapper, postSelector } from '../util/interface.js';
-import { translate } from '../util/language_data.js';
 import { megaEdit } from '../util/mega_editor.js';
 import { modalCancelButton, modalCompleteButton, showErrorModal, showModal } from '../util/modals.js';
 import { onNewPosts, pageModifications } from '../util/mutations.js';
@@ -218,8 +217,9 @@ const processPosts = postElements => filterPostElements(postElements).forEach(po
   const existingButton = postElement.querySelector(`.${buttonClass}`);
   if (existingButton !== null) { return; }
 
-  const editButton = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"][aria-label=${translate('Edit')}]`);
-  if (!editButton) { return; }
+  const editIcon = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"] use[href="#managed-icon__edit"]`);
+  if (!editIcon) { return; }
+  const editButton = editIcon.closest('a');
 
   const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: togglePopupDisplay });
   const controlIcon = editButton.closest(controlIconSelector);

--- a/src/scripts/trim_reblogs.js
+++ b/src/scripts/trim_reblogs.js
@@ -2,7 +2,6 @@ import { createControlButtonTemplate, cloneControlButton } from '../util/control
 import { keyToCss } from '../util/css_map.js';
 import { dom } from '../util/dom.js';
 import { filterPostElements, postSelector } from '../util/interface.js';
-import { translate } from '../util/language_data.js';
 import { showModal, hideModal, modalCancelButton, showErrorModal } from '../util/modals.js';
 import { onNewPosts } from '../util/mutations.js';
 import { notify } from '../util/notifications.js';
@@ -160,8 +159,9 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
   const existingButton = postElement.querySelector(`.${buttonClass}`);
   if (existingButton !== null) { return; }
 
-  const editButton = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"][aria-label=${translate('Edit')}]`);
-  if (!editButton) { return; }
+  const editIcon = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"] use[href="#managed-icon__edit"]`);
+  if (!editIcon) { return; }
+  const editButton = editIcon.closest('a');
 
   const { trail = [], content = [] } = await timelineObject(postElement);
   const items = trail.length + (content.length ? 1 : 0);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As per the linked issue, we can't rely on the translate utility to target DOM elements with CSS/query selectors, as there may be more than one localized string and some may not match the utility's output.

I think this should work? The edit button is always an icon, i.e. not "Edit," right?

Resolves #1459, but the pattern applies more broadly across the extension and another issue should track ensuring they're all made consistent.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Ensure that Quick Tags and Trim Reblogs buttons are consistently added to editable posts (including in Russian and Hindi; language should not matter now).
