### PR TITLE
Quick Reblog: Restore changed popup font size/weight

### DIFF
--- a/src/scripts/quick_reblog.css
+++ b/src/scripts/quick_reblog.css
@@ -6,6 +6,8 @@
   border-radius: 3px;
   overflow: hidden;
   color: rgb(var(--black));
+  font-size: .875rem;
+  font-weight: normal;
   background-color: rgb(var(--white));
   background-image: linear-gradient(rgba(var(--black), 0.13), rgba(var(--black), 0.13));
   display: flex;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Resolves #1474.

As noted in the linked issue, a change to Tumblr's CSS resulted in the Quick Reblog menu's fonts changing size and weight, since we did not previously specify them.

(Not sure exactly who I'm writing this note for, as the main person who reads these is the one who pointed the information out to me—thanks April—but the change appears to be that `button`, `input`, `textarea`, and `select` elements have `font: inherit`; presumably some or all did not previously and used browser defaults.)

I'm not actually at all certain that this actually does restore the appearance the menu had prior to both changes, with and without Palettes for Tumblr overrides/XKit 7 Old Blue, in both Firefox and Chromium. I could find one screenshot I had incidentally (Chromium, Palettes-with-font-override) and side-by-side it looks fine?

No idea if this results in Favorit being used where it previously wasn't, or something like that.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Unless one has screenshots to compare, this might just have to be the eye test?
