### PR TITLE
Refactor: Use Array.prototype.at

### DIFF
--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -75,7 +75,7 @@ ${postSelector} footer button[aria-label="${translate('Reblog')}"]:not([role])
 const renderBlogAvatar = async () => {
   const { value: selectedUuid } = blogSelector;
   const { avatar } = userBlogs.find(({ uuid }) => uuid === selectedUuid);
-  const { url } = avatar[avatar.length - 1];
+  const { url } = avatar.at(-1);
   blogAvatar.style.backgroundImage = `url(${url})`;
 };
 blogSelector.addEventListener('change', renderBlogAvatar);

--- a/src/features/trim_reblogs.js
+++ b/src/features/trim_reblogs.js
@@ -73,7 +73,7 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
 
   const createPreviewItem = ({ blog, brokenBlog, content, disableCheckbox = false }) => {
     const { avatar, name } = blog ?? brokenBlog ?? blogPlaceholder;
-    const { url: src } = avatar[avatar.length - 1];
+    const { url: src } = avatar.at(-1);
     const textContent = content.map(({ text }) => text).find(Boolean) ?? '\u22EF';
 
     const checkbox = dom('input', { type: 'checkbox' });

--- a/src/utils/sidebar.js
+++ b/src/utils/sidebar.js
@@ -116,7 +116,7 @@ const addSidebarToPage = (siblingCandidates) => {
 const addSidebarToDrawer = (navItems) => {
   updateSidebarItemVisibility();
 
-  const lastNavItem = navItems[navItems.length - 1];
+  const lastNavItem = navItems.at(-1);
   lastNavItem?.after(sidebarItems);
 };
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

We may now use Array.prototype.at due to the browser version requirement bumps in #1466.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/at

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

I confirmed that both avatars and sidebar item insertion in the mobile layout drawer still work (Chrome 126).

