### PR TITLE
Quote Replies: Fix feature on threaded replies

### DIFF
--- a/src/features/quote_replies.js
+++ b/src/features/quote_replies.js
@@ -68,12 +68,12 @@ const quoteReply = async (tumblelogName, notificationProps) => {
   if (!reply) throw new Error('No replies found on target post.');
   if (Math.floor(reply.timestamp) !== timestamp) throw new Error('Reply not found.');
 
-  const message = {
+  const verbiage = {
     reply: 'replied to your post',
     reply_to_comment: 'replied to you in a post',
     note_mention: 'mentioned you on a post'
   }[type];
-  const text = `@${reply.blog.name} ${message} \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`;
+  const text = `@${reply.blog.name} ${verbiage} \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`;
   const formatting = [
     { start: 0, end: reply.blog.name.length + 1, type: 'mention', blog: { uuid: reply.blog.uuid } },
     { start: text.indexOf('\u201C'), end: text.length - 1, type: 'link', url: `https://${targetTumblelogName}.tumblr.com/post/${targetPostId}` }

--- a/src/features/quote_replies.js
+++ b/src/features/quote_replies.js
@@ -31,7 +31,7 @@ const processNotifications = notifications => notifications.forEach(async notifi
     notification
   );
 
-  if (!['reply', 'note_mention'].includes(notificationProps.type)) return;
+  if (!['reply', 'note_mention', 'reply_to_comment'].includes(notificationProps.type)) return;
 
   const activityElement = notification.querySelector(activitySelector);
   if (!activityElement) return;
@@ -58,7 +58,6 @@ const quoteReply = async (tumblelogName, notificationProps) => {
   const uuid = userBlogs.find(({ name }) => name === tumblelogName).uuid;
   const { type, targetPostId, targetPostSummary, targetTumblelogName, targetTumblelogUuid, timestamp } = notificationProps;
 
-  const isReply = type === 'reply';
   const { response } = await apiFetch(
     `/v2/blog/${targetTumblelogUuid}/post/${targetPostId}/notes/timeline`,
     { queryParams: { mode: 'replies', before_timestamp: `${timestamp + 1}000000` } }
@@ -69,9 +68,11 @@ const quoteReply = async (tumblelogName, notificationProps) => {
   if (!reply) throw new Error('No replies found on target post.');
   if (Math.floor(reply.timestamp) !== timestamp) throw new Error('Reply not found.');
 
-  const text = isReply
-    ? `@${reply.blog.name} replied to your post \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`
-    : `@${reply.blog.name} mentioned you on a post \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`;
+  const text = {
+    reply: `@${reply.blog.name} replied to your post \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`,
+    note_mention: `@${reply.blog.name} mentioned you on a post \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`,
+    reply_to_comment: `@${reply.blog.name} replied to you in a post \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`
+  }[type];
   const formatting = [
     { start: 0, end: reply.blog.name.length + 1, type: 'mention', blog: { uuid: reply.blog.uuid } },
     { start: text.indexOf('\u201C'), end: text.length - 1, type: 'link', url: `https://${targetTumblelogName}.tumblr.com/post/${targetPostId}` }

--- a/src/features/quote_replies.js
+++ b/src/features/quote_replies.js
@@ -68,11 +68,12 @@ const quoteReply = async (tumblelogName, notificationProps) => {
   if (!reply) throw new Error('No replies found on target post.');
   if (Math.floor(reply.timestamp) !== timestamp) throw new Error('Reply not found.');
 
-  const text = {
-    reply: `@${reply.blog.name} replied to your post \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`,
-    note_mention: `@${reply.blog.name} mentioned you on a post \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`,
-    reply_to_comment: `@${reply.blog.name} replied to you in a post \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`
+  const message = {
+    reply: 'replied to your post',
+    reply_to_comment: 'replied to you in a post',
+    note_mention: 'mentioned you on a post'
   }[type];
+  const text = `@${reply.blog.name} ${message} \u201C${targetPostSummary.replace(/\n/g, ' ')}\u201D:`;
   const formatting = [
     { start: 0, end: reply.blog.name.length + 1, type: 'mention', blog: { uuid: reply.blog.uuid } },
     { start: text.indexOf('\u201C'), end: text.length - 1, type: 'link', url: `https://${targetTumblelogName}.tumblr.com/post/${targetPostId}` }

--- a/src/features/quote_replies.js
+++ b/src/features/quote_replies.js
@@ -31,7 +31,7 @@ const processNotifications = notifications => notifications.forEach(async notifi
     notification
   );
 
-  if (!['reply', 'note_mention', 'reply_to_comment'].includes(notificationProps.type)) return;
+  if (!['reply', 'reply_to_comment', 'note_mention'].includes(notificationProps.type)) return;
 
   const activityElement = notification.querySelector(activitySelector);
   if (!activityElement) return;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Threaded replies have a different `type` value internally, so Quote Replies currently doesn't recognize them. This fixes this and adds the correct message to correspond with the activity item text.

~~I didn't bother to file an issue for this, so this doesn't resolve one.~~

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Use Quote Replies on all three types of activity and confirm that it works and the resulting post text matches the activity item text.