### PR TITLE
Mass Privater: Display total fetched count without filtering

### DIFF
--- a/src/features/mass_privater.js
+++ b/src/features/mass_privater.js
@@ -192,26 +192,24 @@ const privatePosts = async ({ uuid, name, tags, before }) => {
     ]
   });
 
-  const allPostIdsSet = new Set();
+  let fetchedPosts = 0;
   const filteredPostIdsSet = new Set();
 
   const collect = async resource => {
     while (resource) {
       await Promise.all([
         apiFetch(resource).then(({ response }) => {
-          const posts = response.posts
+          response.posts
             .filter(({ canEdit }) => canEdit === true)
-            .filter(({ state }) => state === 'published');
-
-          posts.forEach(({ id }) => allPostIdsSet.add(id));
-
-          posts
+            .filter(({ state }) => state === 'published')
             .filter(({ timestamp }) => timestamp < before)
             .forEach(({ id }) => filteredPostIdsSet.add(id));
 
+          fetchedPosts += response.posts.length;
+
           resource = response.links?.next?.href;
 
-          gatherStatus.textContent = `Found ${filteredPostIdsSet.size} posts (checked ${allPostIdsSet.size})${resource ? '...' : '.'}`;
+          gatherStatus.textContent = `Found ${filteredPostIdsSet.size} posts (checked ${fetchedPosts})${resource ? '...' : '.'}`;
         }),
         sleep(1000)
       ]);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Resolves #1609.

This changes the "checked x" count that Mass Privater shows while fetching posts to include all posts without any filtering, ensuring that it continues to increment in real time even if the posts currently being fetched aren't relevant.

This includes counting the same post multiple times if it has multiple searched tags and gets fetched multiple times; do you think this makes sense? (Maybe it makes "checked x" slightly inaccurate; that could be "fetched x" or "downloaded x" something, I dunno.) There's a tradeoff here.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

I did not really test this, as I don't have enough private posts to notice the difference.

