### PR TITLE
No Recommended: Hide recommended communities feature

### DIFF
--- a/src/features/no_recommended.json
+++ b/src/features/no_recommended.json
@@ -28,6 +28,11 @@
       "label": "Hide recommended tags between posts",
       "default": false
     },
+    "hide_community_carousels": {
+      "type": "checkbox",
+      "label": "Hide recommended communities between posts",
+      "default": false
+    },
     "hide_lightbox_related": {
       "type": "checkbox",
       "label": "Hide related posts in the photo lightbox",

--- a/src/features/no_recommended/hide_community_carousels.js
+++ b/src/features/no_recommended/hide_community_carousels.js
@@ -1,0 +1,36 @@
+import { keyToCss } from '../../utils/css_map.js';
+import { buildStyle, getTimelineItemWrapper } from '../../utils/interface.js';
+import { pageModifications } from '../../utils/mutations.js';
+import { timelineObject } from '../../utils/react_props.js';
+
+const hiddenAttribute = 'data-no-recommended-community-carousels-hidden';
+
+export const styleElement = buildStyle(`
+  [${hiddenAttribute}] { position: relative; }
+  [${hiddenAttribute}] > div { visibility: hidden; position: absolute; max-width: 100%; }
+  [${hiddenAttribute}] > div :is(img, video, canvas) { display: none }
+`);
+
+const carouselSelector = `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')}`;
+
+const hideCommunityCarousels = carousels =>
+  carousels.forEach(async carousel => {
+    const { elements } = await timelineObject(carousel);
+    if (elements.some(({ objectType }) => objectType === 'community_card')) {
+      const timelineItem = getTimelineItemWrapper(carousel);
+      if (timelineItem.previousElementSibling.querySelector(keyToCss('titleObject'))) {
+        timelineItem.setAttribute(hiddenAttribute, '');
+        timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
+      }
+    }
+  });
+
+export const main = async function () {
+  pageModifications.register(carouselSelector, hideCommunityCarousels);
+};
+
+export const clean = async function () {
+  pageModifications.unregister(hideCommunityCarousels);
+
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
+};


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

~~Not currently tested; I've never seen one of these and extrapolated the format by looking at the code.~~

Adds an option to No Recommended to hide the recommended community carousels on the For You page.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

