### PR TITLE
Fix Quick Reblog double reblogs after extension update/restart (alternative 1)

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -86,16 +86,6 @@
     return installedScripts;
   };
 
-  const initMainWorld = () => new Promise(resolve => {
-    document.documentElement.addEventListener('xkitinjectionready', resolve, { once: true });
-
-    const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
-    const script = document.createElement('script');
-    script.nonce = nonce;
-    script.src = browser.runtime.getURL('/main_world/index.js');
-    document.documentElement.append(script);
-  });
-
   const init = async function () {
     $('style.xkit').remove();
 
@@ -106,15 +96,14 @@
       { enabledScripts = [] }
     ] = await Promise.all([
       getInstalledScripts(),
-      browser.storage.local.get('enabledScripts'),
-      initMainWorld()
+      browser.storage.local.get('enabledScripts')
     ]);
 
     /**
      * fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await
      * @see https://github.com/sveltejs/kit/issues/7805#issuecomment-1330078207
      */
-    await Promise.all(['css_map', 'language_data', 'user'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
+    await Promise.all(['inject', 'css_map', 'language_data', 'user'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
 
     installedScripts
       .filter(scriptName => enabledScripts.includes(scriptName))

--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -1,9 +1,10 @@
 'use strict';
 
 {
+  const { injectKey } = document.currentScript.dataset;
   const moduleCache = {};
 
-  document.documentElement.addEventListener('xkitinjectionrequest', async event => {
+  document.documentElement.addEventListener(`xkitinjectionrequest-${injectKey}`, async event => {
     const { detail, target } = event;
     const { id, path, args } = JSON.parse(detail);
 
@@ -15,11 +16,11 @@
 
       const result = await func.apply(target, args);
       target.dispatchEvent(
-        new CustomEvent('xkitinjectionresponse', { detail: JSON.stringify({ id, result }) })
+        new CustomEvent(`xkitinjectionresponse-${injectKey}`, { detail: JSON.stringify({ id, result }) })
       );
     } catch (exception) {
       target.dispatchEvent(
-        new CustomEvent('xkitinjectionresponse', {
+        new CustomEvent(`xkitinjectionresponse-${injectKey}`, {
           detail: JSON.stringify({
             id,
             exception: {
@@ -34,5 +35,5 @@
     }
   });
 
-  document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready'));
+  document.documentElement.dispatchEvent(new CustomEvent(`xkitinjectionready-${injectKey}`));
 }

--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -1,3 +1,13 @@
+await new Promise(resolve => {
+  document.documentElement.addEventListener('xkitinjectionready', resolve, { once: true });
+
+  const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
+  const script = document.createElement('script');
+  script.nonce = nonce;
+  script.src = browser.runtime.getURL('/main_world/index.js');
+  document.documentElement.append(script);
+});
+
 /**
  * Runs a script in the page's "main" execution environment and returns its result.
  * This permits access to variables exposed by the Tumblr web platform that are normally inaccessible

--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -1,9 +1,14 @@
+import { getRandomHexString } from './crypto.js';
+
+const injectKey = getRandomHexString();
+
 await new Promise(resolve => {
-  document.documentElement.addEventListener('xkitinjectionready', resolve, { once: true });
+  document.documentElement.addEventListener(`xkitinjectionready-${injectKey}`, resolve, { once: true });
 
   const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
   const script = document.createElement('script');
   script.nonce = nonce;
+  script.dataset.injectKey = injectKey;
   script.src = browser.runtime.getURL('/main_world/index.js');
   document.documentElement.append(script);
 });
@@ -27,12 +32,12 @@ export const inject = (path, args = [], target = document.documentElement) =>
       const { id, result, exception } = JSON.parse(detail);
       if (id !== requestId) return;
 
-      target.removeEventListener('xkitinjectionresponse', responseHandler);
+      target.removeEventListener(`xkitinjectionresponse-${injectKey}`, responseHandler);
       exception ? reject(exception) : resolve(result);
     };
-    target.addEventListener('xkitinjectionresponse', responseHandler);
+    target.addEventListener(`xkitinjectionresponse-${injectKey}`, responseHandler);
 
     target.dispatchEvent(
-      new CustomEvent('xkitinjectionrequest', { detail: JSON.stringify(data), bubbles: true })
+      new CustomEvent(`xkitinjectionrequest-${injectKey}`, { detail: JSON.stringify(data), bubbles: true })
     );
   });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Resolves  #1597. See issue for background.

As mentioned, one way to prevent this problem is to communicate a unique key to the main world handler function by putting a data attribute on the script element, and appending the key to the event types. There are probably other methods.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Load the extension in Firefox.
- Turn the extension on and off a large number of times.
- Reblog a post with Quick Reblog and confirm that it is only reblogged once.
