### PR TITLE
Fix Quick Reblog double reblogs after extension update/restart (alternative 3)

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -87,7 +87,7 @@
   };
 
   const initMainWorld = () => new Promise(resolve => {
-    document.documentElement.addEventListener('xkitinjectionready', resolve, { once: true });
+    document.documentElement.addEventListener('xkit-injection-ready', resolve, { once: true });
 
     const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
     const script = document.createElement('script');

--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -3,7 +3,7 @@
 {
   const moduleCache = {};
 
-  document.documentElement.addEventListener('xkitinjectionrequest', async event => {
+  document.documentElement.addEventListener('xkit-injection-request', async event => {
     const { detail, target } = event;
     const { id, path, args } = JSON.parse(detail);
 
@@ -15,11 +15,11 @@
 
       const result = await func.apply(target, args);
       target.dispatchEvent(
-        new CustomEvent('xkitinjectionresponse', { detail: JSON.stringify({ id, result }) })
+        new CustomEvent('xkit-injection-response', { detail: JSON.stringify({ id, result }) })
       );
     } catch (exception) {
       target.dispatchEvent(
-        new CustomEvent('xkitinjectionresponse', {
+        new CustomEvent('xkit-injection-response', {
           detail: JSON.stringify({
             id,
             exception: {
@@ -34,5 +34,5 @@
     }
   });
 
-  document.documentElement.dispatchEvent(new CustomEvent('xkitinjectionready'));
+  document.documentElement.dispatchEvent(new CustomEvent('xkit-injection-ready'));
 }

--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -2,8 +2,11 @@
 
 {
   const moduleCache = {};
+  const xkitMainWorldKey = Math.random();
+  window.xkitMainWorldKey = xkitMainWorldKey;
 
   document.documentElement.addEventListener('xkit-injection-request', async event => {
+    if (window.xkitMainWorldKey !== xkitMainWorldKey) return;
     const { detail, target } = event;
     const { id, path, args } = JSON.parse(detail);
 

--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -17,12 +17,12 @@ export const inject = (path, args = [], target = document.documentElement) =>
       const { id, result, exception } = JSON.parse(detail);
       if (id !== requestId) return;
 
-      target.removeEventListener('xkitinjectionresponse', responseHandler);
+      target.removeEventListener('xkit-injection-response', responseHandler);
       exception ? reject(exception) : resolve(result);
     };
-    target.addEventListener('xkitinjectionresponse', responseHandler);
+    target.addEventListener('xkit-injection-response', responseHandler);
 
     target.dispatchEvent(
-      new CustomEvent('xkitinjectionrequest', { detail: JSON.stringify(data), bubbles: true })
+      new CustomEvent('xkit-injection-request', { detail: JSON.stringify(data), bubbles: true })
     );
   });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Resolves  #1597. See issue for background.

One simple, self-contained way to prevent this problem is to have only the last-registered event listener actually respond to the event by overwriting a key on `window` each time we register a new listener. This is compatible with #1538, as it requires no communication between the main world script(s) and content script, but it feels a little inelegant.

This won't apply to the instance where a version of the code without this PR merged is replaced by one with it, so this also changes the custom event names to handle that case.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Load the extension in Firefox.
- Turn the extension on and off a large number of times.
- Reblog a post with Quick Reblog and confirm that it is only reblogged once.

