### PR TITLE
AccessKit Disable GIFs: Fix recommended blog card hover

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -58,10 +58,7 @@ export const styleElement = buildStyle(`
 }
 `);
 
-const blogCarouselBackgroundSelector = `${keyToCss('background')} > *`;
-
 const addLabel = (element, inside = false) => {
-  if (element.matches(blogCarouselBackgroundSelector)) return;
   if (element.parentNode.querySelector(`.${labelClass}`) === null) {
     const gifLabel = document.createElement('p');
     gifLabel.className = element.clientWidth && element.clientWidth < 150

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -4,6 +4,7 @@ import { dom } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
+const hoverContainerAttribute = 'data-paused-gif-hover-container';
 const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
@@ -42,8 +43,8 @@ export const styleElement = buildStyle(`
 
 *:hover > .${canvasClass},
 *:hover > .${labelClass},
-.${containerClass}:hover .${canvasClass},
-.${containerClass}:hover .${labelClass} {
+[${hoverContainerAttribute}]:hover .${canvasClass},
+[${hoverContainerAttribute}]:hover .${labelClass} {
   display: none;
 }
 
@@ -57,7 +58,10 @@ export const styleElement = buildStyle(`
 }
 `);
 
+const blogCarouselBackgroundSelector = `${keyToCss('background')} > *`;
+
 const addLabel = (element, inside = false) => {
+  if (element.matches(blogCarouselBackgroundSelector)) return;
   if (element.parentNode.querySelector(`.${labelClass}`) === null) {
     const gifLabel = document.createElement('p');
     gifLabel.className = element.clientWidth && element.clientWidth < 150
@@ -120,13 +124,16 @@ const processRows = function (rowsElements) {
       if (row.previousElementSibling?.classList?.contains(containerClass)) {
         row.previousElementSibling.append(row);
       } else {
-        const wrapper = dom('div', { class: containerClass });
+        const wrapper = dom('div', { class: containerClass, [hoverContainerAttribute]: '' });
         row.replaceWith(wrapper);
         wrapper.append(row);
       }
     });
   });
 };
+
+const processHoverableElements = elements =>
+  elements.forEach(element => element.setAttribute(hoverContainerAttribute, ''));
 
 export const main = async function () {
   const gifImage = `
@@ -140,6 +147,11 @@ export const main = async function () {
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 
   pageModifications.register(
+    `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}`,
+    processHoverableElements
+  );
+
+  pageModifications.register(
     `:is(${postSelector}, ${keyToCss('blockEditorContainer')}) ${keyToCss('rows')}`,
     processRows
   );
@@ -149,6 +161,7 @@ export const clean = async function () {
   pageModifications.unregister(processGifs);
   pageModifications.unregister(processBackgroundGifs);
   pageModifications.unregister(processRows);
+  pageModifications.unregister(processHoverableElements);
 
   [...document.querySelectorAll(`.${containerClass}`)].forEach(wrapper =>
     wrapper.replaceWith(...wrapper.children)
@@ -156,4 +169,5 @@ export const clean = async function () {
 
   $(`.${canvasClass}, .${labelClass}`).remove();
   $(`.${backgroundGifClass}`).removeClass(backgroundGifClass);
+  $(`[${hoverContainerAttribute}]`).removeAttr(hoverContainerAttribute);
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

At present, AccessKit does pause GIFs in recommended blog carousels, but they don't unpause on hover. This makes the recommended blog cards into hover-to-unpause targets.

<details><summary>outdated; see comment below</summary>

At present, AccessKit does pause GIFs in recommended blog carousels, but a) they don't unpause on hover, and b) there are sometimes two overlapping gif labels visible due to the way Tumblr makes a blurred background copy of non-square images*. This ~hides~ _removes_ the duplicate labels and makes the recommended blog cards into hover-to-unpause targets.

*~~I can't get a screenshot of this because by the time I reverted this PR, I no longer had any of these. Developing modifications for a nondeterministic feature is annoying.~~ **edit:** https://www.tumblr.com/tagged/gif reliably has some:

<img width="569" src="https://github.com/user-attachments/assets/1ee3ee14-2ddf-4f2b-8c65-a73a92bef529">

</details>

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Get a recommended blog carousel card with a non-square GIF, ~~by the grace of god or whatever~~ by scrolling down https://www.tumblr.com/tagged/gif.
- Confirm that it is paused correctly, unpauses correctly when the card is hovered, and has a correct-looking label when paused.