### PR TITLE
Timeline ID util: Process current Tumblr Patio IDs

### DIFF
--- a/src/utils/timeline_id.js
+++ b/src/utils/timeline_id.js
@@ -4,28 +4,33 @@ export const timelineSelector = ':is([data-timeline], [data-timeline-id])';
 
 const exactly = string => `^${string}$`;
 const anyBlog = '[a-z0-9-]{1,32}';
+const uuidV4 = '[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[a-f0-9]{4}-[a-f0-9]{12}';
 
 export const followingTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
   timeline === '/v2/timeline/dashboard' ||
-  timelineId === '/dashboard/following';
+  timelineId === '/dashboard/following' ||
+  timelineId?.startsWith('following-');
 
 export const followingTimelineSelector = createSelector(
   `[data-timeline="${'/v2/timeline/dashboard'}"]`,
-  `[data-timeline-id="${'/dashboard/following'}"]`
+  `[data-timeline-id="${'/dashboard/following'}"]`,
+  `[data-timeline-id^="${'following-'}"]`
 );
 
 // includes "channel" user blog view page
 export const anyBlogTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
   timeline?.match(exactly(`/v2/blog/${anyBlog}/posts`)) ||
   timelineId?.match(exactly(`peepr-posts-${anyBlog}-undefined-undefined-undefined-undefined-undefined-undefined`)) ||
-  timelineId?.match(exactly(`blog-view-${anyBlog}`));
+  timelineId?.match(exactly(`blog-view-${anyBlog}`)) ||
+  timelineId?.match(exactly(`blog-${uuidV4}-${anyBlog}`));
 
 // includes "channel" user blog view page
 export const blogTimelineFilter = blog =>
   ({ dataset: { timeline, timelineId } }) =>
     timeline === `/v2/blog/${blog}/posts` ||
     timelineId === `peepr-posts-${blog}-undefined-undefined-undefined-undefined-undefined-undefined` ||
-    timelineId === `blog-view-${blog}`;
+    timelineId === `blog-view-${blog}` ||
+    timelineId?.match(exactly(`blog-${uuidV4}-${blog}`));
 
 export const blogSubsTimelineFilter = ({ dataset: { timeline, which, timelineId } }) =>
   timeline === '/v2/timeline?which=blog_subscriptions' ||
@@ -33,12 +38,15 @@ export const blogSubsTimelineFilter = ({ dataset: { timeline, which, timelineId 
   timelineId === '/dashboard/blog_subs';
 
 export const anyDraftsTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
-  timeline?.match(exactly(`/v2/blog/${anyBlog}/posts/draft`));
+  timeline?.match(exactly(`/v2/blog/${anyBlog}/posts/draft`)) ||
+  timelineId?.match(exactly(`drafts-${uuidV4}-${anyBlog}`));
 
 export const anyQueueTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
-  timeline?.match(exactly(`/v2/blog/${anyBlog}/posts/queue`));
+  timeline?.match(exactly(`/v2/blog/${anyBlog}/posts/queue`)) ||
+  timelineId?.match(exactly(`queue-${uuidV4}-${anyBlog}`));
 
 export const tagTimelineFilter = tag =>
   ({ dataset: { timeline, timelineId } }) =>
     timeline === `/v2/hubs/${encodeURIComponent(tag)}/timeline` ||
-    timelineId?.startsWith(`hubsTimeline-${tag}-recent-`);
+    timelineId?.startsWith(`hubsTimeline-${tag}-recent-`) ||
+    timelineId?.match(exactly(`tag-${uuidV4}-${tag}-recent`));


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds the current Tumblr Patio timeline IDs to the timeline ID utility, so that we don't need to add them later if they are released in their current state.

The uuid v4 regex is fairly specific, so I can't imagine this will have any side effects.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

