### PR TITLE
Mutations util: Isolate callback errors via async function

### DIFF
--- a/src/util/mutations.js
+++ b/src/util/mutations.js
@@ -74,11 +74,11 @@ const onBeforeRepaint = () => {
 
   if (addedNodes.length === 0) return;
 
-  for (const [modifierFunction, selector] of pageModifications.listeners) {
+  pageModifications.listeners.forEach(async (selector, modifierFunction) => {
     if (modifierFunction.length === 0) {
       const shouldRun = addedNodes.some(addedNode => addedNode.matches(selector) || addedNode.querySelector(selector) !== null);
       if (shouldRun) modifierFunction();
-      continue;
+      return;
     }
 
     const matchingElements = [
@@ -89,7 +89,7 @@ const onBeforeRepaint = () => {
     if (matchingElements.length !== 0) {
       modifierFunction(matchingElements);
     }
-  }
+  });
 };
 
 const cellSelector = keyToCss('cell');


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

One weird way to fix #1508, rather than the eminently reasonable "two try-catches with `console.log(error)` in the catch block", is to run the relevant code in an async forEach. This means exceptions become rejected promises in the console and don't affect other loop iterations.

This also means that there is an `async` keyword which serves a purpose despite having no corresponding `await`, which is pretty terrible practice (I try to remove those!), especially uncommented.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

