### PR TITLE
Mutual Checker: Apply to new communities post header

### DIFF
--- a/src/features/mutual_checker.js
+++ b/src/features/mutual_checker.js
@@ -12,7 +12,7 @@ import { followingTimelineSelector } from '../utils/timeline_id.js';
 const mutualIconClass = 'xkit-mutual-icon';
 const hiddenAttribute = 'data-mutual-checker-hidden';
 const mutualsClass = 'from-mutual';
-const postAttributionSelector = `header ${keyToCss('attribution')} a:not(${keyToCss('reblogAttribution', 'rebloggedFromName')} *)`;
+const postAttributionSelector = 'header a[rel="author"]';
 
 const onlyMutualsStyleElement = buildStyle(`${keyToCss('notification')}:not([data-mutuals]) { display: none !important; }`);
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

It appears that it doesn't need to be any more complex than this!

Applies Mutual Checker to the timestamps in the new unique post header used in tumblr communities (`communitiesRedpopPostChrome`) by taking advantage of the `rel="author"` property. I see no reason why additional elements would be added with this property and I assume(?) it's fine to rely on the property not being forgotten/lost in the future?

Resolves #1694.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that Mutual Checker works on community posts with the new header (feature flag enabled).
- Confirm that Mutual Checker works on non-community posts.

I'd like to find a blazed-by-someone-else post to see what happens here (semi-related: #1069) but that's quite unlikely so I may have to just read the code. But, like... eh, who cares, also.
