### PR TITLE
Remove unused chrome-webstore-upload args

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,7 +46,7 @@ jobs:
         run: npm ci
 
       - name: Upload to Web Store
-        run: npx chrome-webstore-upload upload --source=src/ --auto-publish
+        run: npx chrome-webstore-upload --source=src/
         env:
           EXTENSION_ID: ${{ secrets.EXTENSION_ID }}
           CLIENT_ID: ${{ secrets.CLIENT_ID }}


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in https://github.com/fregante/chrome-webstore-upload-cli/releases/tag/v3.2.0, as of that version, the combination of `upload` and `--auto-publish` arguments to `chrome-webstore-upload` is the default and can be removed. This does so.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
n/a
