### PR TITLE
User util: Improve extension load speed

### DIFF
--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -1,14 +1,18 @@
 import { apiFetch } from './tumblr_helpers.js';
 
-const fetchedUserInfo = await apiFetch('/v2/user/info').catch((error) => {
-  console.error(error);
-  return { response: {} };
-});
-
-const fetchedCommunitiesInfo = await apiFetch('/v2/communities').catch((error) => {
-  console.error(error);
-  return { response: [] };
-});
+const [
+  fetchedUserInfo,
+  fetchedCommunitiesInfo
+] = await Promise.all([
+  apiFetch('/v2/user/info').catch((error) => {
+    console.error(error);
+    return { response: {} };
+  }),
+  apiFetch('/v2/communities').catch((error) => {
+    console.error(error);
+    return { response: [] };
+  })
+]);
 
 /**
  * {object?} userInfo - The contents of the /v2/user/info API endpoint


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This takes around 100ms off the extension's initial load speed by performing both fetches in the user util at once.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm basic extension functionality.
- Modify the communities API URL so that it's incorrect and its fetch will fail. Confirm that Quick Reblog does not have communities as reblog targets, but that the extension continues to function otherwise.

