### PR TITLE
Show Originals: Enable in communities

### DIFF
--- a/src/features/show_originals.js
+++ b/src/features/show_originals.js
@@ -11,7 +11,8 @@ import {
   blogTimelineFilter,
   blogSubsTimelineFilter,
   timelineSelector,
-  anyCommunityTimelineFilter
+  anyCommunityTimelineFilter,
+  communitiesTimelineFilter
 } from '../utils/timeline_id.js';
 
 const hiddenAttribute = 'data-show-originals-hidden';
@@ -80,7 +81,7 @@ const getLocation = timelineElement => {
     disabled: isBlog && disabledBlogs.some(name => blogTimelineFilter(name)(timelineElement)),
     peepr: isBlog,
     blogSubscriptions: blogSubsTimelineFilter(timelineElement),
-    community: anyCommunityTimelineFilter(timelineElement)
+    community: anyCommunityTimelineFilter(timelineElement) || communitiesTimelineFilter(timelineElement)
   };
   return Object.keys(on).find(location => on[location]);
 };

--- a/src/features/show_originals.js
+++ b/src/features/show_originals.js
@@ -105,14 +105,15 @@ const processPosts = async function (postElements) {
 
   filterPostElements(postElements, { includeFiltered })
     .forEach(async postElement => {
-      const { rebloggedRootId, content, blogName, rebloggedFromFollowing } = await timelineObject(postElement);
+      const { rebloggedRootId, content, blogName, community, postAuthor, rebloggedFromFollowing } = await timelineObject(postElement);
       const myPost = await isMyPost(postElement);
 
       if (!rebloggedRootId) { return; }
       if (showOwnReblogs && myPost) { return; }
       if (showReblogsWithContributedContent && content.length > 0) { return; }
       if (showReblogsOfNotFollowing && !rebloggedFromFollowing) { return; }
-      if (whitelist.includes(blogName)) { return; }
+      const visibleBlogName = community ? postAuthor : blogName;
+      if (whitelist.includes(visibleBlogName)) { return; }
 
       getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
     });

--- a/src/features/show_originals.js
+++ b/src/features/show_originals.js
@@ -5,7 +5,14 @@ import { onNewPosts } from '../utils/mutations.js';
 import { keyToCss } from '../utils/css_map.js';
 import { translate } from '../utils/language_data.js';
 import { userBlogs } from '../utils/user.js';
-import { followingTimelineFilter, anyBlogTimelineFilter, blogTimelineFilter, blogSubsTimelineFilter, timelineSelector } from '../utils/timeline_id.js';
+import {
+  followingTimelineFilter,
+  anyBlogTimelineFilter,
+  blogTimelineFilter,
+  blogSubsTimelineFilter,
+  timelineSelector,
+  anyCommunityTimelineFilter
+} from '../utils/timeline_id.js';
 
 const hiddenAttribute = 'data-show-originals-hidden';
 const lengthenedClass = 'xkit-show-originals-lengthened';
@@ -72,7 +79,8 @@ const getLocation = timelineElement => {
     dashboard: followingTimelineFilter(timelineElement),
     disabled: isBlog && disabledBlogs.some(name => blogTimelineFilter(name)(timelineElement)),
     peepr: isBlog,
-    blogSubscriptions: blogSubsTimelineFilter(timelineElement)
+    blogSubscriptions: blogSubsTimelineFilter(timelineElement),
+    community: anyCommunityTimelineFilter(timelineElement)
   };
   return Object.keys(on).find(location => on[location]);
 };

--- a/src/utils/react_props.js
+++ b/src/utils/react_props.js
@@ -52,6 +52,9 @@ export const isMyPost = async (postElement) => {
   // Post was created by the user on a group blog
   if (postAuthor === primaryBlogName && !isSubmission) return true;
 
+  // Post was created by the user in a community
+  if (postAuthor === primaryBlogName && !isSubmission) return true;
+
   // Submission belongs to group blog which the user is admin of
   if (isSubmission && userIsAdmin) return true;
 

--- a/src/utils/react_props.js
+++ b/src/utils/react_props.js
@@ -39,7 +39,7 @@ export const notificationObject = function (notificationElement) {
 export const blogData = async (meatballMenu) => inject('/main_world/unbury_blog.js', [], meatballMenu);
 
 export const isMyPost = async (postElement) => {
-  const { blog, isSubmission, postAuthor } = await timelineObject(postElement);
+  const { blog, isSubmission, postAuthor, community } = await timelineObject(postElement);
   const userIsMember = userBlogNames.includes(blog.name);
   const userIsAdmin = adminBlogNames.includes(blog.name);
 
@@ -53,7 +53,7 @@ export const isMyPost = async (postElement) => {
   if (postAuthor === primaryBlogName && !isSubmission) return true;
 
   // Post was created by the user in a community
-  if (postAuthor === primaryBlogName && !isSubmission) return true;
+  if (community && userBlogNames.includes(postAuthor)) return true;
 
   // Submission belongs to group blog which the user is admin of
   if (isSubmission && userIsAdmin) return true;

--- a/src/utils/timeline_id.js
+++ b/src/utils/timeline_id.js
@@ -54,3 +54,6 @@ export const tagTimelineFilter = tag =>
 
 export const anyCommunityTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
   timelineId?.match(exactly(`communities-${anyBlog}-recent`));
+
+export const communitiesTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
+  timelineId === 'communities-for_you';

--- a/src/utils/timeline_id.js
+++ b/src/utils/timeline_id.js
@@ -51,3 +51,6 @@ export const tagTimelineFilter = tag =>
     timeline === `/v2/hubs/${encodeURIComponent(tag)}/timeline` ||
     timelineId?.startsWith(`hubsTimeline-${tag}-recent-`) ||
     timelineId?.match(exactly(`tag-${uuidV4}-${tag}-recent`));
+
+export const anyCommunityTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
+  timelineId?.match(exactly(`communities-${anyBlog}-recent`));


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

What it says on the tin: this enables Show Originals on the main feeds of Tumblr Communities and the main "community posts" feed.

It also includes a fix for the `isMyPost` utility to detect posts made in communities using a user's sideblog, but that's currently untested since you can't do so yet.

Resolves #1581.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that Show Originals works on the main feed of a community.
- Confirm that Show Originals works on https://www.tumblr.com/communities

