### PR TITLE
AccessKit Disable GIFs: Refactor async callbacks

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -68,21 +68,23 @@ const addLabel = (element, inside = false) => {
   }
 };
 
-const pauseGif = function (gifElement) {
+const pauseGif = async function (gifElement) {
+  await gifElement.decode();
+
   const image = new Image();
   image.src = gifElement.currentSrc;
-  image.onload = () => {
-    if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
-      const canvas = document.createElement('canvas');
-      canvas.width = image.naturalWidth;
-      canvas.height = image.naturalHeight;
-      canvas.className = gifElement.className;
-      canvas.classList.add(canvasClass);
-      canvas.getContext('2d').drawImage(image, 0, 0);
-      gifElement.parentNode.append(canvas);
-      addLabel(gifElement);
-    }
-  };
+  await image.decode();
+
+  if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
+    const canvas = document.createElement('canvas');
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+    canvas.className = gifElement.className;
+    canvas.classList.add(canvasClass);
+    canvas.getContext('2d').drawImage(image, 0, 0);
+    gifElement.parentNode.append(canvas);
+    addLabel(gifElement);
+  }
 };
 
 const processGifs = function (gifElements) {
@@ -96,12 +98,7 @@ const processGifs = function (gifElements) {
       gifElement.after(...pausedGifElements);
       return;
     }
-
-    if (gifElement.complete && gifElement.currentSrc) {
-      pauseGif(gifElement);
-    } else {
-      gifElement.onload = () => pauseGif(gifElement);
-    }
+    pauseGif(gifElement);
   });
 };
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Disable GIFs currently sets some `onload` callbacks to wait for image element sources to be loaded. This replaces them with the [decode() HTMLImageElement instance method](https://developer.mozilla.org/en-US/docs/Web/API/HTMLImageElement/decode) that I found while looking through MDN for something different-but-related, removing some nesting. Conveniently, this doesn't require a conditional for whether the image is already loaded (try `$0.decode().then(() => console.log('done'))` on an already-loaded image).

"Hide whitespace" is recommended.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that Disable GIFs continues to work as expected.

