### PR TITLE
AccessKit: Apply Disable GIFs to all WebP images

### DIFF
--- a/src/features/accesskit.json
+++ b/src/features/accesskit.json
@@ -11,7 +11,7 @@
   "preferences": {
     "disable_gifs": {
       "type": "checkbox",
-      "label": "Pause GIFs until they are hovered over",
+      "label": "Pause GIF/WebP images until they are hovered over",
       "default": false
     },
     "boring_tag_chiclets": {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -25,12 +25,14 @@ const styleElement = buildStyle(`
   line-height: 1em;
 }
 
-.${labelClass}::before {
-  content: "GIF";
-}
-
 .${labelClass}.mini {
   font-size: 0.6rem;
+}
+.${labelClass}.four {
+  font-size: 0.75rem;
+}
+.${labelClass}.mini.four {
+  font-size: 0.45rem;
 }
 
 .${canvasClass} {
@@ -57,12 +59,11 @@ const styleElement = buildStyle(`
 }
 `);
 
-const addLabel = (element, inside = false) => {
+const addLabel = (element, labelText, inside = false) => {
   if (element.parentNode.querySelector(`.${labelClass}`) === null) {
-    const gifLabel = document.createElement('p');
-    gifLabel.className = element.clientWidth && element.clientWidth < 150
-      ? `${labelClass} mini`
-      : labelClass;
+    const gifLabel = dom('p', { class: labelClass }, null, [labelText]);
+    element.clientWidth && element.clientWidth < 150 && gifLabel.classList.add('mini');
+    labelText.length > 3 && gifLabel.classList.add('four');
 
     inside ? element.append(gifLabel) : element.parentNode.append(gifLabel);
   }
@@ -80,7 +81,7 @@ const pauseGif = function (gifElement) {
       canvas.classList.add(canvasClass);
       canvas.getContext('2d').drawImage(image, 0, 0);
       gifElement.parentNode.append(canvas);
-      addLabel(gifElement);
+      addLabel(gifElement, gifElement.currentSrc.includes('.webp') ? 'WEBP' : 'GIF');
     }
   };
 };
@@ -108,7 +109,7 @@ const processGifs = function (gifElements) {
 const processBackgroundGifs = function (gifBackgroundElements) {
   gifBackgroundElements.forEach(gifBackgroundElement => {
     gifBackgroundElement.classList.add(backgroundGifClass);
-    addLabel(gifBackgroundElement, true);
+    addLabel(gifBackgroundElement, 'GIF', true);
   });
 };
 
@@ -132,7 +133,7 @@ export const main = async function () {
   document.documentElement.append(styleElement);
 
   const gifImage = `
-    :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img[srcset*=".gif"]:not(${keyToCss('poster')})
+    :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img:is([srcset*=".gif"], [srcset*=".webp"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Still not sure if this is a good idea (in this state). There are, apparently, a fair number of non-animated WebP images.

This
- Applies Disable GIFs to WebP images (including non-animated ones; it is [not particularly easy](https://github.com/AprilSylph/XKit-Rewritten/pull/1402) to [distinguish the two](https://github.com/AprilSylph/XKit-Rewritten/compare/master...marcustyphoon:XKit-Rewritten:webp-riffchunks?expand=1)).
- Makes the label accurately indicate the source image type, so at least when it false positives on a non-animated image the user knows why. 

Resolves #1401.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Animated WebP: https://www.tumblr.com/changes/758172275271991296/threaded-replies-are-here
Animated GIF: https://www.tumblr.com/@radar/757906400962920448, https://www.tumblr.com/april-codes/700206746833240064
Non-animated GIF: https://www.tumblr.com/@radar/753920129042153472
Non-animated WebP: https://www.tumblr.com/minmos/744793127262601216/front-facing-egrets-making-me-lose-control-of, https://www.tumblr.com/@radar/755279084134744066, https://www.tumblr.com/@radar/750568043810340864
