### PR TITLE
Sidebar util: Prevent erroneous sidebar in communities settings

### DIFF
--- a/src/utils/sidebar.js
+++ b/src/utils/sidebar.js
@@ -96,7 +96,7 @@ const updateSidebarItemVisibility = () => [...sidebarItems.children]
   .forEach(sidebarItem => { sidebarItem.hidden = !conditions.get(sidebarItem)(); });
 
 const addSidebarToPage = (siblingCandidates) => {
-  if (/^\/settings/.test(location.pathname)) { return; }
+  if (/^\/settings/.test(location.pathname) || /^\/communities.*\/settings$/.test(location.pathname)) { return; }
 
   updateSidebarItemVisibility();
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Right now, the xkit sidebar is erroneously inserted in between two of the menu items on the right side of the communities settings page. We don't really need it to be on that page at all, similar to how we don't add it to the main Tumblr settings interface, so this prevents this.

<img width="600" src="https://github.com/user-attachments/assets/9db6ac82-d349-4a70-a58a-9c447a1d5f97">

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm there is no XKit sidebar on `https://www.tumblr.com/communities/[some community id you have admin in]/settings`. Or, you know, don't; this one's pretty simple.

