### PR TITLE
NotificationBlock: Enable in communities

### DIFF
--- a/src/features/notificationblock.js
+++ b/src/features/notificationblock.js
@@ -79,11 +79,12 @@ const onButtonClicked = async function ({ currentTarget }) {
   });
 };
 
-const blockPostFilter = async ({ blogName, rebloggedRootName, rebloggedFromName, id, rebloggedRootId }) => {
+const blockPostFilter = async ({ blogName, rebloggedRootName, rebloggedFromName, id, rebloggedRootId, community, postAuthor }) => {
   const rootId = rebloggedRootId || id;
   const canReceiveActivity = userBlogNames.includes(blogName) ||
     userBlogNames.includes(rebloggedFromName) ||
-    userBlogNames.includes(rebloggedRootName);
+    userBlogNames.includes(rebloggedRootName) ||
+    (community && userBlogNames.includes(postAuthor));
 
   return canReceiveActivity && blockedPostTargetIDs.includes(rootId) === false;
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Enables notificationblock on community posts you authored.

See #1441.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

At time of writing, I have a spare community with invite link https://www.tumblr.com/join/oki7cQsr.

- Make an original post in a community.
- Reply to the post.
- Confirm that the post's meatballs menu has a notificationblock button.
- Confirm that notificationblock hides the notification for the reply when it's used.
- Confirm that the post's meatballs menu has a notificationblock unblock button.
- Confirm that notificationblock no longer hides the notification for the reply when it's used.

--

- Reblog a post into a community.
- Reply to the post.
- Confirm that the post's meatballs menu has a notificationblock button.
- Confirm that notificationblock hides the notification for the reply when it's used.
- Confirm that the post's meatballs menu has a notificationblock unblock button.
- Confirm that notificationblock no longer hides the notification for the reply when it's used.
