### PR TITLE
AccessKit Visible Alt Text: Fix empty captions on GIFs without alt text

### DIFF
--- a/src/features/accesskit/visible_alt_text.js
+++ b/src/features/accesskit/visible_alt_text.js
@@ -26,8 +26,10 @@ const processImages = function (imageElements) {
   const imageBlocks = new Map();
   imageElements.forEach(imageElement => {
     const { alt } = imageElement;
-    const imageBlock = imageElement.closest(imageBlockSelector);
-    imageBlocks.set(imageBlock, alt);
+    if (alt) {
+      const imageBlock = imageElement.closest(imageBlockSelector);
+      imageBlocks.set(imageBlock, alt);
+    }
   });
 
   for (const [imageBlock, alt] of imageBlocks) {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Simple enough.

This skips processing image elements with `alt` attributes that are actually empty strings, treating them the same way we do images without the attribute at all. This fixes empty caption elements being added below GIFs without alt text.

Resolves #1687.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that GIFs in posts that don't have alt text (try https://www.tumblr.com/search/gif) aren't affected by AccessKit Visible Alt Text.
- Confirm that images with alt text (try https://www.tumblr.com/search/described) are still affected by AccessKit Visible Alt Text.
- Confirm that GIFs with alt text (try https://www.tumblr.com/meltknuckles/757727655146799104/a-herd-of-dairy-cow-isopods-grazing-the-great) are still affected by AccessKit Visible Alt Text.

