### PR TITLE
Quote Replies: Option to reply as a reblog

### DIFF
--- a/src/features/quote_replies.json
+++ b/src/features/quote_replies.json
@@ -17,6 +17,11 @@
       "type": "checkbox",
       "label": "Open created posts in new tabs",
       "default": false
+    },
+    "enableReblogReplies": {
+      "type": "checkbox",
+      "label": "Enable replying in a reblog",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Working proof of concept.

This implements the ability for Quote Replies to—rather than creating a new draft post with the quoted reply—create a draft reblog of the target post with the quoted reply.

<img width="600" src="https://github.com/user-attachments/assets/52d7da45-7535-4e2f-859b-32b3124898fc">

UI-wise, this currently adds a second button next to the quote replies button on notifications, this isn't great but I didn't love the alternatives I thought of either: a) open a modal with both options every time, which is clunky, or b) always do one or the other based on a user preference, which isn't how I would expect anyone to actually want to use this. Also, no idea what icon to use (two quote icons with subscript plus/reblog icons would be kind of neat maybe). 

Currently not sure what happens when someone clicks on a big reblog chain and replies to you under it. Does this target the reblog or the root post? I had nothing to test this on and haven't gotten around to making a test case.

Resolves #1414.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

