### PR TITLE
No Recommended: Fix fallback behavior when hiding the entire dash

### DIFF
--- a/src/features/no_recommended/hide_recommended_posts.js
+++ b/src/features/no_recommended/hide_recommended_posts.js
@@ -34,10 +34,10 @@ export const styleElement = buildStyle(`
 const precedingHiddenPosts = ({ previousElementSibling: previousElement }, count = 0) => {
   // If there is no previous sibling, stop counting
   if (!previousElement) return count;
-  // If the previous sibling is not a post, skip over it
-  if (!previousElement.matches(postSelector) || !previousElement.querySelector(postSelector)) return precedingHiddenPosts(previousElement, count);
   // If the previous sibling is hidden, count it and continue
   if (previousElement.matches(`[${hiddenAttribute}]`)) return precedingHiddenPosts(previousElement, count + 1);
+  // If the previous sibling is not a post, skip over it
+  if (!previousElement.matches(postSelector) || !previousElement.querySelector(postSelector)) return precedingHiddenPosts(previousElement, count);
   // Otherwise, we've hit a non-hidden post; stop counting
   return count;
 };

--- a/src/features/no_recommended/hide_recommended_posts.js
+++ b/src/features/no_recommended/hide_recommended_posts.js
@@ -59,7 +59,7 @@ const processPosts = async function (postElements) {
     timelineItem.setAttribute(hiddenAttribute, '');
 
     if (precedingHiddenPosts(timelineItem) >= 10) {
-      timelineItem.setAttribute(hiddenAttribute, '');
+      timelineItem.setAttribute(unHiddenAttribute, '');
     }
   });
 };

--- a/src/features/no_recommended/hide_recommended_posts.js
+++ b/src/features/no_recommended/hide_recommended_posts.js
@@ -10,6 +10,10 @@ const timeline = followingTimelineFilter;
 const includeFiltered = true;
 
 export const styleElement = buildStyle(`
+[${hiddenAttribute}] {
+  outline: 3px dotted red;
+}
+
 [${hiddenAttribute}]:not([${unHiddenAttribute}]) article {
   display: none;
 }
@@ -33,32 +37,47 @@ export const styleElement = buildStyle(`
 
 const precedingHiddenPosts = ({ previousElementSibling: previousElement }, count = 0) => {
   // If there is no previous sibling, stop counting
-  if (!previousElement) return count;
+  if (!previousElement) {
+    console.log('--', count, 'there is no previous sibling, stop counting');
+    return count;
+  }
   // If the previous sibling is hidden, count it and continue
-  if (previousElement.matches(`[${hiddenAttribute}]`)) return precedingHiddenPosts(previousElement, count + 1);
+  if (previousElement.matches(`[${hiddenAttribute}]`)) {
+    console.log('--', count, 'the previous sibling is hidden, count it and continue', previousElement);
+    return precedingHiddenPosts(previousElement, count + 1);
+  }
   // If the previous sibling is not a post, skip over it
-  if (!previousElement.matches(postSelector) || !previousElement.querySelector(postSelector)) return precedingHiddenPosts(previousElement, count);
+  if (!previousElement.matches(postSelector) || !previousElement.querySelector(postSelector)) {
+    console.log('--', count, 'the previous sibling is not a post, skip over it', previousElement);
+    return precedingHiddenPosts(previousElement, count);
+  }
   // Otherwise, we've hit a non-hidden post; stop counting
+  console.log('--', count, "we've hit a non-hidden post; stop counting", previousElement);
   return count;
 };
 
 const processPosts = async function (postElements) {
   filterPostElements(postElements, { excludeClass, timeline, includeFiltered }).forEach(async postElement => {
-    const { recommendationReason } = await timelineObject(postElement);
-    if (!recommendationReason) return;
+    if (Math.random() < 0.1) {
+      const { recommendationReason } = await timelineObject(postElement);
+      if (!recommendationReason) return;
 
-    const { loggingReason } = recommendationReason;
-    if (!loggingReason) return;
+      const { loggingReason } = recommendationReason;
+      if (!loggingReason) return;
 
-    if (loggingReason.startsWith('pin:')) return;
-    if (loggingReason.startsWith('search:')) return;
-    if (loggingReason === 'orbitznews') return;
+      if (loggingReason.startsWith('pin:')) return;
+      if (loggingReason.startsWith('search:')) return;
+      if (loggingReason === 'orbitznews') return;
+    }
 
     const timelineItem = getTimelineItemWrapper(postElement);
 
     timelineItem.setAttribute(hiddenAttribute, '');
 
-    if (precedingHiddenPosts(timelineItem) >= 10) {
+    const count = precedingHiddenPosts(timelineItem);
+    console.log(count);
+
+    if (count >= 10) {
       timelineItem.setAttribute(unHiddenAttribute, '');
     }
   });

--- a/src/features/no_recommended/hide_recommended_posts.js
+++ b/src/features/no_recommended/hide_recommended_posts.js
@@ -10,10 +10,6 @@ const timeline = followingTimelineFilter;
 const includeFiltered = true;
 
 export const styleElement = buildStyle(`
-[${hiddenAttribute}] {
-  outline: 3px dotted red;
-}
-
 [${hiddenAttribute}]:not([${unHiddenAttribute}]) article {
   display: none;
 }
@@ -37,47 +33,32 @@ export const styleElement = buildStyle(`
 
 const precedingHiddenPosts = ({ previousElementSibling: previousElement }, count = 0) => {
   // If there is no previous sibling, stop counting
-  if (!previousElement) {
-    console.log('--', count, 'there is no previous sibling, stop counting');
-    return count;
-  }
+  if (!previousElement) return count;
   // If the previous sibling is hidden, count it and continue
-  if (previousElement.matches(`[${hiddenAttribute}]`)) {
-    console.log('--', count, 'the previous sibling is hidden, count it and continue', previousElement);
-    return precedingHiddenPosts(previousElement, count + 1);
-  }
+  if (previousElement.matches(`[${hiddenAttribute}]`)) return precedingHiddenPosts(previousElement, count + 1);
   // If the previous sibling is not a post, skip over it
-  if (!previousElement.matches(postSelector) || !previousElement.querySelector(postSelector)) {
-    console.log('--', count, 'the previous sibling is not a post, skip over it', previousElement);
-    return precedingHiddenPosts(previousElement, count);
-  }
+  if (!previousElement.matches(postSelector) || !previousElement.querySelector(postSelector)) return precedingHiddenPosts(previousElement, count);
   // Otherwise, we've hit a non-hidden post; stop counting
-  console.log('--', count, "we've hit a non-hidden post; stop counting", previousElement);
   return count;
 };
 
 const processPosts = async function (postElements) {
   filterPostElements(postElements, { excludeClass, timeline, includeFiltered }).forEach(async postElement => {
-    if (Math.random() < 0.1) {
-      const { recommendationReason } = await timelineObject(postElement);
-      if (!recommendationReason) return;
+    const { recommendationReason } = await timelineObject(postElement);
+    if (!recommendationReason) return;
 
-      const { loggingReason } = recommendationReason;
-      if (!loggingReason) return;
+    const { loggingReason } = recommendationReason;
+    if (!loggingReason) return;
 
-      if (loggingReason.startsWith('pin:')) return;
-      if (loggingReason.startsWith('search:')) return;
-      if (loggingReason === 'orbitznews') return;
-    }
+    if (loggingReason.startsWith('pin:')) return;
+    if (loggingReason.startsWith('search:')) return;
+    if (loggingReason === 'orbitznews') return;
 
     const timelineItem = getTimelineItemWrapper(postElement);
 
     timelineItem.setAttribute(hiddenAttribute, '');
 
-    const count = precedingHiddenPosts(timelineItem);
-    console.log(count);
-
-    if (count >= 10) {
+    if (precedingHiddenPosts(timelineItem) >= 10) {
       timelineItem.setAttribute(unHiddenAttribute, '');
     }
   });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Back in #1008 I added "Too many recommended posts to hide!" fallback code when No Recommended hid way too many posts in a row. In #1213, I apparently made a typo and completely broke it, which we (quite reasonably, imho) didn't notice.

This fixes it... mostly. There are some edge cases, but it's good enough, I think.

Notably, the virtual scroller means that some cell elements are empty and thus won't match `postSelector` even though they are actually posts.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
This one might be best to treat as a "just look at the diff," honestly? Or, more accurately, "hey, can't be worse than it was before." But I committed the code I was using with a bunch of random logging and a simulation of having a lot more recommended posts.
