### PR TITLE
Quick Reblog: Enable reblogging posts into communities

### DIFF
--- a/src/features/quick_reblog.css
+++ b/src/features/quick_reblog.css
@@ -187,6 +187,8 @@ div:first-child + span + #quick-reblog,
 #quick-reblog button[data-state="queue"] { color: rgb(var(--pink)); }
 #quick-reblog button[data-state="draft"] { color: rgb(var(--orange)); }
 
+#quick-reblog .action-buttons.community-selected button:not([data-state="published"]) { display: none; }
+
 .published :is(a[role="button"], button[class=""]) svg[style*="--black"] use { --icon-color-primary: rgb(var(--green)); }
 .queue :is(a[role="button"], button[class=""]) svg[style*="--black"] use { --icon-color-primary: rgb(var(--purple)); }
 .draft :is(a[role="button"], button[class=""]) svg[style*="--black"] use { --icon-color-primary: rgb(var(--red)); }

--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -67,7 +67,7 @@ const alreadyRebloggedStorageKey = 'quick_reblog.alreadyRebloggedList';
 const rememberedBlogStorageKey = 'quick_reblog.rememberedBlogs';
 const quickTagsStorageKey = 'quick_tags.preferences.tagBundles';
 const blogHashes = new Map();
-const avatarUrls = {};
+const avatarUrls = new Map();
 
 const reblogButtonSelector = `
 ${postSelector} footer a[href*="/reblog/"],
@@ -75,7 +75,7 @@ ${postSelector} footer button[aria-label="${translate('Reblog')}"]:not([role])
 `;
 
 const renderBlogAvatar = () => {
-  blogAvatar.style.backgroundImage = `url(${avatarUrls[blogSelector.value]})`;
+  blogAvatar.style.backgroundImage = `url(${avatarUrls.get(blogSelector.value)})`;
 };
 blogSelector.addEventListener('change', renderBlogAvatar);
 
@@ -342,7 +342,7 @@ export const main = async function () {
   [...userBlogs, ...joinedCommunities].forEach((data) => {
     const avatar = data.avatarImage ?? data.avatar;
     const { url } = avatar.at(-1);
-    avatarUrls[data.uuid] = url;
+    avatarUrls.set(data.uuid, url);
   });
 
   if (rememberLastBlog) {

--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -2,7 +2,7 @@ import { sha256 } from '../utils/crypto.js';
 import { timelineObject } from '../utils/react_props.js';
 import { apiFetch } from '../utils/tumblr_helpers.js';
 import { postSelector, filterPostElements, postType, appendWithoutOverflow } from '../utils/interface.js';
-import { userBlogs } from '../utils/user.js';
+import { joinedCommunities, userBlogs } from '../utils/user.js';
 import { getPreferences } from '../utils/preferences.js';
 import { onNewPosts } from '../utils/mutations.js';
 import { notify } from '../utils/notifications.js';
@@ -50,7 +50,6 @@ let lastPostID;
 let timeoutID;
 let suggestableTags;
 let accountKey;
-let joinedCommunities;
 
 let popupPosition;
 let showBlogSelector;
@@ -333,10 +332,6 @@ export const main = async function () {
     alreadyRebloggedEnabled,
     alreadyRebloggedLimit
   } = await getPreferences('quick_reblog'));
-
-  joinedCommunities = await apiFetch('/v2/communities')
-    .then(({ response }) => response)
-    .catch(() => []);
 
   blogSelector.replaceChildren(
     ...userBlogs.map(({ name, uuid }) => dom('option', { value: uuid }, null, [name])),

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -5,6 +5,11 @@ const fetchedUserInfo = await apiFetch('/v2/user/info').catch((error) => {
   return { response: {} };
 });
 
+const fetchedCommunitiesInfo = await apiFetch('/v2/communities').catch((error) => {
+  console.error(error);
+  return { response: [] };
+});
+
 /**
  * {object?} userInfo - The contents of the /v2/user/info API endpoint
  */
@@ -39,3 +44,8 @@ export const adminBlogs = userInfo?.blogs?.filter(blog => blog.admin) ?? [];
  * {string[]} adminBlogNames - An array of blog names the current user is admin of
  */
 export const adminBlogNames = adminBlogs.map(blog => blog.name);
+
+/**
+ * {object?} userInfo - The contents of the /v2/user/info API endpoint
+ */
+export const joinedCommunities = fetchedCommunitiesInfo.response;

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -46,6 +46,6 @@ export const adminBlogs = userInfo?.blogs?.filter(blog => blog.admin) ?? [];
 export const adminBlogNames = adminBlogs.map(blog => blog.name);
 
 /**
- * {object?} userInfo - The contents of the /v2/user/info API endpoint
+ * {object?} joinedCommunities - An array of community objects the current user has joined
  */
 export const joinedCommunities = fetchedCommunitiesInfo.response;

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -51,6 +51,6 @@ export const adminBlogNames = adminBlogs.map(blog => blog.name);
 export const joinedCommunities = fetchedCommunitiesInfo.response;
 
 /**
- * {object?} joinedCommunities - An array of community objects the current user has joined
+ * {string[]} joinedCommunityUuids - An array of community uuids the current user has joined
  */
 export const joinedCommunityUuids = joinedCommunities.map(community => community.uuid);

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -49,3 +49,8 @@ export const adminBlogNames = adminBlogs.map(blog => blog.name);
  * {object?} joinedCommunities - An array of community objects the current user has joined
  */
 export const joinedCommunities = fetchedCommunitiesInfo.response;
+
+/**
+ * {object?} joinedCommunities - An array of community objects the current user has joined
+ */
+export const joinedCommunityUuids = joinedCommunities.map(community => community.uuid);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds communities the user has joined to the Quick Reblog blog selector dropdown.

Note that posts drafted or queued into a community (presumably) disappear into the ether, so this puts up an error modal if the user tries to do so. (Ideally it should probably grey out the buttons in question; I was hoping one could css select based on a `<select>`'s current value but I'm not sure you can, so this would probably have to be a bunch of js.)

Should alreadyReblogged exclude reblogging into a community? ¯\\\_(ツ)\_/¯ 


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

At time of writing, I have a spare community with invite link [tumblr.com/join/oki7cQsr](https://www.tumblr.com/join/oki7cQsr).

todo: list performed tests