### PR TITLE
 MV3 branch: Stop processing disconnected elements (simple)

### DIFF
--- a/src/features/quick_tags.js
+++ b/src/features/quick_tags.js
@@ -219,10 +219,10 @@ const processPosts = postElements => filterPostElements(postElements).forEach(po
 
   const editIcon = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"] use[href="#managed-icon__edit"]`);
   if (!editIcon) { return; }
-  const editButton = editIcon.closest('a');
+
+  const controlIcon = editIcon.closest(controlIconSelector);
 
   const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: togglePopupDisplay });
-  const controlIcon = editButton.closest(controlIconSelector);
   controlIcon.before(clonedControlButton);
 });
 

--- a/src/features/quote_replies/get_notification_props.js
+++ b/src/features/quote_replies/get_notification_props.js
@@ -16,7 +16,7 @@
     }
   };
 
-  getNotificationProps()
+  document.currentScript.isConnected && getNotificationProps()
     .then(result => { dataset.result = JSON.stringify(result ?? null); })
     .catch(exception => {
       dataset.exception = JSON.stringify({

--- a/src/features/trim_reblogs.js
+++ b/src/features/trim_reblogs.js
@@ -161,13 +161,13 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
 
   const editIcon = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"] use[href="#managed-icon__edit"]`);
   if (!editIcon) { return; }
-  const editButton = editIcon.closest('a');
+
+  const controlIcon = editIcon.closest(controlIconSelector);
 
   const { trail = [], content = [] } = await timelineObject(postElement);
   const items = trail.length + (content.length ? 1 : 0);
 
   const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: event => onButtonClicked(event).catch(showErrorModal) }, items < 2);
-  const controlIcon = editButton.closest(controlIconSelector);
   controlIcon.before(clonedControlButton);
 });
 

--- a/src/utils/inject/test_header_element.js
+++ b/src/utils/inject/test_header_element.js
@@ -15,7 +15,7 @@
     }
   };
 
-  testHeaderElement(...JSON.parse(dataset.arguments))
+  document.currentScript.isConnected && testHeaderElement(...JSON.parse(dataset.arguments))
     .then(result => { dataset.result = JSON.stringify(result ?? null); })
     .catch(exception => {
       dataset.exception = JSON.stringify({

--- a/src/utils/inject/unbury_blog.js
+++ b/src/utils/inject/unbury_blog.js
@@ -16,7 +16,7 @@
     }
   };
 
-  unburyBlog()
+  document.currentScript.isConnected && unburyBlog()
     .then(result => { dataset.result = JSON.stringify(result ?? null); })
     .catch(exception => {
       dataset.exception = JSON.stringify({

--- a/src/utils/inject/unbury_notification.js
+++ b/src/utils/inject/unbury_notification.js
@@ -16,7 +16,7 @@
     }
   };
 
-  unburyNotification()
+  document.currentScript.isConnected && unburyNotification()
     .then(result => { dataset.result = JSON.stringify(result ?? null); })
     .catch(exception => {
       dataset.exception = JSON.stringify({

--- a/src/utils/inject/unbury_timeline_object.js
+++ b/src/utils/inject/unbury_timeline_object.js
@@ -16,7 +16,7 @@
     }
   };
 
-  unburyTimelineObject()
+  document.currentScript.isConnected && unburyTimelineObject()
     .then(result => { dataset.result = JSON.stringify(result ?? null); })
     .catch(exception => {
       dataset.exception = JSON.stringify({


### PR DESCRIPTION
Replaces #1501, which I guess I can't reopen, for Reasons. See that PR for comments.

> <img src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/f78b28d1-d64e-4ffc-a6be-66c4a0f0738d">
> 
> Asynchronous inject can result in race conditions where there were previously not any. (Well, maybe this isn't what you would think of of as a race condition? Anyway, by the time the code runs, the target may not be attached to the DOM any more, e.g. if you've scrolled past it.)
> 
> Presuming we don't want to pursue instant injection, at least at the moment, this should be fairly easy to handle. I would probably just decline to run `unburyTimelineObject` and never resolve the inject promise, at first thought? That would stall the function awaiting the inject forever rather than making it have to put a conditional on the result. Not sure how garbage collection works in that case, though; we don't want to leave DOM elements un-GC'd because they have event listeners pending.
> 
> _Originally posted by @marcustyphoon in https://github.com/AprilSylph/XKit-Rewritten/pull/1466#discussion_r1616413489_
            

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

One way to prevent the console being filled with errors whenever you scroll any timeline with the current MV3 branch, without needing to adjust every location we call `timelineObject()`, is to respond to injection requests for no-longer-attached-by-the-time-we-process elements with a promise that is neither resolved nor rejected. One would otherwise have to add a conditional early return to each invocation of the function.

This diff is very nice, but it does leave around some mutation observers that will never get triggered. Probably fine?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Scroll the dashboard quickly and confirm that there are no errors in the console similar to those experienced in the branch without this PR.
- Continue testing all MV3 functionality.