### PR TITLE
Fix page title not being updated when navigating

### DIFF
--- a/src/features/tweaks/hide_following_notification_badge.js
+++ b/src/features/tweaks/hide_following_notification_badge.js
@@ -15,10 +15,14 @@ export const styleElement = buildStyle(`
 }
 `);
 
-const onTitleChanged = ([titleElement]) => {
+const onTitleChanged = () => {
+  const titleElement = document.querySelector('head title:not([data-xkit])');
+
   const rawTitle = titleElement.textContent;
   const newTitle = rawTitle.replace(/^\(\d{1,2}\) /, '');
   customTitleElement.textContent = newTitle;
+
+  new MutationObserver(onTitleChanged).observe(titleElement, { characterData: true, subtree: true });
 };
 
 export const main = async () => {

--- a/src/features/tweaks/hide_following_notification_badge.js
+++ b/src/features/tweaks/hide_following_notification_badge.js
@@ -22,8 +22,9 @@ const onTitleChanged = () => {
   const newTitle = rawTitle.replace(/^\(\d{1,2}\) /, '');
   customTitleElement.textContent = newTitle;
 
-  new MutationObserver(onTitleChanged).observe(titleElement, { characterData: true, subtree: true });
+  observer.observe(titleElement, { characterData: true, subtree: true });
 };
+const observer = new MutationObserver(onTitleChanged);
 
 export const main = async () => {
   pageModifications.register('head title:not([data-xkit])', onTitleChanged);


### PR DESCRIPTION
> I thought I remember instances in which the React code modified the title element rather than replacing it (and why wouldn't it, after all, if that's the minimal DOM diff). That being said...

_Originally posted by @marcustyphoon in https://github.com/AprilSylph/XKit-Rewritten/issues/1360#issuecomment-1922832314_

Yeah, I don't know why I ever believed we wouldn't have to handle that case.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

When navigating from one tagged page to another, with our "Hide the Home/Following unread count" tweak enabled, the page title is not updated due to limitations in the code that detects the page title changing.

This fixes this by observing changes to the title element as well as its replacement, as my original code did.

Resolves #1613.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Enable the "Hide the Home/Following unread count" tweak
- Navigate to a tagged page
- Navigate to another tagged page by clicking on a tag or clicking a Tag Tracking+ sidebar item
- Confirm that the page title corresponds with the current page (and does not include an unread count)
