### PR TITLE
Refactor: remove unnecessary `:is()` on single selectors

### DIFF
--- a/src/utils/css_map.js
+++ b/src/utils/css_map.js
@@ -10,9 +10,11 @@ export const keyToClasses = (...keys) => keys.flatMap(key => cssMap[key]).filter
 
 /**
  * @param {...string} keys - One or more element source names
- * @returns {string} - A CSS :is() selector which targets all elements that match any of the given source names
+ * @returns {string} - A CSS selector which targets all elements that match any of the given source names
  */
 export const keyToCss = function (...keys) {
-  const classes = keyToClasses(...keys);
-  return `:is(${classes.map(className => `.${className}`).join(', ')})`;
+  const selectors = keyToClasses(...keys).map(className => `.${className}`);
+  return selectors.length > 1
+    ? `:is(${selectors.join(', ')})`
+    : selectors[0];
 };

--- a/src/utils/css_map.js
+++ b/src/utils/css_map.js
@@ -14,7 +14,7 @@ export const keyToClasses = (...keys) => keys.flatMap(key => cssMap[key]).filter
  */
 export const keyToCss = function (...keys) {
   const selectors = keyToClasses(...keys).map(className => `.${className}`);
-  return selectors.length > 1
-    ? `:is(${selectors.join(', ')})`
-    : selectors[0];
+  return selectors.length === 1
+    ? selectors[0]
+    : `:is(${selectors.join(', ')})`;
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This tweaks the output of `keyToCss` to remove an unnecessary `:is()` occasionally. No point to this at all, really.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

