### PR TITLE
Anti-Capitalism: Make blazed post hiding optional

### DIFF
--- a/src/features/anti_capitalism.js
+++ b/src/features/anti_capitalism.js
@@ -16,7 +16,9 @@ const processVideoCTAs = videoCTAs => videoCTAs
 
 export const main = async () => {
   const { includeBlazed } = await getPreferences('anti_capitalism');
-  const blazeFilter = includeBlazed ? '' : ':not(:has(header use[href="#managed-icon__badge-blaze"], header use[href="#managed-icon__ds-blaze-filled-16"]))';
+  const blazeFilter = includeBlazed
+    ? ''
+    : ':not(:has(header use[href="#managed-icon__ds-blaze-filled-16"]))';
 
   styleElement.textContent = `
     [${hiddenAttribute}] > div,

--- a/src/features/anti_capitalism.js
+++ b/src/features/anti_capitalism.js
@@ -6,12 +6,7 @@ const hiddenAttribute = 'data-anti-capitalism-hidden';
 
 const listTimelineObjectInnerSelector = keyToCss('listTimelineObjectInner');
 
-export const styleElement = buildStyle(`
-[${hiddenAttribute}] > div,
-${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner')} {
-  display: none !important;
-}`
-);
+export const styleElement = buildStyle();
 
 const processVideoCTAs = videoCTAs => videoCTAs
   .map(getTimelineItemWrapper)
@@ -19,6 +14,13 @@ const processVideoCTAs = videoCTAs => videoCTAs
   .forEach(timelineItem => timelineItem.setAttribute(hiddenAttribute, ''));
 
 export const main = async () => {
+  styleElement.textContent = `
+    [${hiddenAttribute}] > div,
+    ${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner')} {
+      display: none !important;
+    }
+  `;
+
   pageModifications.register(
     `
       ${listTimelineObjectInnerSelector}:first-child ${keyToCss('videoCTA', 'videoImageCTA')},

--- a/src/features/anti_capitalism.js
+++ b/src/features/anti_capitalism.js
@@ -1,6 +1,7 @@
 import { keyToCss } from '../utils/css_map.js';
 import { buildStyle, getTimelineItemWrapper } from '../utils/interface.js';
 import { pageModifications } from '../utils/mutations.js';
+import { getPreferences } from '../utils/preferences.js';
 
 const hiddenAttribute = 'data-anti-capitalism-hidden';
 
@@ -14,9 +15,12 @@ const processVideoCTAs = videoCTAs => videoCTAs
   .forEach(timelineItem => timelineItem.setAttribute(hiddenAttribute, ''));
 
 export const main = async () => {
+  const { includeBlazed } = await getPreferences('anti_capitalism');
+  const blazeFilter = includeBlazed ? '' : ':not(:has(header use[href="#managed-icon__badge-blaze"]))';
+
   styleElement.textContent = `
     [${hiddenAttribute}] > div,
-    ${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner')} {
+    ${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner')}${blazeFilter} {
       display: none !important;
     }
   `;
@@ -24,7 +28,7 @@ export const main = async () => {
   pageModifications.register(
     `
       ${listTimelineObjectInnerSelector}:first-child ${keyToCss('videoCTA', 'videoImageCTA')},
-      ${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner')}
+      ${keyToCss('adTimelineObject', 'instreamAd', 'mrecContainer', 'nativeIponWebAd', 'takeoverBanner')}${blazeFilter}
     `,
     processVideoCTAs
   );

--- a/src/features/anti_capitalism.js
+++ b/src/features/anti_capitalism.js
@@ -16,7 +16,7 @@ const processVideoCTAs = videoCTAs => videoCTAs
 
 export const main = async () => {
   const { includeBlazed } = await getPreferences('anti_capitalism');
-  const blazeFilter = includeBlazed ? '' : ':not(:has(header use[href="#managed-icon__badge-blaze"]))';
+  const blazeFilter = includeBlazed ? '' : ':not(:has(header use[href="#managed-icon__badge-blaze"], header use[href="#managed-icon__ds-blaze-filled-16"]))';
 
   styleElement.textContent = `
     [${hiddenAttribute}] > div,

--- a/src/features/anti_capitalism.json
+++ b/src/features/anti_capitalism.json
@@ -7,5 +7,12 @@
     "background_color": "#cd0000"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#anti-capitalism",
-  "relatedTerms": [ "sponsored" ]
+  "relatedTerms": [ "sponsored" ],
+  "preferences": {
+    "includeBlazed": {
+      "type": "checkbox",
+      "label": "Hide blazed posts",
+      "default": true
+    }
+  }
 }

--- a/src/features/anti_capitalism.json
+++ b/src/features/anti_capitalism.json
@@ -11,7 +11,7 @@
   "preferences": {
     "includeBlazed": {
       "type": "checkbox",
-      "label": "Hide blazed posts",
+      "label": "Hide Blazed posts",
       "default": true
     }
   }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Blazed posts are somewhat different than third-party algorithmic advertising, and some users of this feature might want to continue to see them. ~~I'm not actually sure if they still show up with e.g. ublock origin lite enabled (it was hard enough just finding a blazed post to test this on at all), but it's not like one has to do that.~~ **edit:** _ah, managed to get one in testing and they do! nice._

Note that this doesn't apply to the kind of advertisement that appears sort of like a post with a large CTA button at the bottom (not sure if this is what Blaze Pro is). I get these from Tor Books; they do have post ids but do not have the orange blaze icon anywhere.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Find a blazed post on the dashboard. Enable Anti-Capitalism and confirm that the post is hidden only when the checkbox is disabled.
- Find a blazed post on the dashboard with the new post header flag enabled. Enable Anti-Capitalism and confirm that the post is hidden only when the checkbox is disabled.