### PR TITLE
Fix static styles failing to update

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -6,6 +6,8 @@
 
   const restartListeners = {};
 
+  const randomId = Math.random();
+
   const runScript = async function (name) {
     const scriptPath = browser.runtime.getURL(`/features/${name}.js`);
     const { main, clean, stylesheet, styleElement, onStorageChanged } = await import(scriptPath);
@@ -16,8 +18,9 @@
     if (stylesheet) {
       const link = Object.assign(document.createElement('link'), {
         rel: 'stylesheet',
-        href: browser.runtime.getURL(`/features/${name}.css`)
+        href: browser.runtime.getURL(`/features/${name}.css?v=${randomId}`)
       });
+      link.className = 'xkit';
       document.documentElement.appendChild(link);
     }
     if (styleElement) {
@@ -50,7 +53,7 @@
       clean().catch(console.error);
     }
     if (stylesheet) {
-      document.querySelector(`link[href="${browser.runtime.getURL(`/features/${name}.css`)}"]`)?.remove();
+      document.querySelector(`link[href^="${browser.runtime.getURL(`/features/${name}.css`)}"]`)?.remove();
     }
     if (styleElement) {
       styleElement.remove();
@@ -97,7 +100,7 @@
   });
 
   const init = async function () {
-    $('style.xkit').remove();
+    $('style.xkit, link.xkit').remove();
 
     browser.storage.onChanged.addListener(onStorageChanged);
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

> You wanna know what's really scaring me? The link-element-pointing-to-a-css-file-in-the-extension-package method, when loaded via web-ext run, doesn't even show changes when I press refresh on the page. I have to command-shift-R. Surely that can't reflect the real update experience... right?
> 
> _Originally posted by @marcustyphoon in https://github.com/AprilSylph/XKit-Rewritten/issues/1354#issuecomment-2352212011_

This is what I had to do to get the automatic reload from `web-ext run` to apply changes to static stylesheets included with features: have the load process remove the link element, then add a new link element with a different (cache busted) URL.

Presumably, this resolves #1354. Maybe only one of these two changes would be sufficient to fix the issue in practice; I'm not sure. Both were required when I used web-ext. At some point maybe I'll test just loading the extension as unpacked?

(Not sure if this is technically a performance regression.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Load the extension into Firefox and open Tumblr. Enable a feature with a static stylesheet (say, AccessKit).
- Add something random like `body { border: 10px solid red; }` to the feature stylesheet.
- Reload/update the extension, if you aren't using `web-ext`to doing that for you.
- Confirm that the style is applied.

<br />

- Disable the feature.
- Confirm that the link element is removed and the style is no longer applied.

There may be a more accurate way to simulate an extension update, like loading an old version's xpi. I haven't tried that yet (gotta go find a change to a static stylesheet in the release history that would be really easy to test, especially given other bugs in the Firefox autoupdate process we've recently fixed).
