### PR TITLE
Tweaks: Add communities badge hide tweak

### DIFF
--- a/src/features/tweaks.json
+++ b/src/features/tweaks.json
@@ -103,6 +103,11 @@
       "label": "Hide the Activity notification badge",
       "default": false
     },
+    "hide_communities_notification_badge": {
+      "type": "checkbox",
+      "label": "Hide the Communities notification badge",
+      "default": false
+    },
     "no_where_were_we": {
       "type": "checkbox",
       "label": "Hide the \"Now, where were we?\" button",

--- a/src/features/tweaks.json
+++ b/src/features/tweaks.json
@@ -98,14 +98,14 @@
       "label": "Hide the Home/Following unread count",
       "default": false
     },
-    "hide_activity_notification_badge": {
-      "type": "checkbox",
-      "label": "Hide the Activity notification badge",
-      "default": false
-    },
     "hide_communities_notification_badge": {
       "type": "checkbox",
       "label": "Hide the Communities notification badge",
+      "default": false
+    },
+    "hide_activity_notification_badge": {
+      "type": "checkbox",
+      "label": "Hide the Activity notification badge",
       "default": false
     },
     "no_where_were_we": {

--- a/src/features/tweaks/hide_communities_notification_badge.js
+++ b/src/features/tweaks/hide_communities_notification_badge.js
@@ -1,0 +1,15 @@
+import { keyToCss } from '../../utils/css_map.js';
+import { buildStyle } from '../../utils/interface.js';
+import { translate } from '../../utils/language_data.js';
+
+const communitiesButton = `button[aria-label="${translate('Communities')}"]`;
+const mobileMenuButton = `button[aria-label="${translate('Menu')}"]`;
+
+const styleElement = buildStyle(`
+:is(${communitiesButton}, ${mobileMenuButton}) ${keyToCss('notificationBadge')} {
+  display: none;
+}
+`);
+
+export const main = async () => document.documentElement.append(styleElement);
+export const clean = async () => styleElement.remove();

--- a/src/features/tweaks/hide_communities_notification_badge.js
+++ b/src/features/tweaks/hide_communities_notification_badge.js
@@ -5,11 +5,8 @@ import { translate } from '../../utils/language_data.js';
 const communitiesButton = `button[aria-label="${translate('Communities')}"]`;
 const mobileMenuButton = `button[aria-label="${translate('Menu')}"]`;
 
-const styleElement = buildStyle(`
+export const styleElement = buildStyle(`
 :is(${communitiesButton}, ${mobileMenuButton}) ${keyToCss('notificationBadge')} {
   display: none;
 }
 `);
-
-export const main = async () => document.documentElement.append(styleElement);
-export const clean = async () => styleElement.remove();


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Copies the activity notification badge hide tweak for the communities badge.

Leaves, of course, the notification badge on each community when you click to view them all. (Maybe someone wants those hidden too, but that feels like a separate feature. This one is, I imagine/have seen, wanted by a ton of people, me included.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Join a community. Wait until there's new activity in it.
- Confirm that the new tweak hides the badge in desktop/tablet/mobile layouts.
- Confirm that this still works in every Tumblr UI language.

