### PR TITLE
Main world injection: Don't stringify results/errors

### DIFF
--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -10,21 +10,11 @@ document.documentElement.addEventListener('xkitinjectionrequest', async event =>
 
     const result = await func.apply(target, args);
     target.dispatchEvent(
-      new CustomEvent('xkitinjectionresponse', { detail: JSON.stringify({ id, result }) })
+      new CustomEvent('xkitinjectionresponse', { detail: { id, result } })
     );
   } catch (exception) {
     target.dispatchEvent(
-      new CustomEvent('xkitinjectionresponse', {
-        detail: JSON.stringify({
-          id,
-          exception: {
-            message: exception.message,
-            name: exception.name,
-            stack: exception.stack,
-            ...exception
-          }
-        })
-      })
+      new CustomEvent('xkitinjectionresponse', { detail: { id, exception } })
     );
   }
 });

--- a/src/main_world/unbury_timeline_object.js
+++ b/src/main_world/unbury_timeline_object.js
@@ -1,4 +1,7 @@
 export default function unburyTimelineObject () {
+  const a = undefined;
+  console.log(a.b);
+
   const postElement = this;
   const reactKey = Object.keys(postElement).find(key => key.startsWith('__reactFiber'));
   let fiber = postElement[reactKey];

--- a/src/main_world/unbury_timeline_object.js
+++ b/src/main_world/unbury_timeline_object.js
@@ -1,7 +1,4 @@
 export default function unburyTimelineObject () {
-  const a = undefined;
-  console.log(a.b);
-
   const postElement = this;
   const reactKey = Object.keys(postElement).find(key => key.startsWith('__reactFiber'));
   let fiber = postElement[reactKey];

--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -13,8 +13,7 @@ export const inject = (path, args = [], target = document.documentElement) =>
     const requestId = String(Math.random());
     const data = { path: browser.runtime.getURL(path), args, id: requestId };
 
-    const responseHandler = ({ detail }) => {
-      const { id, result, exception } = JSON.parse(detail);
+    const responseHandler = ({ detail: { id, result, exception } }) => {
       if (id !== requestId) return;
 
       target.removeEventListener('xkitinjectionresponse', responseHandler);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in https://github.com/AprilSylph/XKit-Rewritten/pull/1466#discussion_r1616412097, Firefox—for whatever reason—gives a useless "uncaught exception: Object" message if you throw an object in an async function, and we currently throw objects out of injected functions due to the need to serialize them to JSON.

<img width="540" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/a8d1cf8d-86cb-492d-a8b9-55378325e7c6">

Fun fact, however: **we don't need to serialize them to JSON**. `CustomEvent`s support sending any `StructuredClone`-able value in Chromium, and Firefox... \*mumble mumble xray vision mumble\*.

This PR therefore removes the serialization step entirely.

<img width="540" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/328a7559-6408-4c15-9e81-e6bb44f8c438">

Oddly, I'm not observing the `cloneInto()` call I needed to make for Firefox to allow this in [`1052f23` (#1284)](https://github.com/AprilSylph/XKit-Rewritten/pull/1284/commits/1052f23b2a5d583e7f54240d025d12274ac9afbb) being necessary, when testing this current code in Firefox 126. I don't know whether this is due to MV3, due to a change in Firefox, or both. Therefore, **big caveat:** merging this PR without would require us to confirm that `cloneInto()` is not required in any Firefox version we support.

Not well-tested at time of writing. I would like to see that this works on `Response` objects, ideally.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

