### PR TITLE
Refactor: Standardize capitalization of "onclick"

### DIFF
--- a/src/features/scroll_to_bottom.js
+++ b/src/features/scroll_to_bottom.js
@@ -56,7 +56,7 @@ const stopScrolling = () => {
   scrollToBottomButton?.classList.remove(activeClass);
 };
 
-const onClick = () => active ? stopScrolling() : startScrolling();
+const onclick = () => active ? stopScrolling() : startScrolling();
 const onKeyDown = ({ key }) => key === '.' && stopScrolling();
 
 const checkForButtonRemoved = () => {
@@ -76,7 +76,7 @@ const addButtonToPage = async function ([scrollToTopButton]) {
     scrollToBottomButton.removeAttribute('aria-label');
     scrollToBottomButton.style.marginTop = '0.5ch';
     scrollToBottomButton.style.transform = 'rotate(180deg)';
-    scrollToBottomButton.addEventListener('click', onClick);
+    scrollToBottomButton.addEventListener('click', onclick);
     scrollToBottomButton.id = scrollToBottomButtonId;
 
     scrollToBottomButton.classList[active ? 'add' : 'remove'](activeClass);

--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -34,11 +34,11 @@ export const unregisterMeatballItem = id => {
  * @param {object} options - Destructured
  * @param {string} options.id - Identifier for this button (must be unique)
  * @param {string|Function} options.label - Button text to display. May be a function accepting the blog data of the post element being actioned on.
- * @param {Function} options.onClick - Button click listener function
+ * @param {Function} options.onclick - Button click listener function
  * @param {Function} [options.blogFilter] - Filter function, called with the blog data of the menu element being actioned on. Must return true for button to be added. Some blog data fields, such as "followed", are not available in blog cards.
  */
-export const registerBlogMeatballItem = function ({ id, label, onClick, blogFilter }) {
-  blogMeatballItems[id] = { label, onClick, blogFilter };
+export const registerBlogMeatballItem = function ({ id, label, onclick, blogFilter }) {
+  blogMeatballItems[id] = { label, onclick, blogFilter };
   pageModifications.trigger(addMeatballItems);
 };
 
@@ -111,14 +111,14 @@ const addBlogMeatballItem = async meatballMenu => {
   $(meatballMenu).children('[data-xkit-blog-meatball-button]').remove();
 
   Object.keys(blogMeatballItems).sort().forEach(id => {
-    const { label, onClick, blogFilter } = blogMeatballItems[id];
+    const { label, onclick, blogFilter } = blogMeatballItems[id];
 
     const meatballItemButton = dom('button', {
       class: 'xkit-meatball-button',
       'data-xkit-blog-meatball-button': id,
       hidden: true
     }, {
-      click: onClick
+      click: onclick
     }, [
       '\u22EF'
     ]);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This standardizes the capitalization of "onclick" to all-lowercase.

For some reason—I think a misguided notion that it was correct and the opposite was a mistake—I used "onClick" in #910, even though it's "onclick" in the utilities exported from the same file. This isn't used in any current feature, but it is used in #677, so that PR must be updated after merging this one.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

