### PR TITLE
Require jsdoc on exported functions

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -16,7 +16,16 @@
     "sourceType": "module"
   },
   "rules": {
-    "import/no-cycle": "error"
+    "import/no-cycle": "error",
+    "jsdoc/require-jsdoc": [
+      "warn",
+      {
+        "publicOnly": true,
+        "contexts": [
+          ":not([id.name=\"main\"], [id.name=\"clean\"], [id.name=\"onStorageChanged\"]) > :matches(FunctionExpression, ArrowFunctionExpression)"
+        ]
+      }
+    ]
   },
   "ignorePatterns": [
     "lib/"


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Fun fact: eslint plugins use a lightly modified CSS selector syntax to target specific parts of the abstract syntax tree. That's cute!

Anyway, as an obligatory followup to our discussion in https://github.com/AprilSylph/XKit-Rewritten/pull/1514#discussion_r1649783093, this adds "function expression" and "arrow function expression" to the list of function types the `jsdoc/require-jsdoc` eslint rule applies to. [By default, it only applies to function declarations](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/require-jsdoc.md#require), which I think is very stupid.

That would mean we need to jsdoc a billion functions, which is silly; this therefore also filters the functions to only those exported from the module they're contained in (very neat!) and excludes those named "main," "clean," or "onStorageChanged," as we know what those are for.

This method is fairly ridiculous—I had to use the AST explorer tool [linked here](https://github.com/gajus/eslint-plugin-jsdoc/blob/HEAD/docs/advanced.md#discovering-available-ast-definitions) and trial and error to have any idea what I was doing. Neat to be aware of, though.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

