### PR TITLE
Prevent errors in console during queue rearranging

### DIFF
--- a/src/utils/mutations.js
+++ b/src/utils/mutations.js
@@ -56,7 +56,7 @@ export const pageModifications = Object.freeze({
 });
 
 export const onNewPosts = Object.freeze({
-  addListener: callback => pageModifications.register(`${postSelector} article`, callback),
+  addListener: callback => pageModifications.register(`${postSelector}:not(.sortable-fallback) article`, callback),
   removeListener: callback => pageModifications.unregister(callback)
 });
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Clicking and dragging a post in your queue to rearrange it (either in the queue "channel" page or in patio) generates a ghost post that will throw errors if our react data getters are called on it. Well, technically that's inaccurate; the thing that's created that would be accurately referred to as a "ghost" post is fine; the post that errors is the "fallback" post. Yes, I read the sortablejs readme; no it didn't make it at all clear to me which element is which. Whatever.

Anyway, this excludes the post in question from triggering `onNewPosts` handlers.

Resolves #1070.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Click and drag to rearrange a queued post on `https://www.tumblr.com/blog/[blogname]/queue`. Confirm that no errors appear in the javascript console.
- Click and drag to rearrange a queued post on tumblr patio. Confirm that no errors appear in the javascript console.

