### PR TITLE
Main world injection: Prevent race condition

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -76,24 +76,27 @@
     return installedScripts;
   };
 
-  const initMainWorld = () => {
+  const initMainWorld = () => new Promise(resolve => {
+    document.documentElement.addEventListener('xkitinjectionready', resolve, { once: true });
+
     const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
     const script = document.createElement('script');
     script.type = 'module';
     script.nonce = nonce;
     script.src = browser.runtime.getURL('/main_world/index.js');
     document.documentElement.append(script);
-  };
+  });
 
   const init = async function () {
     $('style.xkit').remove();
 
-    initMainWorld();
+    const mainWorldReady = initMainWorld();
 
     browser.storage.onChanged.addListener(onStorageChanged);
 
     const installedScripts = await getInstalledScripts();
     const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
+    await mainWorldReady;
 
     /**
      * fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -90,13 +90,16 @@
   const init = async function () {
     $('style.xkit').remove();
 
-    const mainWorldReady = initMainWorld();
-
     browser.storage.onChanged.addListener(onStorageChanged);
 
-    const installedScripts = await getInstalledScripts();
-    const { enabledScripts = [] } = await browser.storage.local.get('enabledScripts');
-    await mainWorldReady;
+    const [
+      installedScripts,
+      { enabledScripts = [] }
+    ] = await Promise.all([
+      getInstalledScripts(),
+      browser.storage.local.get('enabledScripts'),
+      initMainWorld()
+    ]);
 
     /**
      * fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await

--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -29,4 +29,4 @@ document.documentElement.addEventListener('xkitinjectionrequest', async event =>
   }
 });
 
-setTimeout(() => document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready')), 5000);
+document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready'));

--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -28,3 +28,5 @@ document.documentElement.addEventListener('xkitinjectionrequest', async event =>
     );
   }
 });
+
+document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready'));

--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -29,4 +29,4 @@ document.documentElement.addEventListener('xkitinjectionrequest', async event =>
   }
 });
 
-document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready'));
+setTimeout(() => document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready')), 5000);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#1514 relies on the fact that fetching a json file and performing an extension storage query will take longer than the browser fetching the main_world script file, as we need the latter to be performed before importing modules with side effects or executing code that uses injection.

This performs a back-and-forth handshake to confirm that the main_world script file has been executed before proceeding with main install.

Random aside: to improve extension load speed slightly, one can do:

```css
    const [
      installedScripts,
      { enabledScripts = [] }
    ] = await Promise.all([
      getInstalledScripts(),
      browser.storage.local.get('enabledScripts'),
      mainWorldReady
    ]);
 ```

but I can't figure out how to make the code not look stupid.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm basic extension functionality.
- If desired, unrevert the test commit and confirm that basic functionality appears with a significant delay on page load.

I have no tests for the bad case this prevents, as I can't for the life of me get it to happen.