### PR TITLE
 AccessKit: Hide frozen blaze fire animation

### DIFF
--- a/src/scripts/accesskit/disable_animations.js
+++ b/src/scripts/accesskit/disable_animations.js
@@ -17,7 +17,7 @@ ${keyToCss('postLikeHeartAnimation')} {
   display: none;
 }
 
-canvas#fire-everywhere {
+canvas#fire-everywhere, [style*="--fire-container-height"] {
   display: none;
 }
 `);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

I'd swear I did this already, like, months or years ago.

<img src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/1980aa3e-44c2-4fe3-a76f-54570c95912f">

Gets rid of the fire atop the screen, here.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Enable AccessKit and "disable layout animations." Click the blaze button at the bottom of a post and confirm that the erroneous fire does not appear.

