### PR TITLE
Quote Replies: Don't break on communities activity

### DIFF
--- a/src/features/quote_replies.js
+++ b/src/features/quote_replies.js
@@ -32,6 +32,7 @@ const processNotifications = notifications => notifications.forEach(async notifi
   );
 
   if (!['reply', 'note_mention'].includes(notificationProps.type)) return;
+  if (notificationProps.community) return;
 
   const activityElement = notification.querySelector(activitySelector);
   if (!activityElement) return;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Currently, Quote Replies puts an action button on activity items from communities, but the API request to get the note data 404s, and in general the feature is a little iffy on communities posts even in theory (particularly if we make it create reblogs).

This makes the broken button not appear.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

