### PR TITLE
Cleanfeed: Add "content label" to metadata

### DIFF
--- a/src/features/cleanfeed.json
+++ b/src/features/cleanfeed.json
@@ -7,7 +7,7 @@
     "background_color": "#ff567e"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#cleanfeed",
-  "relatedTerms": [ "NSFW", "Mature", "Adult", "Sensitive", "Community Label" ],
+  "relatedTerms": [ "NSFW", "Mature", "Adult", "Sensitive", "Community Label", "Content Label" ],
   "preferences": {
     "blockingMode": {
       "label": "Hide media from:",


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

The new terminology for Tumblr's content labels is "content label;" this simply adds said term to CleanFeed's searchable metadata.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

