### PR TITLE
Tweaks: Fix subtle following/mutuals tweak in communities

### DIFF
--- a/src/features/tweaks/subtle_activity_mutuals.js
+++ b/src/features/tweaks/subtle_activity_mutuals.js
@@ -3,7 +3,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle } from '../../utils/interface.js';
 import { dom } from '../../utils/dom.js';
 
-const labelSelector = keyToCss('followingBadgeContainer', 'mutualsBadgeContainer');
+const labelSelector = `${keyToCss('followingBadgeContainer', 'mutualsBadgeContainer')}:has(> svg)`;
 
 const spanClass = 'xkit-tweaks-subtle-activity-span';
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

For whatever reason, in the Communities members page, the following/mutuals labels don't have an icon, so the tweak to hide the text and only display the icon makes a pretty silly resulting appearance. This enables the tweak only if there is an icon to show.

<img width="570" src="https://github.com/user-attachments/assets/0dfc83ee-65b3-4901-ba6a-83cb4daa3156">

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm labels are not affected on (e.g.) https://www.tumblr.com/communities/communities-feedback/members?page=1
- Confirm labels are affected on the activity page