### PR TITLE
Fix extension restarts in Firefox

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -81,7 +81,6 @@
 
     const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
     const script = document.createElement('script');
-    script.type = 'module';
     script.nonce = nonce;
     script.src = browser.runtime.getURL('/main_world/index.js');
     document.documentElement.append(script);

--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -1,34 +1,38 @@
-const moduleCache = {};
+'use strict';
 
-document.documentElement.addEventListener('xkitinjectionrequest', async event => {
-  const { detail, target } = event;
-  const { id, path, args } = JSON.parse(detail);
+{
+  const moduleCache = {};
 
-  try {
-    moduleCache[path] ??= await import(path);
-    const func = moduleCache[path].default;
+  document.documentElement.addEventListener('xkitinjectionrequest', async event => {
+    const { detail, target } = event;
+    const { id, path, args } = JSON.parse(detail);
 
-    if (target.isConnected === false) return;
+    try {
+      moduleCache[path] ??= await import(path);
+      const func = moduleCache[path].default;
 
-    const result = await func.apply(target, args);
-    target.dispatchEvent(
-      new CustomEvent('xkitinjectionresponse', { detail: JSON.stringify({ id, result }) })
-    );
-  } catch (exception) {
-    target.dispatchEvent(
-      new CustomEvent('xkitinjectionresponse', {
-        detail: JSON.stringify({
-          id,
-          exception: {
-            message: exception.message,
-            name: exception.name,
-            stack: exception.stack,
-            ...exception
-          }
+      if (target.isConnected === false) return;
+
+      const result = await func.apply(target, args);
+      target.dispatchEvent(
+        new CustomEvent('xkitinjectionresponse', { detail: JSON.stringify({ id, result }) })
+      );
+    } catch (exception) {
+      target.dispatchEvent(
+        new CustomEvent('xkitinjectionresponse', {
+          detail: JSON.stringify({
+            id,
+            exception: {
+              message: exception.message,
+              name: exception.name,
+              stack: exception.stack,
+              ...exception
+            }
+          })
         })
-      })
-    );
-  }
-});
+      );
+    }
+  });
 
-document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready'));
+  document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready'));
+}


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Ah, fuck, yeah, it was my fault. I essentially already knew this, too.

If the script element created in initMainWorld is a module script, disabling and re-enabling the extension adds another identical module script to the page. This won't execute anything, because modules are only executed once, and so the whole extension will break on that page.

This changes the main world script (back) to a classic script, fixing this.

See #1550; probably fixes the main issue there, but I haven't fully tested that yet.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

In Firefox, turn the extension off and then back on. Without this PR, observe that everything breaks. With this PR, smoke test the extension and confirm it works.

