### PR TITLE
Quick Reblog: Respect user community sort order

### DIFF
--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -49,10 +49,20 @@ export const adminBlogs = userInfo?.blogs?.filter(blog => blog.admin) ?? [];
  */
 export const adminBlogNames = adminBlogs.map(blog => blog.name);
 
+let communitiesOrder = [];
+try {
+  communitiesOrder = JSON.parse(localStorage.getItem('sortableCommunitiesOrder'));
+} catch {}
+
+const getOrder = community => {
+  const index = communitiesOrder.indexOf(community.name);
+  return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+};
+
 /**
  * {object?} joinedCommunities - An array of community objects the current user has joined
  */
-export const joinedCommunities = fetchedCommunitiesInfo.response;
+export const joinedCommunities = [...fetchedCommunitiesInfo.response].sort((a, b) => getOrder(a) - getOrder(b));
 
 /**
  * {string[]} joinedCommunityUuids - An array of community uuids the current user has joined

--- a/src/utils/user.js
+++ b/src/utils/user.js
@@ -51,7 +51,7 @@ export const adminBlogNames = adminBlogs.map(blog => blog.name);
 
 let communitiesOrder = [];
 try {
-  communitiesOrder = JSON.parse(localStorage.getItem('sortableCommunitiesOrder'));
+  communitiesOrder = JSON.parse(localStorage.getItem('sortableCommunitiesOrder')) ?? [];
 } catch {}
 
 const getOrder = community => {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adjusts the order of the user's communities (i.e. in Quick Reblog) to match the order the user has chosen in the sidebar. Tumblr saves this on a per-browser basis. (If it's in the roadmap to move this ordering to the server soon, this of course makes little sense to merge.)

Really feels like `indexOf` would default to undefined instead of -1 if implemented today, don't you think?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Join multiple communities.
- Confirm that Quick Reblog lists communities in the same order in which they appear in the Tumblr sidebar.
- Change the order of the communities in the Tumblr sidebar.
- Refresh the page.
- Confirm that Quick Reblog lists communities in the same order in which they appear in the Tumblr sidebar.

<br />

- Edit an error into the JSON.parse block. Confirm that Quick Reblog still works, listing communities in the default (alphabetocal by name) order.
- Edit `communitiesOrder` to only contain a subset of your communities. Confirm that Quick Reblog still works, listing included communities in order, followed by the rest.
