### PR TITLE
Meatballs util: Fix blog meatball items not being removed

### DIFF
--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -108,7 +108,7 @@ const addPostMeatballItem = async meatballMenu => {
 const addBlogMeatballItem = async meatballMenu => {
   const __blogData = await blogData(meatballMenu);
 
-  $(meatballMenu).children('[data-xkit-meatball-button]').remove();
+  $(meatballMenu).children('[data-xkit-blog-meatball-button]').remove();
 
   Object.keys(blogMeatballItems).sort().forEach(id => {
     const { label, onClick, blogFilter } = blogMeatballItems[id];


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Fixes an obvious typo in my blog-meatball-menu-item code that prevents the removal of outdated items.

Resolves #1140.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Not tested (we don't currently have a script that uses this part of the util). Could be tested by merging the Mute PR, opening a blog meatball menu, changing a Mute setting with it open, and confirming that the menu item is no longer duplicated when the feature restarts.