### PR TITLE
Tweaks: Fix "hide following/mutuals indicators on notifications" option

### DIFF
--- a/src/features/tweaks/hide_activity_mutuals.js
+++ b/src/features/tweaks/hide_activity_mutuals.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle } from '../../utils/interface.js';
 
 export const styleElement = buildStyle(`
-${keyToCss('activity')} ${keyToCss('followingBadgeContainer', 'mutualsBadgeContainer')} {
+${keyToCss('activity', 'activityItem')} ${keyToCss('followingBadgeContainer', 'mutualsBadgeContainer')} {
   display: none;
 }
 `);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in #1658, there is a tweaked Tumblr notification type which breaks some features, like the "hide following/mutuals indicators on notifications" tweak. This fixes this one.

Resolves #1692.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that the feature functions correctly on a new "replied to your post"/"replied to you in a post" notification from a mutual/followed user on both the activity page and in the activity modal.
- Confirm that the feature functions correctly on the classic style of notification (most other notification types) from a mutual/followed user on both the activity page and in the activity modal.
- Confirm that the mutual/following indicators on the communities members page are unaffected.