### PR TITLE
Seen Posts: Fix soft refresh

### DIFF
--- a/src/features/seen_posts.js
+++ b/src/features/seen_posts.js
@@ -13,7 +13,7 @@ const onlyDimAvatarsClass = 'xkit-seen-posts-only-dim-avatar';
 const hideClass = 'xkit-seen-posts-hide';
 const lengthenedClass = 'xkit-seen-posts-lengthened';
 
-const softRefreshLoaderSelector = `${followingTimelineSelector} ${keyToCss('container')}:has(+ ${keyToCss('scrollContainer')}) > ${keyToCss('knightRiderLoader')}`;
+const softRefreshLoaderSelector = `${followingTimelineSelector} ${keyToCss('container')}:has(~ div ${postSelector}) > ${keyToCss('knightRiderLoader')}`;
 
 const storageKey = 'seen_posts.seenPosts';
 let seenPosts = [];

--- a/src/features/seen_posts.js
+++ b/src/features/seen_posts.js
@@ -61,12 +61,12 @@ const dimPosts = function (postElements, reprocessPosts = false) {
     const { id } = postElement.dataset;
     const timelineItem = getTimelineItemWrapper(postElement);
 
-    const isFirstRender = reprocessPosts || timelineItem.getAttribute(excludeAttribute) === null;
+    const isFirstRender = timelineItem.getAttribute(excludeAttribute) === null;
     timelineItem.setAttribute(excludeAttribute, '');
 
     if (seenPosts.includes(id) === false) {
       observer.observe(postElement.querySelector('article header + *'));
-    } else if (isFirstRender) {
+    } else if (isFirstRender || reprocessPosts) {
       timelineItem.setAttribute(dimAttribute, '');
     }
   }

--- a/src/features/seen_posts.js
+++ b/src/features/seen_posts.js
@@ -44,7 +44,7 @@ const markAsSeen = (element) => {
 
   seenPosts.push(id);
   seenPosts.splice(0, seenPosts.length - 10000);
-  // browser.storage.local.set({ [storageKey]: seenPosts });
+  browser.storage.local.set({ [storageKey]: seenPosts });
 };
 
 const lengthenTimelines = () =>

--- a/src/features/seen_posts.js
+++ b/src/features/seen_posts.js
@@ -76,7 +76,6 @@ const onSoftRefresh = loaderElements => {
   const refreshedPostElements = loaderElements.flatMap(
     element => [...element.closest(timelineSelector).querySelectorAll(postSelector)]
   );
-
   dimPosts(refreshedPostElements, true);
 };
 

--- a/src/features/seen_posts.js
+++ b/src/features/seen_posts.js
@@ -1,4 +1,4 @@
-import { filterPostElements, getPostElements, getTimelineItemWrapper, postSelector } from '../utils/interface.js';
+import { filterPostElements, getTimelineItemWrapper, postSelector } from '../utils/interface.js';
 import { getPreferences } from '../utils/preferences.js';
 import { onNewPosts, pageModifications } from '../utils/mutations.js';
 import { keyToCss } from '../utils/css_map.js';
@@ -54,14 +54,14 @@ const lengthenTimelines = () =>
     }
   });
 
-const dimPosts = function (postElements) {
+const dimPosts = function (postElements, reprocessPosts = false) {
   lengthenTimelines();
 
   for (const postElement of filterPostElements(postElements, { timeline, includeFiltered })) {
     const { id } = postElement.dataset;
     const timelineItem = getTimelineItemWrapper(postElement);
 
-    const isFirstRender = timelineItem.getAttribute(excludeAttribute) === null;
+    const isFirstRender = reprocessPosts || timelineItem.getAttribute(excludeAttribute) === null;
     timelineItem.setAttribute(excludeAttribute, '');
 
     if (seenPosts.includes(id) === false) {
@@ -74,16 +74,9 @@ const dimPosts = function (postElements) {
 
 const onSoftRefresh = loaderElements => {
   const refreshedTimelineElements = loaderElements.map(element => element.closest(timelineSelector));
-  const refreshedPostElements = getPostElements({ timeline: element => refreshedTimelineElements.includes(element), includeFiltered });
+  const refreshedPostElements = refreshedTimelineElements.flatMap(element => [...element.querySelectorAll(postSelector)]);
 
-  for (const postElement of refreshedPostElements) {
-    const { id } = postElement.dataset;
-    const timelineItem = getTimelineItemWrapper(postElement);
-
-    if (seenPosts.includes(id)) {
-      timelineItem.setAttribute(dimAttribute, '');
-    }
-  }
+  dimPosts(refreshedPostElements, true);
 };
 
 export const onStorageChanged = async function (changes, areaName) {

--- a/src/features/seen_posts.js
+++ b/src/features/seen_posts.js
@@ -44,7 +44,7 @@ const markAsSeen = (element) => {
 
   seenPosts.push(id);
   seenPosts.splice(0, seenPosts.length - 10000);
-  browser.storage.local.set({ [storageKey]: seenPosts });
+  // browser.storage.local.set({ [storageKey]: seenPosts });
 };
 
 const lengthenTimelines = () =>

--- a/src/features/seen_posts.js
+++ b/src/features/seen_posts.js
@@ -73,8 +73,9 @@ const dimPosts = function (postElements, reprocessPosts = false) {
 };
 
 const onSoftRefresh = loaderElements => {
-  const refreshedTimelineElements = loaderElements.map(element => element.closest(timelineSelector));
-  const refreshedPostElements = refreshedTimelineElements.flatMap(element => [...element.querySelectorAll(postSelector)]);
+  const refreshedPostElements = loaderElements.flatMap(
+    element => [...element.closest(timelineSelector).querySelectorAll(postSelector)]
+  );
 
   dimPosts(refreshedPostElements, true);
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Resolves #1539. Method:

- Detect, via a hopefully-very-specific CSS selector, the addition of an element that only gets added when the user manually soft refreshes a V2 timeline (by using pull to refresh, clicking the tumblr logo, home button, or top of a patio column—are there other ways to trigger this?)
- For each post in a refreshed timeline, if we've already seen it, dim it.

This should be identical in effect to the code in `dimPosts` that is specifically run when `isFirstRender === true`, since that's what we're trying to simulate in this special case. Perhaps we could refactor both to make this slightly more obvious:

```js
    // dimPosts
    if (seenPosts.includes(id) === false) {
      observer.observe(postElement.querySelector('article header + *'));
    }
    if (isFirstRender && seenPosts.includes(id) === true) {
      timelineItem.setAttribute(dimAttribute, '');
    }
    
    // onSoftRefresh
    if (seenPosts.includes(id) === true) {
      timelineItem.setAttribute(dimAttribute, '');
    }
```

(I also tried having `onSoftRefresh` just call `dimPosts`, which works and happens to have no side effects to my knowledge, but the reasoning to conclude that is complicated.)

Is there a better way to do this?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Feature flag modification may be required to test this on Patio.

Note that pull-to-refresh is a valid way of soft refreshing; one can test that using the responsive design mode in a desktop browser's dev tools.