### PR TITLE
Inject util: Stop processing disconnected elements

### DIFF
--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -8,7 +8,7 @@ document.documentElement.addEventListener('xkitinjectionrequest', async event =>
     moduleCache[path] ??= await import(path);
     const func = moduleCache[path].default;
 
-    if (target instanceof Node && target.isConnected === false) return;
+    if (target.isConnected === false) return;
 
     const result = await func.apply(target, args);
     target.dispatchEvent(

--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -8,6 +8,8 @@ document.documentElement.addEventListener('xkitinjectionrequest', async event =>
     moduleCache[path] ??= await import(path);
     const func = moduleCache[path].default;
 
+    if (target instanceof Node && target.isConnected === false) return;
+
     const result = await func.apply(target, args);
     target.dispatchEvent(
       new CustomEvent('xkitinjectionresponse', { detail: JSON.stringify({ id, result }) })


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in https://github.com/AprilSylph/XKit-Rewritten/pull/1466#discussion_r1616413489 and previously addressed by #1501, it is possible for exceptions to be logged to the javascript console when we call certain injected functions on a target element that is no longer in the page by the time the injected function is executed.

As of #1514, it is usually fairly difficult for this to happen.

Nevertheless, it should be possible; the first time an injected function is executed it has to be imported asynchronously, for example.

This therefore uses a similar "just don't trigger the listener and resolve the promise" method to prevent any processing code from being run in this now-extremely-rare case. Fortunately, the new structure makes this a oneliner.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm basic functionality.

If one wants to observe the behavior this fixes:
- Load the extension without this PR. Enable at least one feature that calls `timeline()`
- Open the javascript console on Tumblr Patio (with at least one column that the feature processes).
- Click the Tumblr Patio button, triggering a refresh (redpop does not use soft navigate in this instance, so this will perform a full page load and full extension initialization).
- During the resulting post load, click "home" to navigate to the dashboard. This will—not always, but fairly reliably with the right click timing—log a bunch of errors to the console as `unbury_timeline_object` throws on every Patio post for every feature that uses it.
- Perform this same sequence of events with this PR and confirm there are no longer exceptions logged.