### PR TITLE
Fix UI accent colors

### DIFF
--- a/src/scripts/mass_privater.css
+++ b/src/scripts/mass_privater.css
@@ -11,7 +11,7 @@
   border-radius: 1em;
   margin: 0.25rem 0;
 
-  background-color: rgb(var(--accent));
+  background-color: rgb(var(--deprecated-accent));
   color: rgb(var(--navy));
 }
 

--- a/src/scripts/postblock/options/index.css
+++ b/src/scripts/postblock/options/index.css
@@ -63,7 +63,7 @@ header {
 
   appearance: none;
   background-color: transparent;
-  color: rgb(var(--accent));
+  color: rgb(var(--deprecated-accent));
   cursor: pointer;
   font-weight: bold;
 }

--- a/src/scripts/show_originals.css
+++ b/src/scripts/show_originals.css
@@ -33,6 +33,6 @@
 [data-show-originals="on"].xkit-show-originals-controls > a[data-mode="on"],
 [data-show-originals="off"].xkit-show-originals-controls > a[data-mode="off"],
 .xkit-show-originals-controls > a[data-mode="disabled"] {
-  box-shadow: inset 0 -3px 0 var(--blog-link-color, rgb(var(--accent)));
-  color: var(--blog-link-color, rgb(var(--accent)));
+  box-shadow: inset 0 -3px 0 var(--blog-link-color, rgb(var(--deprecated-accent)));
+  color: var(--blog-link-color, rgb(var(--deprecated-accent)));
 }

--- a/src/scripts/tag_replacer.css
+++ b/src/scripts/tag_replacer.css
@@ -11,7 +11,7 @@
   border-radius: 1em;
   margin: 0.25rem 0;
 
-  background-color: rgb(var(--accent));
+  background-color: rgb(var(--deprecated-accent));
   color: rgb(var(--navy));
 }
 

--- a/src/scripts/themed_posts.js
+++ b/src/scripts/themed_posts.js
@@ -57,8 +57,8 @@ const processPosts = async function (postElements) {
           [data-xkit-themed="${name}"] {
             --white: ${backgroundColorRGB};
             --black: ${titleColorRGB};
-            --accent: ${linkColorRGB};
-            --color-primary-link: rgb(var(--accent));
+            --deprecated-accent: ${linkColorRGB};
+            --color-primary-link: rgb(var(--deprecated-accent));
           }
         `;
       }
@@ -98,13 +98,13 @@ export const main = async function () {
         ${timelineSelector} {
           --xkit-root-white: var(--white);
           --xkit-root-black: var(--black);
-          --xkit-root-accent: var(--accent);
+          --xkit-root-accent: var(--deprecated-accent);
         }
 
         [data-xkit-themed] {
           --white: var(--xkit-root-white);
           --black: var(--xkit-root-black);
-          --accent: var(--xkit-root-accent);
+          --deprecated-accent: var(--xkit-root-accent);
         }
       `;
     }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Changes references to the `--accent` CSS variable to reference `--deprecated-accent`, fixing UI colors in Show Originals, Mass Privater, and Tag Replacer, and... possibly fixing something in Themed Posts in some circumstance? (I can't figure out what the code in question actually affects, so I wasn't able to test that part.)

Resolves #1468. Background: https://github.com/AprilSylph/Palettes-for-Tumblr/pull/185#issuecomment-2134525907.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Enable Show Originals, navigate to a timeline it affects, and confirm that its control element has a highlight on the selected mode and that it is the correct color.
- Enter an invalid tag into Tag Replacer, press next, and confirm that the tag is shown in the correct color.
- Enter an invalid tag into Mass Privater, press next, and confirm that the tag is shown in the correct color.

As mentioned, I didn't test Themed Posts.

