### PR TITLE
Tweaks: Improve badge hiding tweak reliability

### DIFF
--- a/src/features/tweaks/hide_activity_notification_badge.js
+++ b/src/features/tweaks/hide_activity_notification_badge.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
 
-const activityButton = `button[aria-label="${translate('Activity')}"]`;
+const activityButton = ':is(button, li):has(use[href="#managed-icon__lightning"])';
 const mobileMenuButton = `button[aria-label="${translate('Menu')}"]`;
 
 export const styleElement = buildStyle(`

--- a/src/features/tweaks/hide_communities_notification_badge.js
+++ b/src/features/tweaks/hide_communities_notification_badge.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
 
-const communitiesButton = `button[aria-label="${translate('Communities')}"]`;
+const communitiesButton = ':is(button, li):has(use[href="#managed-icon__communities"])';
 const mobileMenuButton = `button[aria-label="${translate('Menu')}"]`;
 
 export const styleElement = buildStyle(`

--- a/src/features/tweaks/hide_following_notification_badge.js
+++ b/src/features/tweaks/hide_following_notification_badge.js
@@ -4,7 +4,7 @@ import { buildStyle } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
 import { pageModifications } from '../../utils/mutations.js';
 
-const followingHomeButton = `:is(li[title="${translate('Home')}"], button[aria-label="${translate('Home')}"], a[href="/dashboard/following"])`;
+const followingHomeButton = `:is(li[title="${translate('Home')}"], button[aria-label="${translate('Home')}"], a[href="/dashboard/following"], a[href="/dashboard"])`;
 const mobileMenuButton = `button[aria-label="${translate('Menu')}"]`;
 
 const customTitleElement = dom('title', { 'data-xkit': true });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This improves the badge-hiding tweaks by:
- removing reliance on translation strings that have multiple possible translation values in selectors (checked via https://gist.github.com/marcustyphoon/5cffac5d1c480603696e777632943f3a), ensuring they work in all UI languages
- adding `li` to selectors missing them, an oversight that made them not apply to the mobile menu
- adding an alternative href attribute used for the old (pre-vertical-nav) dashboard, in case anyone is still running that

Resolves  #1461.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Confirm that the notification badge hiding tweaks work:
- in all page widths of the regular desktop layout
- in the mobile layout menu tray
