### PR TITLE
Tweaks: Fix "Hide the Communities notification badge" tweak

### DIFF
--- a/src/features/tweaks/hide_communities_notification_badge.js
+++ b/src/features/tweaks/hide_communities_notification_badge.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
 
-const communitiesButton = ':is(button, li):has(use[href="#managed-icon__communities"])';
+const communitiesButton = `button[aria-label="${translate('Communities')}"]`;
 const mobileMenuButton = `button[aria-label="${translate('Menu')}"]`;
 
 export const styleElement = buildStyle(`


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Updates the communities button selector in the "Hide the Communities notification badge" tweak, restoring its functionality.

Resolves #1690.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Confirm that the tweak in question functions in each browser viewport width, including in the mobile drawer.