### PR TITLE
Quick Reblog: Reimplement tag suggestion UI

### DIFF
--- a/src/features/quick_reblog.css
+++ b/src/features/quick_reblog.css
@@ -4,7 +4,6 @@
   box-shadow: 0 0 15px 0 rgba(0,0,0,.5);
   padding: 2px;
   border-radius: 3px;
-  overflow: hidden;
   color: rgb(var(--black));
   font-size: .875rem;
   font-weight: normal;
@@ -138,6 +137,53 @@ div:first-child + span + #quick-reblog,
 
   content: "\2713";
   line-height: 1;
+}
+
+#quick-reblog .tags-input-wrapper > input {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+#quick-reblog .tags-input-wrapper:not(:focus, :focus-within) > .tag-suggestions {
+  display: none;
+}
+
+#quick-reblog .tag-suggestions {
+  position: absolute;
+  z-index: 1;
+  max-width: 250px;
+  margin: 7px;
+  padding: 2px;
+
+  border-radius: 4px;
+  color: rgb(var(--black), 0.65);
+  background-color: rgb(var(--white));
+  box-shadow: 0 0 15px 0 rgba(0, 0, 0, .5);
+}
+
+#quick-reblog .tag-suggestions::before {
+  position: absolute;
+  bottom: 100%;
+  left: 10px;
+
+  content: '';
+  border-left: 9px solid transparent;
+  border-right: 9px solid transparent;
+  border-bottom: 9px solid rgb(var(--white));
+}
+
+#quick-reblog .tag-suggestions > div {
+  max-height: 250px;
+  overflow-y: scroll;
+}
+
+#quick-reblog .tag-suggestions button {
+  padding: 0.75ch 1ch;
+  padding-right: calc(1ch + 1em + 1ch);
+  max-width: 100%;
+
+  overflow-x: hidden;
+  white-space: nowrap;
 }
 
 #quick-reblog .action-buttons {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This manually implements a component similar to the HTML `datalist` element that we're currently using to show the user tag suggestions. This should result in:

- Support for Firefox for Android. Resolves #1611.
- Consistent UI between browsers that we can customize; see the previously linked issue for a buggy example in Kiwi Browser, and note that desktop Firefox and Chrome have noticeably different UI designs (neither of which, imo, look great).
- Suggestions containing only the suggested tag instead of everything in the tags input box. Usable suggestions when there is more than a small amount of content in the tags input box.
- A suggestion box that opens consistently, with a single click, in all browsers. Resolves #1102.

At time of writing, the DOM structure and CSS I created are... uh, let's just say "probably improvable." This feels like one of those PRs that could use the "April fixes everything" special.

<img width="631" src="https://github.com/user-attachments/assets/6821be45-785d-4d98-9e15-f05fee4493df">


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Needs further testing for modal logic edge cases. Needs further testing for overflow (e.g. with long suggested tags/many suggested tags)

