### PR TITLE
Tag Tracking+: Improve count clearing consistency

### DIFF
--- a/src/features/tag_tracking_plus.js
+++ b/src/features/tag_tracking_plus.js
@@ -108,6 +108,9 @@ const processPosts = async function (postElements) {
   let updated = false;
 
   for (const postElement of filterPostElements(postElements, { excludeClass, timeline, includeFiltered })) {
+    // see https://github.com/AprilSylph/XKit-Rewritten/issues/1666
+    if (!postElement.isConnected) continue;
+
     const { tags, timestamp } = await timelineObject(postElement);
 
     if (tags.every(tag => tag.toLowerCase() !== currentTag.toLowerCase())) {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

The minimum change required to fix #1666. This skips attempting to process post elements that have already been removed from the page in the count clearing check in Tag Tracking+.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Confirm general feature functionality.
