### PR TITLE
Vanilla Video: Fix possible post overlap

### DIFF
--- a/src/features/vanilla_video.js
+++ b/src/features/vanilla_video.js
@@ -18,6 +18,10 @@ const cloneVideoElements = videoElements => videoElements.forEach(videoElement =
   });
   newVideoElement.setAttribute('playsinline', true);
 
+  if (videoElement.width && videoElement.height) {
+    newVideoElement.style.setProperty('aspect-ratio', `${videoElement.width} / ${videoElement.height}`);
+  }
+
   const videoSources = [...videoElement.children];
   newVideoElement.append(
     ...videoSources.map(sourceElement => sourceElement.cloneNode(true))


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in the linked issue, when running Vanilla Video with endless scrolling enabled it's possible for posts to overlap each other in certain circumstances. I never truly figured out what sequence of events occurs here, but there must be a time at which the Tumblr code reads the height of a post element containing a video, gets that the video is too short (the default vertical height of a video element), uses that to place the next post, and doesn't update this once the video poster and/or source load in and change the video element height.

This solves this by setting the aspect ratio of the Vanilla Videos video element before inserting it, ensuring that there's no way for its height to ever be rendered as another value.

In theory, we could probably add an onload function that removes the CSS property this adds, ensuring that if for some reason the width/height values set on the video element by redpop differ from the actual resulting video's size they'll be ignored. I don't know offhand if that ought to be on poster load or on video source load and if there's a difference in detecting those things, though.

Resolves #1646.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- If desired, in Chrome, enable Vanilla Video on the main branch on the search page for "video." Observe that scrolling up and down rapidly may result in overlapping posts.
- In Chrome, enable Vanilla Video with this PR on the search page for "video." Confirm that videos are rendered correctly and that scrolling up and down slowly/rapidly does not result in overlapping posts.
- In Firefox, enable Vanilla Video with this PR on the search page for "video." Confirm that videos are rendered correctly and that scrolling up and down slowly/rapidly does not result in overlapping posts. (This PR should be a no-op on Firefox, as its video elements don't appear to cause the linked issue.)


