### PR TITLE
Collapsed Queue: Remove outdated erroneous CSS

### DIFF
--- a/src/features/collapsed_queue.css
+++ b/src/features/collapsed_queue.css
@@ -1,12 +1,3 @@
-.sortableContainer header {
-  padding-top: 10px;
-  padding-left: calc(var(--post-padding) - 10px);
-  margin-bottom: 10px;
-}
-.sortableContainer footer {
-  margin-top: 5px;
-  padding-bottom: 5px;
-}
 .xkit-collapsed-queue-wrapper {
   position: relative;
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Removes some CSS from Collapsed Queue that a) that were designed for a previous version of the Tumblr UI and no longer make sense to apply and b) were applied even if the feature was turned off on the queue page, which is of course erroneous.

Resolves #1502.

(One of these rules, reducing the height above the footer from 25px to 5px, does look noticeably better to me, but implementing that properly only when the post is actually collapsed would require actual effort to implement and test. Also, not really related to collapsing at all.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that Collapsed Queue still looks fine on the queue page.