### PR TITLE
Collapsed Queue: Fix uncollapsing when posts are edited

### DIFF
--- a/src/features/collapsed_queue.js
+++ b/src/features/collapsed_queue.js
@@ -4,7 +4,6 @@ import { onNewPosts } from '../utils/mutations.js';
 import { keyToCss } from '../utils/css_map.js';
 import { anyQueueTimelineFilter, anyDraftsTimelineFilter } from '../utils/timeline_id.js';
 
-const excludeClass = 'xkit-collapsed-queue-done';
 const wrapperClass = 'xkit-collapsed-queue-wrapper';
 const containerClass = 'xkit-collapsed-queue-container';
 const footerSelector = keyToCss('footerWrapper');
@@ -12,7 +11,9 @@ const footerSelector = keyToCss('footerWrapper');
 let timeline;
 
 const processPosts = async function (postElements) {
-  filterPostElements(postElements, { excludeClass, timeline }).forEach(async postElement => {
+  filterPostElements(postElements, { timeline }).forEach(async postElement => {
+    if (postElement.querySelector(`.${wrapperClass}`)) return;
+
     const headerElement = postElement.querySelector('header');
     const footerElement = postElement.querySelector(footerSelector);
 
@@ -46,8 +47,6 @@ export const clean = async function () {
     const container = wrapper.querySelector(`.${containerClass}`);
     wrapper.replaceWith(...container.children);
   });
-
-  $(`.${excludeClass}`).removeClass(excludeClass);
 };
 
 export const stylesheet = true;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As mentioned in the comments of #1529, if one opens a draft in the post editor and then closes it (whether or not they save the edit), the post gets rerendered and this removes Collapsed Queue's DOM modifications. This fixes this.

We should probably do another pass on `excludeClass` use at some point, I suppose.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Enable Collapsed Queue on drafts
- Click edit on a draft
- Exit the editor
- Confirm that the draft is still collapsed
