### PR TITLE
chore(deps): remove package-lock.json name property

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "XKit-Rewritten",
       "license": "GPL-3.0",
       "dependencies": {
         "jquery": "^3.7.1",


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Due to https://github.com/npm/cli/issues/4608, a "name" property was added to the package-lock.json file by `npm audit fix` in 01fe042bac00fb5c6d1a3f0a4abd9c1ab45c6fe3 even though `npm install` removes it again.

This commits the diff caused by running `npm install`. Of course, if the linked issue gets resolved in the other direction (always creating a name property in package-lock.json based on the folder name if there is no name in package.json), this would be incorrect, but this is how it is at the moment. (Also, that wouldn't make much sense as a resolution, imho).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
n/a
