### PR TITLE
Quick Reblog: List communities above blogs

### DIFF
--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -2,7 +2,7 @@ import { sha256 } from '../utils/crypto.js';
 import { timelineObject } from '../utils/react_props.js';
 import { apiFetch } from '../utils/tumblr_helpers.js';
 import { postSelector, filterPostElements, postType, appendWithoutOverflow } from '../utils/interface.js';
-import { joinedCommunities, joinedCommunityUuids, userBlogs } from '../utils/user.js';
+import { joinedCommunities, joinedCommunityUuids, primaryBlog, userBlogs } from '../utils/user.js';
 import { getPreferences } from '../utils/preferences.js';
 import { onNewPosts } from '../utils/mutations.js';
 import { notify } from '../utils/notifications.js';
@@ -138,7 +138,7 @@ const showPopupOnHover = ({ currentTarget }) => {
   const thisPostID = thisPost.dataset.id;
   if (thisPostID !== lastPostID) {
     if (!rememberLastBlog) {
-      blogSelector.value = blogSelector.options[0].value;
+      blogSelector.value = primaryBlog.uuid;
       onBlogSelectorChange();
     }
     commentInput.value = '';
@@ -331,9 +331,9 @@ export const main = async function () {
   } = await getPreferences('quick_reblog'));
 
   blogSelector.replaceChildren(
-    ...userBlogs.map(({ name, uuid }) => dom('option', { value: uuid }, null, [name])),
+    ...joinedCommunities.map(({ title, uuid, blog: { name } }) => dom('option', { value: uuid }, null, [`${title} (${name})`])),
     ...joinedCommunities.length ? [dom('hr')] : [],
-    ...joinedCommunities.map(({ title, uuid, blog: { name } }) => dom('option', { value: uuid }, null, [`${title} (${name})`]))
+    ...userBlogs.map(({ name, uuid }) => dom('option', { value: uuid }, null, [name]))
   );
 
   [...userBlogs, ...joinedCommunities].forEach((data) => {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This is a UI tweak that makes a ton of sense if the user has a lot of sideblogs and is not in a lot of communities. If the user is in enough communities that the top (presumably most-used) one now scrolls off the screen when it would have otherwise been, like, list item 3, that's rather silly.

As a general rule, placing the default-selected menu item in the middle makes accessing the whole list easier. So there is some upside. But, eh, this could definitely be argued to be more confusing for some users, while the current way is at least clear even when it's kind of inconvenient.

Not worth a preference, certainly.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

