### PR TITLE
Safari compatibility: remove `browser.runtime` destructure

### DIFF
--- a/src/action/render_scripts.js
+++ b/src/action/render_scripts.js
@@ -2,10 +2,8 @@ const configSection = document.getElementById('configuration');
 const configSectionLink = document.querySelector('a[href="#configuration"]');
 const scriptsDiv = configSection.querySelector('.scripts');
 
-const { getURL } = browser.runtime;
-
 const getInstalledScripts = async function () {
-  const url = getURL('/features/_index.json');
+  const url = browser.runtime.getURL('/features/_index.json');
   const file = await fetch(url);
   const installedScripts = await file.json();
 
@@ -137,7 +135,7 @@ const renderScripts = async function () {
   const disabledScripts = installedScripts.filter(scriptName => enabledScripts.includes(scriptName) === false);
 
   for (const scriptName of [...orderedEnabledScripts, ...disabledScripts]) {
-    const url = getURL(`/features/${scriptName}.json`);
+    const url = browser.runtime.getURL(`/features/${scriptName}.json`);
     const file = await fetch(url);
     const {
       title = scriptName,

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -1,14 +1,13 @@
 'use strict';
 
 {
-  const { getURL } = browser.runtime;
   const redpop = [...document.scripts].some(({ src }) => src.includes('/pop/'));
   const isReactLoaded = () => document.querySelector('[data-rh]') === null;
 
   const restartListeners = {};
 
   const runScript = async function (name) {
-    const scriptPath = getURL(`/features/${name}.js`);
+    const scriptPath = browser.runtime.getURL(`/features/${name}.js`);
     const { main, clean, stylesheet, onStorageChanged } = await import(scriptPath);
 
     main().catch(console.error);
@@ -16,7 +15,7 @@
     if (stylesheet) {
       const link = Object.assign(document.createElement('link'), {
         rel: 'stylesheet',
-        href: getURL(`/features/${name}.css`)
+        href: browser.runtime.getURL(`/features/${name}.css`)
       });
       document.documentElement.appendChild(link);
     }
@@ -38,13 +37,13 @@
   };
 
   const destroyScript = async function (name) {
-    const scriptPath = getURL(`/features/${name}.js`);
+    const scriptPath = browser.runtime.getURL(`/features/${name}.js`);
     const { clean, stylesheet } = await import(scriptPath);
 
     clean().catch(console.error);
 
     if (stylesheet) {
-      document.querySelector(`link[href="${getURL(`/features/${name}.css`)}"]`)?.remove();
+      document.querySelector(`link[href="${browser.runtime.getURL(`/features/${name}.css`)}"]`)?.remove();
     }
 
     browser.storage.onChanged.removeListener(restartListeners[name]);
@@ -70,7 +69,7 @@
   };
 
   const getInstalledScripts = async function () {
-    const url = getURL('/features/_index.json');
+    const url = browser.runtime.getURL('/features/_index.json');
     const file = await fetch(url);
     const installedScripts = await file.json();
 
@@ -89,7 +88,7 @@
      * fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await
      * @see https://github.com/sveltejs/kit/issues/7805#issuecomment-1330078207
      */
-    await Promise.all(['css_map', 'language_data', 'user'].map(name => import(getURL(`/utils/${name}.js`))));
+    await Promise.all(['css_map', 'language_data', 'user'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
 
     installedScripts
       .filter(scriptName => enabledScripts.includes(scriptName))

--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -1,6 +1,5 @@
 import { dom } from './dom.js';
 
-const { getURL } = browser.runtime;
 const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
 
 /**
@@ -14,7 +13,7 @@ export const inject = async (path, args = [], target = document.documentElement)
   const script = dom('script', {
     'data-arguments': JSON.stringify(args),
     nonce,
-    src: getURL(path)
+    src: browser.runtime.getURL(path)
   });
 
   return new Promise((resolve, reject) => {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Weirdly, in Safari desktop 17.4.1 (19618.1.15.11.14), if you destructure `const { getURL } = browser.runtime;` the getURL variable will contain a version of the function that _can_ be executed, but returns `undefined` for every string value I tested.

I don't actually know if this a bug or an execution detail per se. Probably a bug? When I log `browser.runtime` I see:

<img width="435" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/2391ad23-5bd3-4ca6-8544-5091c45a3551">

So it seems like, in Safari's implementation, getURL() is not a direct property of `runtime`. I assume this isn't fundamentally the issue—you can destructure inherited methods, right? I never played with this—but, I dunno, maybe some runtime binding is missing, whatever, this is not my area of expertise. Also this is technically through browser-polyfill but I think the result was the same when I tried `const { getURL } = browser.runtime;` vs `chrome.runtime.getURL` so that shouldn't matter.

Anyway, this PR removes this pattern and restores functionality in Safari. We don't support or publish to Safari, so this only helps people who install it themselves. 

I mostly wanted to make the PR to refer to in case I ever get around to bug reporting this to Safari.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm basic functionality
