### PR TITLE
 Fix Quick Reblog double reblogs after extension update/restart (alternative 2)

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -86,16 +86,6 @@
     return installedScripts;
   };
 
-  const initMainWorld = () => new Promise(resolve => {
-    document.documentElement.addEventListener('xkitinjectionready', resolve, { once: true });
-
-    const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
-    const script = document.createElement('script');
-    script.nonce = nonce;
-    script.src = browser.runtime.getURL('/main_world/index.js');
-    document.documentElement.append(script);
-  });
-
   const init = async function () {
     $('style.xkit').remove();
 
@@ -106,15 +96,14 @@
       { enabledScripts = [] }
     ] = await Promise.all([
       getInstalledScripts(),
-      browser.storage.local.get('enabledScripts'),
-      initMainWorld()
+      browser.storage.local.get('enabledScripts')
     ]);
 
     /**
      * fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await
      * @see https://github.com/sveltejs/kit/issues/7805#issuecomment-1330078207
      */
-    await Promise.all(['css_map', 'language_data', 'user'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
+    await Promise.all(['inject', 'css_map', 'language_data', 'user'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
 
     installedScripts
       .filter(scriptName => enabledScripts.includes(scriptName))

--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -2,10 +2,12 @@
 
 {
   const moduleCache = {};
+  const injectKey = Math.random();
 
   document.documentElement.addEventListener('xkitinjectionrequest', async event => {
     const { detail, target } = event;
-    const { id, path, args } = JSON.parse(detail);
+    const { injectKey: requestInjectKey, id, path, args } = JSON.parse(detail);
+    if (injectKey !== requestInjectKey) return;
 
     try {
       moduleCache[path] ??= await import(path);
@@ -34,5 +36,5 @@
     }
   });
 
-  document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready'));
+  document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready', { detail: JSON.stringify({ injectKey }) }));
 }

--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -1,5 +1,10 @@
+let injectKey;
+
 await new Promise(resolve => {
-  document.documentElement.addEventListener('xkitinjectionready', resolve, { once: true });
+  document.documentElement.addEventListener('xkitinjectionready', ({ detail }) => {
+    ({ injectKey } = JSON.parse(detail));
+    resolve();
+  }, { once: true });
 
   const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
   const script = document.createElement('script');
@@ -21,7 +26,7 @@ await new Promise(resolve => {
 export const inject = (path, args = [], target = document.documentElement) =>
   new Promise((resolve, reject) => {
     const requestId = String(Math.random());
-    const data = { path: browser.runtime.getURL(path), args, id: requestId };
+    const data = { path: browser.runtime.getURL(path), args, injectKey, id: requestId };
 
     const responseHandler = ({ detail }) => {
       const { id, result, exception } = JSON.parse(detail);

--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -1,3 +1,13 @@
+await new Promise(resolve => {
+  document.documentElement.addEventListener('xkitinjectionready', resolve, { once: true });
+
+  const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
+  const script = document.createElement('script');
+  script.nonce = nonce;
+  script.src = browser.runtime.getURL('/main_world/index.js');
+  document.documentElement.append(script);
+});
+
 /**
  * Runs a script in the page's "main" execution environment and returns its result.
  * This permits access to variables exposed by the Tumblr web platform that are normally inaccessible


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Resolves https://github.com/AprilSylph/XKit-Rewritten/issues/1597. See issue for background.

Another way to prevent this problem is to communicate a unique key from the main world handler function to the content script by including it in the `xkitinjectionready` event, and including the key in the request data.

Off the top of my head, this seems slightly worse than #1598; it's still not compatible with #1538. It might have an advantage I'm not thinking of, so I'm committing it for completeness.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Load the extension in Firefox.
- Turn the extension on and off a large number of times.
- Reblog a post with Quick Reblog and confirm that it is only reblogged once.
