### PR TITLE
AccessKit Disable GIFs: Remove white background workaround

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -66,6 +66,7 @@ const addLabel = (element, inside = false) => {
 const createCanvas = src => new Promise(resolve => {
   const image = new Image();
   image.src = src;
+  image.crossOrigin = 'anonymous';
   image.onload = () => {
     const canvas = document.createElement('canvas');
     canvas.width = image.naturalWidth;

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -100,7 +100,7 @@ const processGifs = function (gifElements) {
   });
 };
 
-const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.gifv?(?=["']\))/g;
+const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.(?:gif|gifv|webp)(?=["']\))/g;
 
 const pausedUrlCache = {};
 const createPausedUrl = (sourceUrl) => {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -66,7 +66,6 @@ const addLabel = (element, inside = false) => {
 const createCanvas = src => new Promise(resolve => {
   const image = new Image();
   image.src = src;
-  image.crossOrigin = 'anonymous';
   image.onload = () => {
     const canvas = document.createElement('canvas');
     canvas.width = image.naturalWidth;

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -109,14 +109,21 @@ const processGifs = function (gifElements) {
 const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.gifv?(?=["']\))/g;
 
 const pausedUrlCache = {};
-const createPausedUrl = sourceUrl => {
-  pausedUrlCache[sourceUrl] ??= new Promise(resolve =>
-    createCanvas(sourceUrl).then(canvas =>
+const createPausedUrl = (sourceUrl) => {
+  pausedUrlCache[sourceUrl] ??= new Promise(resolve => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.src = sourceUrl;
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      canvas.getContext('2d').drawImage(image, 0, 0);
       canvas.toBlob(blob =>
         resolve(URL.createObjectURL(blob))
-      )
-    )
-  );
+      );
+    };
+  });
   return pausedUrlCache[sourceUrl];
 };
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -63,21 +63,26 @@ const addLabel = (element, inside = false) => {
   }
 };
 
-const pauseGif = function (gifElement) {
+const createCanvas = src => new Promise(resolve => {
   const image = new Image();
-  image.src = gifElement.currentSrc;
+  image.src = src;
   image.onload = () => {
-    if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
-      const canvas = document.createElement('canvas');
-      canvas.width = image.naturalWidth;
-      canvas.height = image.naturalHeight;
-      canvas.className = gifElement.className;
-      canvas.classList.add(canvasClass);
-      canvas.getContext('2d').drawImage(image, 0, 0);
-      gifElement.parentNode.append(canvas);
-      addLabel(gifElement);
-    }
+    const canvas = document.createElement('canvas');
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+    canvas.getContext('2d').drawImage(image, 0, 0);
+    resolve(canvas);
   };
+});
+
+const pauseGif = async function (gifElement) {
+  const canvas = await createCanvas(gifElement.currentSrc);
+  if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
+    canvas.className = gifElement.className;
+    canvas.classList.add(canvasClass);
+    gifElement.parentNode.append(canvas);
+    addLabel(gifElement);
+  }
 };
 
 const processGifs = function (gifElements) {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -112,20 +112,24 @@ const processGifs = function (gifElements) {
 
 const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.gifv?(?=["']\))/g;
 
-const createPausedUrl = (sourceUrl) => new Promise(resolve => {
-  const image = new Image();
-  image.crossOrigin = 'anonymous';
-  image.src = sourceUrl;
-  image.onload = () => {
-    const canvas = document.createElement('canvas');
-    canvas.width = image.naturalWidth;
-    canvas.height = image.naturalHeight;
-    canvas.getContext('2d').drawImage(image, 0, 0);
-    canvas.toBlob(blob =>
-      resolve(URL.createObjectURL(blob))
-    );
-  };
-});
+const pausedUrlCache = {};
+const createPausedUrl = (sourceUrl) => {
+  pausedUrlCache[sourceUrl] ??= new Promise(resolve => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.src = sourceUrl;
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      canvas.getContext('2d').drawImage(image, 0, 0);
+      canvas.toBlob(blob =>
+        resolve(URL.createObjectURL(blob))
+      );
+    };
+  });
+  return pausedUrlCache[sourceUrl];
+};
 
 const processBackgroundGifs = function (gifBackgroundElements) {
   gifBackgroundElements.forEach(async gifBackgroundElement => {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -109,21 +109,14 @@ const processGifs = function (gifElements) {
 const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.gifv?(?=["']\))/g;
 
 const pausedUrlCache = {};
-const createPausedUrl = (sourceUrl) => {
-  pausedUrlCache[sourceUrl] ??= new Promise(resolve => {
-    const image = new Image();
-    image.crossOrigin = 'anonymous';
-    image.src = sourceUrl;
-    image.onload = () => {
-      const canvas = document.createElement('canvas');
-      canvas.width = image.naturalWidth;
-      canvas.height = image.naturalHeight;
-      canvas.getContext('2d').drawImage(image, 0, 0);
+const createPausedUrl = sourceUrl => {
+  pausedUrlCache[sourceUrl] ??= new Promise(resolve =>
+    createCanvas(sourceUrl).then(canvas =>
       canvas.toBlob(blob =>
         resolve(URL.createObjectURL(blob))
-      );
-    };
-  });
+      )
+    )
+  );
   return pausedUrlCache[sourceUrl];
 };
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -63,26 +63,21 @@ const addLabel = (element, inside = false) => {
   }
 };
 
-const createCanvas = src => new Promise(resolve => {
+const pauseGif = function (gifElement) {
   const image = new Image();
-  image.src = src;
+  image.src = gifElement.currentSrc;
   image.onload = () => {
-    const canvas = document.createElement('canvas');
-    canvas.width = image.naturalWidth;
-    canvas.height = image.naturalHeight;
-    canvas.getContext('2d').drawImage(image, 0, 0);
-    resolve(canvas);
+    if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
+      const canvas = document.createElement('canvas');
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      canvas.className = gifElement.className;
+      canvas.classList.add(canvasClass);
+      canvas.getContext('2d').drawImage(image, 0, 0);
+      gifElement.parentNode.append(canvas);
+      addLabel(gifElement);
+    }
   };
-});
-
-const pauseGif = async function (gifElement) {
-  const canvas = await createCanvas(gifElement.currentSrc);
-  if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
-    canvas.className = gifElement.className;
-    canvas.classList.add(canvasClass);
-    gifElement.parentNode.append(canvas);
-    addLabel(gifElement);
-  }
 };
 
 const processGifs = function (gifElements) {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -105,18 +105,18 @@ const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.gifv?(?=["']\))/g;
 const pausedUrlCache = {};
 const createPausedUrl = (sourceUrl) => {
   pausedUrlCache[sourceUrl] ??= new Promise(resolve => {
-    const image = new Image();
-    image.crossOrigin = 'anonymous';
-    image.src = sourceUrl;
-    image.onload = () => {
-      const canvas = document.createElement('canvas');
-      canvas.width = image.naturalWidth;
-      canvas.height = image.naturalHeight;
-      canvas.getContext('2d').drawImage(image, 0, 0);
-      canvas.toBlob(blob =>
-        resolve(URL.createObjectURL(blob))
-      );
-    };
+    fetch(sourceUrl, { headers: { Accept: 'image/webp,*/*' } })
+      .then(response => response.blob())
+      .then(blob => createImageBitmap(blob))
+      .then(imageBitmap => {
+        const canvas = document.createElement('canvas');
+        canvas.width = imageBitmap.width;
+        canvas.height = imageBitmap.height;
+        canvas.getContext('2d').drawImage(imageBitmap, 0, 0);
+        canvas.toBlob(blob =>
+          resolve(URL.createObjectURL(blob))
+        );
+      });
   });
   return pausedUrlCache[sourceUrl];
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -117,7 +117,7 @@ const updateBackgroundStyle = () => {
     .join('\n');
 };
 
-const createPausedCssValue = (sourceValue, sourceUrl) => new Promise(resolve => {
+const createPausedUrl = (sourceUrl) => new Promise(resolve => {
   const image = new Image();
   image.crossOrigin = 'anonymous';
   image.src = sourceUrl;
@@ -126,10 +126,9 @@ const createPausedCssValue = (sourceValue, sourceUrl) => new Promise(resolve => 
     canvas.width = image.naturalWidth;
     canvas.height = image.naturalHeight;
     canvas.getContext('2d').drawImage(image, 0, 0);
-    canvas.toBlob(blob => {
-      const blobUrl = URL.createObjectURL(blob);
-      resolve(sourceValue.replaceAll(sourceUrlRegex, blobUrl));
-    });
+    canvas.toBlob(blob =>
+      resolve(URL.createObjectURL(blob))
+    );
   };
 });
 
@@ -140,7 +139,7 @@ const processBackgroundGifs = function (gifBackgroundElements) {
 
     if (sourceUrl) {
       const id = await sha256(sourceValue);
-      pausedBackgroundImageValues[id] ??= await createPausedCssValue(sourceValue, sourceUrl);
+      pausedBackgroundImageValues[id] ??= sourceValue.replaceAll(sourceUrlRegex, await createPausedUrl(sourceUrl));
       updateBackgroundStyle();
 
       gifBackgroundElement.dataset.disableGifsId = id;

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -7,7 +7,6 @@ const canvasClass = 'xkit-paused-gif-placeholder';
 const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const pausedBackgroundImageVar = '--xkit-paused-gif-background-image';
-const backgroundGifClass = 'xkit-paused-background-gif';
 
 export const styleElement = buildStyle(`
 .${labelClass} {
@@ -50,15 +49,6 @@ export const styleElement = buildStyle(`
 
 [style*="${pausedBackgroundImageVar}"]:not(:hover) {
   background-image: var(${pausedBackgroundImageVar}) !important;
-}
-
-.${backgroundGifClass}:not(:hover) {
-  background-image: none !important;
-  background-color: rgb(var(--secondary-accent));
-}
-
-.${backgroundGifClass}:not(:hover) > div {
-  color: rgb(var(--black));
 }
 `);
 
@@ -141,10 +131,8 @@ const processBackgroundGifs = function (gifBackgroundElements) {
         pausedBackgroundImageVar,
         sourceValue.replaceAll(sourceUrlRegex, await createPausedUrl(sourceUrl))
       );
-    } else {
-      gifBackgroundElement.classList.add(backgroundGifClass);
+      addLabel(gifBackgroundElement, true);
     }
-    addLabel(gifBackgroundElement, true);
   });
 };
 
@@ -191,7 +179,6 @@ export const clean = async function () {
   );
 
   $(`.${canvasClass}, .${labelClass}`).remove();
-  $(`.${backgroundGifClass}`).removeClass(backgroundGifClass);
   [...document.querySelectorAll(`img[style*="${pausedBackgroundImageVar}"]`)]
     .forEach(element => element.style.removeProperty(pausedBackgroundImageVar));
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

We currently have a workaround for "pausing" certain GIF elements (the ones which use CSS `background-image`) where we simply replace the GIF with a white background instead of properly freezing them until they're hovered. It dawned on me, however, that there is a way to pause these properly: a CSS property override replacing the gif URL with a blob URL referencing a de-animated version of the gif, which we can generate from a canvas element.

This implements this. Functionality-wise, it seems to work quite well. Unfortunately, this relies on quite a bit of inelegant string parsing; I assume the regex I wrote can be cleaned up a little bit, but it's still fundamentally quite complex and I don't know of a better way to parse the url out of e.g. `background-image:linear-gradient(rgba(0, 0, 0, 0), rgba(0, 0, 0, 0.8)), url("https://64.media.tumblr.com/e6ca525d90692476df81e72bdd9cdfe5/539b205af19f15b8-ec/s400x600/a1c55d65fb3374ae5945af2a6ec16d429842cacc.gifv")`.

So it's quite cool that it works, but... yeah, I dunno.

Aside: can you use CSS to effectively replace the contents of an `<img>` element? If so, this method could theoretically replace the entire feature and allow for pausing a whole bunch of random elements we currently don't hit (blog header images, search result thumbnails), which would be kind of wild. I think you might be able to? **edit:** Yes, see #1708.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that the gifs in the right column of the tagged page (e.g. https://www.tumblr.com/tagged/gif) and atop the tags search (e.g. https://www.tumblr.com/search/gif?v=tag) are paused correctly and become unpaused when hovered.
