### PR TITLE
No Recommended: Hide communities in the search dropdown

### DIFF
--- a/src/features/no_recommended.json
+++ b/src/features/no_recommended.json
@@ -33,6 +33,11 @@
       "label": "Hide recommended communities between posts",
       "default": false
     },
+    "hide_search_communities": {
+      "type": "checkbox",
+      "label": "Hide suggested communities in the search dropdown",
+      "default": false
+    },
     "hide_lightbox_related": {
       "type": "checkbox",
       "label": "Hide related posts in the photo lightbox",

--- a/src/features/no_recommended/hide_search_communities.js
+++ b/src/features/no_recommended/hide_search_communities.js
@@ -1,0 +1,7 @@
+import { keyToCss } from '../../utils/css_map.js';
+import { buildStyle } from '../../utils/interface.js';
+import { translate } from '../../utils/language_data.js';
+
+export const styleElement = buildStyle(`
+${keyToCss('typeaheadSection')}:has(> [aria-label="${translate('Suggested communities')}"]) { display: none; }
+`);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Adds a No Recommended feature to hide the "suggested communities" section in the search dropdown ("typeahead", but even I, an ostensible web developer, have no idea what that is).

I was considering instead making a tweak that puts the suggested communities at the bottom of the search dropdown, but thinking about it, no: this is totally internally consistent with the rest of the extension. We don't hide parts of the UI with unique functions or ways to navigate to them; we do hide parts of the UI whose sole purpose is to give algorithmic recommendations, and the place to do that is in No Recommended.

I have checked that "Suggested communities" currently only has one translation by downloading the raw language data.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Enable the new No Recommended checkbox and confirm that the "suggested communities" section of the search dropdown is hidden.
- Confirm that the feature works in the search dropdowns used in the smartphone, tablet, and desktop viewport widths.
- Confirm that the feature works in a different UI language.
