### PR TITLE
Postblock: Fix missing accent color in UI

### DIFF
--- a/src/features/postblock/options/index.css
+++ b/src/features/postblock/options/index.css
@@ -63,7 +63,7 @@ header {
 
   appearance: none;
   background-color: transparent;
-  color: rgb(var(--deprecated-accent));
+  color: rgb(var(--accent));
   cursor: pointer;
   font-weight: bold;
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

So I'm stupid, and #1471 was a little overzealous.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Block any post with postblock.
- Confirm that, in the popup UI, the "unblock" button is highlighted in the accent color, as intended.
