### PR TITLE
Quick Tags, Quick Reblog: Fix popup horizontal cutoff

### DIFF
--- a/src/features/quick_reblog.css
+++ b/src/features/quick_reblog.css
@@ -1,9 +1,3 @@
-/* debug */
-[data-temp-highlight] {
-  outline: 4px dashed red;
-  outline-offset: -2px;
-}
-
 #quick-reblog {
   position: absolute;
   z-index: 97;

--- a/src/features/quick_reblog.css
+++ b/src/features/quick_reblog.css
@@ -1,3 +1,9 @@
+/* debug */
+[data-temp-highlight] {
+  outline: 4px dashed red;
+  outline-offset: -2px;
+}
+
 #quick-reblog {
   position: absolute;
   z-index: 97;
@@ -20,56 +26,22 @@
   display: none !important;
 }
 
-@media (max-width: 650px) {
-  #quick-reblog {
-    top: 50%;
-    right: 100%;
-    transform: translateY(-50%);
-  }
+#quick-reblog {
+  --icon-spacing: 12px;
 }
-
-@media (min-width: 650px) {
-  #quick-reblog {
-    transform: translateX(50%);
-  }
-
-  #quick-reblog.above {
-    bottom: 100%;
-    right: 50%;
-  }
-
-  #quick-reblog.below {
-    top: 100%;
-    right: 50%;
-  }
-}
-
-@media (min-width: 990px) {
-  #quick-reblog.above {
-    transform: translate(50%, -12px)
-  }
-
-  #quick-reblog.below {
-    transform: translate(50%, 12px);
-  }
-}
-
 @media (max-width: 990px) {
-  [role="dialog"] #quick-reblog {
-    top: 50%;
-    bottom: unset;
-    right: 100%;
-    transform: translateY(-50%);
+  #quick-reblog {
+    --icon-spacing: 0px;
   }
 }
 
-@media (min-width: 990px) and (max-width: 1145px) {
-  [role="dialog"] #quick-reblog {
-    top: 50%;
-    bottom: unset;
-    right: 100%;
-    transform: translate(-20px, -50%);
-  }
+#quick-reblog.below {
+  inset: 100% 50% auto auto;
+  transform: translate(calc(50% + var(--horizontal-offset, 0%)), var(--icon-spacing));
+}
+#quick-reblog.above {
+  inset: auto 50% 100% auto;
+  transform: translate(calc(50% + var(--horizontal-offset, 0%)), calc(0px - var(--icon-spacing)));
 }
 
 div:first-child + span + #quick-reblog,

--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -1,7 +1,7 @@
 import { sha256 } from '../utils/crypto.js';
 import { timelineObject } from '../utils/react_props.js';
 import { apiFetch } from '../utils/tumblr_helpers.js';
-import { postSelector, filterPostElements, postType } from '../utils/interface.js';
+import { postSelector, filterPostElements, postType, appendWithoutOverflow } from '../utils/interface.js';
 import { userBlogs } from '../utils/user.js';
 import { getPreferences } from '../utils/preferences.js';
 import { onNewPosts } from '../utils/mutations.js';
@@ -9,6 +9,7 @@ import { notify } from '../utils/notifications.js';
 import { translate } from '../utils/language_data.js';
 import { dom } from '../utils/dom.js';
 import { showErrorModal } from '../utils/modals.js';
+import { keyToCss } from '../utils/css_map.js';
 
 const popupElement = dom('div', { id: 'quick-reblog' });
 const blogSelector = dom('select');
@@ -131,7 +132,7 @@ tagsInput.addEventListener('input', checkLength);
 const showPopupOnHover = ({ currentTarget }) => {
   clearTimeout(timeoutID);
 
-  currentTarget.closest('div').appendChild(popupElement);
+  appendWithoutOverflow(popupElement, currentTarget.closest(keyToCss('controlIcon')), popupPosition);
   popupElement.parentNode.addEventListener('mouseleave', removePopupOnLeave);
 
   const thisPost = currentTarget.closest(postSelector);
@@ -325,8 +326,6 @@ export const main = async function () {
     alreadyRebloggedEnabled,
     alreadyRebloggedLimit
   } = await getPreferences('quick_reblog'));
-
-  popupElement.className = popupPosition;
 
   blogSelector.replaceChildren(
     ...userBlogs.map(({ name, uuid }) => dom('option', { value: uuid }, null, [name]))

--- a/src/features/quick_tags.css
+++ b/src/features/quick_tags.css
@@ -1,9 +1,3 @@
-/* debug */
-[data-temp-highlight] {
-  outline: 4px dashed red;
-  outline-offset: -2px;
-}
-
 #quick-tags,
 #quick-tags-post-option {
   position: absolute;

--- a/src/features/quick_tags.css
+++ b/src/features/quick_tags.css
@@ -1,3 +1,9 @@
+/* debug */
+[data-temp-highlight] {
+  outline: 4px dashed red;
+  outline-offset: -2px;
+}
+
 #quick-tags,
 #quick-tags-post-option {
   position: absolute;
@@ -42,28 +48,13 @@
   }
 }
 
-@media (min-width: 650px) {
-  #quick-tags.below {
-    inset: 100% 50% auto auto;
-    transform: translate(50%, var(--icon-spacing));
-  }
-  #quick-tags.above {
-    inset: auto 50% 100% auto;
-    transform: translate(50%, calc(0px - var(--icon-spacing)));
-  }
+#quick-tags.below {
+  inset: 100% 50% auto auto;
+  transform: translate(calc(50% + var(--horizontal-offset, 0%)), var(--icon-spacing));
 }
-
-@media (max-width: 650px) {
-  #quick-tags {
-    inset: 50% 100% auto auto;
-    transform: translate(calc(0px - var(--icon-spacing)), -50%);
-  }
-}
-@media (max-width: 1145px) {
-  [role="dialog"] #quick-tags {
-    inset: 50% 100% auto auto;
-    transform: translate(calc(0px - var(--icon-spacing)), -50%);
-  }
+#quick-tags.above {
+  inset: auto 50% 100% auto;
+  transform: translate(calc(50% + var(--horizontal-offset, 0%)), calc(0px - var(--icon-spacing)));
 }
 
 #quick-tags:empty::before,

--- a/src/features/quick_tags.js
+++ b/src/features/quick_tags.js
@@ -1,7 +1,7 @@
 import { cloneControlButton, createControlButtonTemplate } from '../utils/control_buttons.js';
 import { keyToCss } from '../utils/css_map.js';
 import { dom } from '../utils/dom.js';
-import { filterPostElements, getTimelineItemWrapper, postSelector } from '../utils/interface.js';
+import { appendWithoutOverflow, filterPostElements, getTimelineItemWrapper, postSelector } from '../utils/interface.js';
 import { megaEdit } from '../utils/mega_editor.js';
 import { modalCancelButton, modalCompleteButton, showErrorModal, showModal } from '../utils/modals.js';
 import { onNewPosts, pageModifications } from '../utils/mutations.js';
@@ -115,14 +115,6 @@ export const onStorageChanged = async function (changes, areaName) {
   }
 };
 
-const appendWithoutViewportOverflow = (element, target) => {
-  element.className = 'below';
-  target.appendChild(element);
-  if (element.getBoundingClientRect().bottom > document.documentElement.clientHeight) {
-    element.className = 'above';
-  }
-};
-
 const togglePopupDisplay = async function ({ target, currentTarget: controlButton }) {
   if (target === popupElement || popupElement.contains(target)) { return; }
 
@@ -131,7 +123,7 @@ const togglePopupDisplay = async function ({ target, currentTarget: controlButto
   if (buttonContainer.contains(popupElement)) {
     buttonContainer.removeChild(popupElement);
   } else {
-    appendWithoutViewportOverflow(popupElement, buttonContainer);
+    appendWithoutOverflow(popupElement, buttonContainer);
   }
 };
 
@@ -141,7 +133,7 @@ const togglePostOptionPopupDisplay = async function ({ target, currentTarget }) 
   if (currentTarget.contains(postOptionPopupElement)) {
     currentTarget.removeChild(postOptionPopupElement);
   } else {
-    appendWithoutViewportOverflow(postOptionPopupElement, currentTarget);
+    appendWithoutOverflow(postOptionPopupElement, currentTarget);
   }
 };
 

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -130,13 +130,6 @@ export const appendWithoutOverflow = (element, target, defaultPosition = 'below'
   target.appendChild(element);
 
   const preventOverflowTarget = closestWithOverflow(target);
-
-  // debug
-  preventOverflowTarget.dataset.tempHighlight = '';
-  setTimeout(() => {
-    delete preventOverflowTarget.dataset.tempHighlight;
-  }, 1000);
-
   const preventOverflowTargetRect = preventOverflowTarget.getBoundingClientRect();
   const elementRect = element.getBoundingClientRect();
 

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -118,9 +118,13 @@ export const postType = ({ trail = [], content = [], layout = [] }) => {
 
 const getClosestWithOverflow = element => {
   const parent = element.parentElement;
-  if (!parent) return element;
-  if (getComputedStyle(parent).overflowX !== 'visible') return parent;
-  return getClosestWithOverflow(parent);
+  if (!parent) {
+    return element;
+  } else if (getComputedStyle(parent).overflowX !== 'visible') {
+    return parent;
+  } else {
+    return getClosestWithOverflow(parent);
+  }
 };
 
 export const appendWithoutOverflow = (element, target, defaultPosition = 'below') => {

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -115,3 +115,35 @@ export const postType = ({ trail = [], content = [], layout = [] }) => {
   else if (content.some(({ type }) => type === 'link')) return 'link';
   else return 'text';
 };
+
+const closestWithOverflow = element => {
+  const parent = element.parentElement;
+  if (!parent) return element;
+  if (getComputedStyle(parent).overflowX !== 'visible') return parent;
+  return closestWithOverflow(parent);
+};
+
+export const appendWithoutOverflow = (element, target, defaultPosition = 'below') => {
+  element.className = defaultPosition;
+  element.style.removeProperty('--horizontal-offset');
+
+  target.appendChild(element);
+
+  const preventOverflowTarget = closestWithOverflow(target);
+
+  // debug
+  preventOverflowTarget.dataset.tempHighlight = '';
+  setTimeout(() => {
+    delete preventOverflowTarget.dataset.tempHighlight;
+  }, 1000);
+
+  const preventOverflowTargetRect = preventOverflowTarget.getBoundingClientRect();
+  const elementRect = element.getBoundingClientRect();
+
+  if (elementRect.bottom > document.documentElement.clientHeight) {
+    element.className = 'above';
+  }
+  if (elementRect.right > preventOverflowTargetRect.right - 15) {
+    element.style.setProperty('--horizontal-offset', `${preventOverflowTargetRect.right - 15 - elementRect.right}px`);
+  }
+};

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -116,11 +116,11 @@ export const postType = ({ trail = [], content = [], layout = [] }) => {
   else return 'text';
 };
 
-const closestWithOverflow = element => {
+const getClosestWithOverflow = element => {
   const parent = element.parentElement;
   if (!parent) return element;
   if (getComputedStyle(parent).overflowX !== 'visible') return parent;
-  return closestWithOverflow(parent);
+  return getClosestWithOverflow(parent);
 };
 
 export const appendWithoutOverflow = (element, target, defaultPosition = 'below') => {
@@ -129,7 +129,7 @@ export const appendWithoutOverflow = (element, target, defaultPosition = 'below'
 
   target.appendChild(element);
 
-  const preventOverflowTarget = closestWithOverflow(target);
+  const preventOverflowTarget = getClosestWithOverflow(target);
   const preventOverflowTargetRect = preventOverflowTarget.getBoundingClientRect();
   const elementRect = element.getBoundingClientRect();
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Right now, it's possible for Quick Tags/Quick Reblog popups to extend past the left or right of their post elements (fundamentally fine) and be clipped off by the edge of the viewport or post column (not fine) in various circumstances. This fixes this by:
 - Removing the special "popup is on the left of the button" position entirely.
 - Adding logic that finds the closest ancestor element to the popup which would horizontally clip content, whatever it is, and shifts the popup's horizontal position to the left if necessary to keep the popup within that element's bounding box. _(not implemented: shifting it right if it's too far to the left)_

A simpler option, of course, would be to keep the popup horizontally within the post (`const preventOverflowTarget = target.closest(postSelector)`). When the viewport is wide enough not to need this I think it feels a bit more natural to leave it centered, but the difference is very small.

Another option, essentially the opposite, would be to target the viewport (adjusting position only on phone screens) and properly float the popups above e.g. the Patio column edges. I'm not sure if there's an elegant way to do this (`HTMLDialogElement`'s `showModal()`, maybe?)

Incidental changes:
 - Unifies the popup placement code between Quick Tags and Quick Reblog.
 - Adjusts the Quick Reblog element DOM position back to where it used to be; `closest('div')` apparently now matches a "root" `div class="v2JIl"` element in <990px viewports that I don't think existed when we wrote the 12px override thingy.

Resolves #1369. Fixes mobile-device issue reported in the New XKit Discord that hasn't been made into an issue yet.

<img width="680" src="https://github.com/AprilSylph/XKit-Rewritten/assets/8336245/49e31796-340b-4d52-89ae-0635183706fc">

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
todo: write full list of tests performed. (patio narrow column, peepr wide, peepr narrow, embedded blog view, tablet/mobile layout, narrow phone layout via browser zoom /// top/bottom positions)

