### PR TITLE
Tag Tracking+: minor `onStorageChanged` refactor

### DIFF
--- a/src/features/tag_tracking_plus.js
+++ b/src/features/tag_tracking_plus.js
@@ -128,12 +128,16 @@ const processPosts = async function (postElements) {
 };
 
 export const onStorageChanged = async (changes, areaName) => {
-  if (Object.keys(changes).includes(storageKey)) {
-    timestamps = changes[storageKey].newValue;
+  const {
+    [storageKey]: timestampsChanges,
+    'tag_tracking_plus.preferences.onlyShowNew': onlyShowNewChanges
+  } = changes;
+
+  if (timestampsChanges) {
+    timestamps = timestampsChanges.newValue;
   }
-  if (Object.keys(changes).some(key => key.startsWith('tag_tracking_plus.preferences'))) {
-    const { onlyShowNew } = await getPreferences('tag_tracking_plus');
-    sidebarItem.dataset.onlyShowNew = onlyShowNew;
+  if (onlyShowNewChanges) {
+    sidebarItem.dataset.onlyShowNew = onlyShowNewChanges.newValue;
   }
 };
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Now that `onlyShowNew` is simpler, this copies the `onStorageChanged` code structure from Seen Posts to Tag Tracking+, no longer calling `getPreferences`  in the middle of it. Not important at all; I was just copying it for something else and went, "wait, what is this doing."

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

