### PR TITLE
Create simple optional eslint pre-commit hook

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "eslint-plugin-jsdoc": "^48.2.7",
         "eslint-plugin-n": "^15.7.0",
         "eslint-plugin-promise": "^6.2.0",
+        "simple-git-hooks": "^2.11.1",
         "web-ext": "^7.12.0"
       }
     },
@@ -6568,6 +6569,16 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
       "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
       "dev": true
+    },
+    "node_modules/simple-git-hooks": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/simple-git-hooks/-/simple-git-hooks-2.11.1.tgz",
+      "integrity": "sha512-tgqwPUMDcNDhuf1Xf6KTUsyeqGdgKMhzaH4PAZZuzguOgTl5uuyeYe/8mWgAr6IBxB5V06uqEf6Dy37gIWDtDg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "simple-git-hooks": "cli.js"
+      }
     },
     "node_modules/sonic-boom": {
       "version": "3.8.1",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "test": "web-ext lint",
     "posttest": "eslint src/",
     "start": "web-ext run",
-    "build": "web-ext build"
+    "build": "web-ext build",
+    "enable-hooks": "simple-git-hooks"
   },
   "devDependencies": {
     "chrome-webstore-upload-cli": "^3.1.0",
@@ -16,7 +17,11 @@
     "eslint-plugin-jsdoc": "^48.2.7",
     "eslint-plugin-n": "^15.7.0",
     "eslint-plugin-promise": "^6.2.0",
+    "simple-git-hooks": "^2.11.1",
     "web-ext": "^7.12.0"
+  },
+  "simple-git-hooks": {
+    "pre-commit": "npx eslint src/ --cache --cache-location \"node_modules/.cache/eslint/.eslintcache\""
   },
   "dependencies": {
     "jquery": "^3.7.1",


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Similar to #1472.

This allows developers to—optionally—install a pre-commit hook that runs eslint locally on staged files before they're committed, preventing the commit if they are not in the semistandard style.

This uses `simple-git-hooks`, which has the drawback (vs husky) of being annoying to install, but as the advantage of not uninstalling itself when you switch branches. This also forgoes `lint-staged` and makes the hook itself not depend on package.json, continuing this trend. I also didn't add `.eslintcache` to `gitignore` or add `--cache` to `posttest`.

Thus, this is a git hook installer that doesn't affect the repository. Whee. That is, one can switch to this PR branch, run `npm run enable-hooks`, switch to another branch, and have the hook continue to work until one manually deletes `.git/hooks/pre-commit`.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

