### PR TITLE
Tweaks: Improve contributed content tweak compatibility

### DIFF
--- a/src/features/tweaks/highlight_contributed_content.js
+++ b/src/features/tweaks/highlight_contributed_content.js
@@ -2,6 +2,6 @@ import { buildStyle } from '../../utils/interface.js';
 
 export const styleElement = buildStyle(`
 [data-is-contributed-content="true"]:not([data-xkit-themed]) {
-  display: flow-root; background-color: rgb(var(--deprecated-accent), 0.1);
+  display: flow-root; background-color: rgb(var(--deprecated-accent), 0.13);
 }
 `);

--- a/src/features/tweaks/highlight_contributed_content.js
+++ b/src/features/tweaks/highlight_contributed_content.js
@@ -4,4 +4,7 @@ export const styleElement = buildStyle(`
 [data-is-contributed-content="true"] {
   display: flow-root; background-color: rgb(var(--deprecated-accent), 0.07);
 }
+:has(+ [data-is-contributed-content="true"]) {
+  display: flow-root; background-color: rgb(var(--blue), 0.07);
+})
 `);

--- a/src/features/tweaks/highlight_contributed_content.js
+++ b/src/features/tweaks/highlight_contributed_content.js
@@ -2,6 +2,6 @@ import { buildStyle } from '../../utils/interface.js';
 
 export const styleElement = buildStyle(`
 [data-is-contributed-content="true"] {
-  display: flow-root; background-color: rgb(var(--follow));
+  display: flow-root; background-color: rgb(var(--deprecated-accent), 0.07);
 }
 `);

--- a/src/features/tweaks/highlight_contributed_content.js
+++ b/src/features/tweaks/highlight_contributed_content.js
@@ -1,7 +1,7 @@
 import { buildStyle } from '../../utils/interface.js';
 
 export const styleElement = buildStyle(`
-[data-is-contributed-content="true"] {
+[data-is-contributed-content="true"]:not([data-xkit-themed]) {
   display: flow-root; background-color: rgb(var(--deprecated-accent), 0.07);
 }
 `);

--- a/src/features/tweaks/highlight_contributed_content.js
+++ b/src/features/tweaks/highlight_contributed_content.js
@@ -2,6 +2,6 @@ import { buildStyle } from '../../utils/interface.js';
 
 export const styleElement = buildStyle(`
 [data-is-contributed-content="true"]:not([data-xkit-themed]) {
-  display: flow-root; background-color: rgb(var(--deprecated-accent), 0.07);
+  display: flow-root; background-color: rgb(var(--deprecated-accent), 0.1);
 }
 `);

--- a/src/features/tweaks/highlight_contributed_content.js
+++ b/src/features/tweaks/highlight_contributed_content.js
@@ -4,7 +4,4 @@ export const styleElement = buildStyle(`
 [data-is-contributed-content="true"] {
   display: flow-root; background-color: rgb(var(--deprecated-accent), 0.07);
 }
-:has(+ [data-is-contributed-content="true"]) {
-  display: flow-root; background-color: rgb(var(--blue), 0.07);
-})
 `);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in the linked issue, the "highlight contributed content" tweak looks like it applies a subtle color highlight to the relevant trail item, but it's actually overriding the background with the `follow` palette color, which generally has that effect on most palettes but isn't compatible with customization.

This applies a low-opacity accent color instead. 7% matches more closely with the current color on the True Blue palette, but I like ~10% better in general.

I also tried `blue` instead of `accent`.

> I prefer blue on:
> cement, strongly
> 
> I prefer deprecated-accent on:
> vampire, moderately
> goth rave, slightly

Most notably, though we override `accent` in Themed Posts, but we don't override `blue`, so `accent` gives more stable results.

In addition, this disables the tweak's effect entirely when Themed Posts' "Theme every reblog trail item individually" setting is enabled; I guess it could make sense not to do this since it'll still work when people have default blog themes? It seems like a lot of the time it would be pointless, though.

Resolves #873.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

The "alternative color demo" commit demos a way to add a second color option and compare side-by-side; one can find a post with a decent reblog chain and shift-P through different palettes.

- Confirm that contributed content trail items look reasonable with Themed Posts disabled in each palette.
- Confirm that contributed content trail items look reasonable with Themed Posts enabled. (Changing palettes should have no effect.)

