### PR TITLE
Tweaks: Create empty reply button tweak

### DIFF
--- a/src/features/tweaks.json
+++ b/src/features/tweaks.json
@@ -63,6 +63,11 @@
       "label": "Hide following/mutuals indicators on notifications",
       "default": false
     },
+    "hide_empty_reply_button": {
+      "type": "checkbox",
+      "label": "Hide the large reply button on replies without a thread",
+      "default": false
+    },
     "hide_footer_tooltips": {
       "type": "checkbox",
       "label": "Hide control button tooltips in the post footer",

--- a/src/features/tweaks/hide_empty_reply_button.js
+++ b/src/features/tweaks/hide_empty_reply_button.js
@@ -1,0 +1,11 @@
+import { keyToCss } from '../../utils/css_map.js';
+import { buildStyle } from '../../utils/interface.js';
+
+const styleElement = buildStyle(`
+footer ${keyToCss('replyCountButton')}:not(:has(span${keyToCss('count')})) {
+  display: none;
+}
+`);
+
+export const main = async () => document.documentElement.append(styleElement);
+export const clean = async () => styleElement.remove();


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Creates a tweak that hides the large reply button in post replies when it doesn't have a reply count. One can still reply to a reply from the meatballs menu, so the button serves no purpose in this case so long as users are aware of this.

This both saves vertical space and, in my opinion, dramatically increases readability of the replies section in some cases by adding more visual distinction between posts at the root of a thread and the thread itself; indentation isn't that much of a distinguishing factor.

Would, of course, need to be removed from the extension in a timely fashion if the reply option gets removed from the meatballs menu (which I would be annoyed about, but I could see happening, as without this tweak it doesn't really make sense). I would probably hack the button into a new location in that case (float? lmao)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

