### PR TITLE
Quick Reblog: Exit cleanly without user info

### DIFF
--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -316,6 +316,7 @@ const preventLongPressMenu = ({ originalEvent: event }) => {
 };
 
 export const main = async function () {
+  if (!userBlogs.find(({ primary }) => primary === true)) return;
   ({
     popupPosition,
     showBlogSelector,

--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -2,7 +2,7 @@ import { sha256 } from '../utils/crypto.js';
 import { timelineObject } from '../utils/react_props.js';
 import { apiFetch } from '../utils/tumblr_helpers.js';
 import { postSelector, filterPostElements, postType, appendWithoutOverflow } from '../utils/interface.js';
-import { joinedCommunities, joinedCommunityUuids, userBlogs } from '../utils/user.js';
+import { joinedCommunities, joinedCommunityUuids, primaryBlog, userBlogs } from '../utils/user.js';
 import { getPreferences } from '../utils/preferences.js';
 import { onNewPosts } from '../utils/mutations.js';
 import { notify } from '../utils/notifications.js';
@@ -316,7 +316,7 @@ const preventLongPressMenu = ({ originalEvent: event }) => {
 };
 
 export const main = async function () {
-  if (!userBlogs.find(({ primary }) => primary === true)) return;
+  if (!primaryBlog) return;
   ({
     popupPosition,
     showBlogSelector,
@@ -348,8 +348,7 @@ export const main = async function () {
       blogHashes.set(uuid, await sha256(uuid));
     }
 
-    const { uuid: primaryUuid } = userBlogs.find(({ primary }) => primary === true);
-    accountKey = blogHashes.get(primaryUuid);
+    accountKey = blogHashes.get(primaryBlog.uuid);
 
     const {
       [rememberedBlogStorageKey]: rememberedBlogs = {}


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Quick Reblog currently:
- Logs a mysterious-looking error to the console if and only if the user is logged out or the user info api fetch fails and the "Remember the last selected blog in the popup" option is enabled.
- Works, but only shows communities as reblog targets, if and only if the user info api fetch fails, the communities info api fetch doesn't fail, **and** the "Remember the last selected blog in the popup" option is disabled.

None of this really makes any sense as error-handling behavior. This PR makes the extension exit cleanly (though we could add a log here) if there is no user info, thus making it so that Quick Reblog:
- Does nothing if the user is logged out.
- Does nothing if the user info api fetch fails.
- Never only shows communities as reblog targets.
- Works, but doesn't show communities as reblog targets, if and only if the user info api fetch works but the communities info api fetch fails (say, if Staff changes that endpoint as part of communities development).

Resolves #1702, though not in the way proposed by the issue text.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that Quick Reblog appears and shows both user blogs and communities as reblog targets.
- Break the user info fetch. Confirm that Quick Reblog does not appear and does not log an error.
- Break the communities info fetch. Confirm that Quick Reblog appears and shows only user blogs reblog targets.
- Log out. Confirm that Quick Reblog does not appear and does not log an error.

