### PR TITLE
Quote Replies: Add action buttons to replies in post notes

### DIFF
--- a/src/main_world/test_parent_element.js
+++ b/src/main_world/test_parent_element.js
@@ -1,0 +1,13 @@
+export default function testParentElement (selector) {
+  const menuElement = this;
+  const reactKey = Object.keys(menuElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = menuElement[reactKey];
+
+  while (fiber !== null) {
+    if (fiber.stateNode?.matches?.(selector)) {
+      return true;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+}

--- a/src/main_world/unbury_note_props.js
+++ b/src/main_world/unbury_note_props.js
@@ -1,0 +1,16 @@
+export default function unburyNoteProps () {
+  const noteElement = this;
+  const reactKey = Object.keys(noteElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = noteElement[reactKey];
+
+  const results = {};
+  while (fiber !== null) {
+    const props = fiber.memoizedProps || {};
+    if (typeof props?.note?.replyId === 'string') {
+      // returns the last set of props corresponding to each replyId, which contains the most information
+      results[props.note.replyId] = props;
+    }
+    fiber = fiber.return;
+  }
+  return Object.values(results);
+}

--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -3,13 +3,14 @@ import { dom } from './dom.js';
 import { postSelector } from './interface.js';
 import { pageModifications } from './mutations.js';
 import { inject } from './inject.js';
-import { blogData, timelineObject } from './react_props.js';
+import { blogData, notePropsObjects, timelineObject } from './react_props.js';
 
 const postHeaderSelector = `${postSelector} article > header`;
 const blogHeaderSelector = `[style*="--blog-title-color"] > div > div > header, ${keyToCss('blogCardHeaderBar')}`;
 
 const meatballItems = {};
 const blogMeatballItems = {};
+const replyMeatballItems = {};
 
 /**
  * Add a custom button to posts' meatball menus.
@@ -47,6 +48,24 @@ export const unregisterBlogMeatballItem = id => {
   $(`[data-xkit-blog-meatball-button="${id}"]`).remove();
 };
 
+/**
+ * Add a custom button to post replies' meatball menus.
+ * @param {object} options - Destructured
+ * @param {string} options.id - Identifier for this button (must be unique)
+ * @param {string|Function} options.label - Button text to display. May be a function accepting the note component props data of the reply element being actioned on.
+ * @param {Function} options.onClick - Button click listener function
+ * @param {Function} [options.notePropsFilter] - Filter function, called with the note component props data of the reply element being actioned on. Must return true for button to be added.
+ */
+export const registerReplyMeatballItem = function ({ id, label, onClick, notePropsFilter }) {
+  replyMeatballItems[id] = { label, onClick, notePropsFilter };
+  pageModifications.trigger(addMeatballItems);
+};
+
+export const unregisterReplyMeatballItem = id => {
+  delete replyMeatballItems[id];
+  $(`[data-xkit-reply-meatball-button="${id}"]`).remove();
+};
+
 const addMeatballItems = meatballMenus => meatballMenus.forEach(async meatballMenu => {
   const inPostHeader = await inject('/main_world/test_header_element.js', [postHeaderSelector], meatballMenu);
   if (inPostHeader) {
@@ -56,6 +75,11 @@ const addMeatballItems = meatballMenus => meatballMenus.forEach(async meatballMe
   const inBlogHeader = await inject('/main_world/test_header_element.js', [blogHeaderSelector], meatballMenu);
   if (inBlogHeader) {
     addBlogMeatballItem(meatballMenu);
+    return;
+  }
+  const inPostFooter = await inject('/main_world/test_parent_element.js', ['footer *'], meatballMenu);
+  if (inPostFooter) {
+    addPostFooterMeatballItem(meatballMenu);
   }
 });
 
@@ -149,6 +173,54 @@ const addBlogMeatballItem = async meatballMenu => {
 
     meatballMenu.append(meatballItemButton);
   });
+};
+
+const addPostFooterMeatballItem = async meatballMenu => {
+  const __notePropsData = await notePropsObjects(meatballMenu);
+
+  if (__notePropsData[0]?.note?.type === 'reply') {
+    $(meatballMenu).children('[data-xkit-reply-meatball-button]').remove();
+
+    Object.keys(replyMeatballItems).sort().forEach(id => {
+      const { label, onclick, notePropsFilter } = replyMeatballItems[id];
+
+      const meatballItemButton = dom('button', {
+        class: 'xkit-meatball-button',
+        'data-xkit-reply-meatball-button': id,
+        hidden: true
+      }, {
+        click: onclick
+      }, [
+        '\u22EF'
+      ]);
+      meatballItemButton.__notePropsData = __notePropsData;
+
+      if (label instanceof Function) {
+        const labelResult = label(__notePropsData);
+
+        if (labelResult instanceof Promise) {
+          labelResult.then(result => { meatballItemButton.textContent = result; });
+        } else {
+          meatballItemButton.textContent = labelResult;
+        }
+      } else {
+        meatballItemButton.textContent = label;
+      }
+
+      if (notePropsFilter instanceof Function) {
+        const shouldShowItem = notePropsFilter(__notePropsData);
+        meatballItemButton.hidden = shouldShowItem !== true;
+
+        if (shouldShowItem instanceof Promise) {
+          shouldShowItem.then(result => { meatballItemButton.hidden = result !== true; });
+        }
+      } else {
+        meatballItemButton.hidden = false;
+      }
+
+      meatballMenu.append(meatballItemButton);
+    });
+  }
 };
 
 pageModifications.register(keyToCss('meatballMenu'), addMeatballItems);

--- a/src/utils/react_props.js
+++ b/src/utils/react_props.js
@@ -3,6 +3,7 @@ import { primaryBlogName, userBlogNames, adminBlogNames } from './user.js';
 
 const timelineObjectCache = new WeakMap();
 const notificationObjectCache = new WeakMap();
+const notePropsCache = new WeakMap();
 
 /**
  * @param {Element} postElement - An on-screen post
@@ -30,6 +31,21 @@ export const notificationObject = function (notificationElement) {
     );
   }
   return notificationObjectCache.get(notificationElement);
+};
+
+/**
+ * @param {Element} noteElement - An on-screen post note element
+ * @returns {Promise<object[]>} - An array containing the element's buried note component props and, if it is a
+ *                                threaded reply, its parents' buried note component props values
+ */
+export const notePropsObjects = function (noteElement) {
+  if (!notePropsCache.has(noteElement)) {
+    notePropsCache.set(
+      noteElement,
+      inject('/main_world/unbury_note_props.js', [], noteElement)
+    );
+  }
+  return notePropsCache.get(noteElement);
 };
 
 /**


### PR DESCRIPTION
As a bit of an aside to the actual issue in question, https://github.com/AprilSylph/XKit-Rewritten/issues/1655#issuecomment-2518848059 also brought up that it's reasonable to expect Quote Replies to be usable from the replies themselves as well as the activity pane. It doesn't... but we can probably do that!

WIP.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

