### PR TITLE
Timeline ID util: Add community patio column ID

### DIFF
--- a/src/utils/timeline_id.js
+++ b/src/utils/timeline_id.js
@@ -53,7 +53,8 @@ export const tagTimelineFilter = tag =>
     timelineId?.match(exactly(`tag-${uuidV4}-${tag}-recent`));
 
 export const anyCommunityTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
-  timelineId?.match(exactly(`communities-${anyBlog}-recent`));
+  timelineId?.match(exactly(`communities-${anyBlog}-recent`)) ||
+  timelineId?.match(exactly(`community-${uuidV4}-${anyBlog}`));
 
 export const communitiesTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
   timelineId === 'communities-for_you';


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Community feeds ~will soon be~ _are_ able to be added to Patio as columns; this adds the relevant timeline ID format.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Add a community column to Tumblr Patio ~via Methods™~. Confirm that Show Originals works on it now.
