### PR TITLE
Timeformat: Apply to new communities post header

### DIFF
--- a/src/features/timeformat.js
+++ b/src/features/timeformat.js
@@ -28,7 +28,8 @@ export const styleElement = buildStyle(`
   cursor: help;
 }
 
-${keyToCss('blogLinkWrapper')}:has(+ [data-formatted-time]) {
+${keyToCss('blogLinkWrapper')}:has(+ [data-formatted-time]),
+${keyToCss('info')}:has(+ ${keyToCss('timestamp')} > [data-formatted-time]) {
   flex: none;
 }
 

--- a/src/features/timeformat.js
+++ b/src/features/timeformat.js
@@ -77,7 +77,7 @@ const formatTimeElements = function (timeElements) {
 
 export const main = async function () {
   ({ format, displayRelative } = await getPreferences('timeformat'));
-  pageModifications.register(`${keyToCss('timestamp')}[datetime]`, formatTimeElements);
+  pageModifications.register(`${keyToCss('timestamp')}[datetime], ${keyToCss('timestamp')} > [datetime]`, formatTimeElements);
 };
 
 export const clean = async function () {

--- a/src/features/timeformat.js
+++ b/src/features/timeformat.js
@@ -23,13 +23,31 @@ export const styleElement = buildStyle(`
   display: inline-block;
 }
 
+${keyToCss('userRow')} [data-formatted-time] {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+${keyToCss('userRow')} [data-formatted-time]::before,
+${keyToCss('userRow')} [data-formatted-relative-time]::after {
+  font-size: .875rem;
+}
+
 [data-formatted-time][title]::before,
 [data-formatted-time][title]::after {
   cursor: help;
 }
 
-${keyToCss('blogLinkWrapper')}:has(+ [data-formatted-time]),
-${keyToCss('info')}:has(+ ${keyToCss('timestamp')} > [data-formatted-time]) {
+${keyToCss('userRow')} ${keyToCss('subheader')}:has([data-formatted-time]) {
+  flex-wrap: wrap;
+}
+
+${keyToCss('userRow')} ${keyToCss('timestamp')}:has([data-formatted-time]) {
+  display: flex;
+  flex-wrap: nowrap;
+}
+
+${keyToCss('blogLinkWrapper')}:has(+ [data-formatted-time]) {
   flex: none;
 }
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Applies timeformat to the timestamps in the new unique post header used in tumblr communities (`communitiesRedpopPostChrome`).

~~Not sure if this will break anything else, like mutual checker~~ yes it does.

Is this actually... desirable? I mean, I assume so, though the aesthetics aren't great.

<img width="567" src="https://github.com/user-attachments/assets/fee982c7-1dfd-4cd0-b745-bdc786f97df6">


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that Timeformat works on community posts with the new header (feature flag enabled).
