### PR TITLE
AccessKit Disable GIFs: Apply to Tumblr TV landing page

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -66,6 +66,7 @@ const addLabel = (element, inside = false) => {
 const createCanvas = src => new Promise(resolve => {
   const image = new Image();
   image.src = src;
+  image.crossOrigin = 'anonymous';
   image.onload = () => {
     const canvas = document.createElement('canvas');
     canvas.width = image.naturalWidth;

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -123,6 +123,10 @@ const createPausedUrl = (sourceUrl) => {
 
 const processBackgroundGifs = function (gifBackgroundElements) {
   gifBackgroundElements.forEach(async gifBackgroundElement => {
+    // "tumblr tv" video cards may be initially rendered with the wrong background
+    if (!gifBackgroundElement.matches('[style*=".gif"]')) await new Promise(requestAnimationFrame);
+    if (!gifBackgroundElement.matches('[style*=".gif"]')) return;
+
     const sourceValue = gifBackgroundElement.style.backgroundImage;
     const sourceUrl = sourceValue.match(sourceUrlRegex)?.[0];
 
@@ -159,7 +163,7 @@ export const main = async function () {
   pageModifications.register(gifImage, processGifs);
 
   const gifBackgroundImage = `
-    ${keyToCss('communityHeaderImage', 'bannerImage', 'videoHubCardWrapper')}[style*=".gif"]
+    ${keyToCss('communityHeaderImage', 'bannerImage', 'videoHubCardWrapper')}
   `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -66,7 +66,6 @@ const addLabel = (element, inside = false) => {
 const createCanvas = src => new Promise(resolve => {
   const image = new Image();
   image.src = src;
-  image.crossOrigin = 'anonymous';
   image.onload = () => {
     const canvas = document.createElement('canvas');
     canvas.width = image.naturalWidth;

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -154,12 +154,12 @@ const processRows = function (rowsElements) {
 
 export const main = async function () {
   const gifImage = `
-    :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img[srcset*=".gif"]:not(${keyToCss('poster')})
+    :is(figure, ${keyToCss('tagImage', 'takeoverBanner', 'videoHubsFeatured')}) img:is([srcset*=".gif"], [src*=".gif"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
 
   const gifBackgroundImage = `
-    ${keyToCss('communityHeaderImage', 'bannerImage')}[style*=".gif"]
+    ${keyToCss('communityHeaderImage', 'bannerImage', 'videoHubCardWrapper')}[style*=".gif"]
   `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -109,14 +109,21 @@ const processGifs = function (gifElements) {
 const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.gifv?(?=["']\))/g;
 
 const pausedUrlCache = {};
-const createPausedUrl = sourceUrl => {
-  pausedUrlCache[sourceUrl] ??= new Promise(resolve =>
-    createCanvas(sourceUrl).then(canvas =>
+const createPausedUrl = (sourceUrl) => {
+  pausedUrlCache[sourceUrl] ??= new Promise(resolve => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.src = sourceUrl;
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      canvas.getContext('2d').drawImage(image, 0, 0);
       canvas.toBlob(blob =>
         resolve(URL.createObjectURL(blob))
-      )
-    )
-  );
+      );
+    };
+  });
   return pausedUrlCache[sourceUrl];
 };
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -63,21 +63,26 @@ const addLabel = (element, inside = false) => {
   }
 };
 
-const pauseGif = function (gifElement) {
+const createCanvas = src => new Promise(resolve => {
   const image = new Image();
-  image.src = gifElement.currentSrc;
+  image.src = src;
   image.onload = () => {
-    if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
-      const canvas = document.createElement('canvas');
-      canvas.width = image.naturalWidth;
-      canvas.height = image.naturalHeight;
-      canvas.className = gifElement.className;
-      canvas.classList.add(canvasClass);
-      canvas.getContext('2d').drawImage(image, 0, 0);
-      gifElement.parentNode.append(canvas);
-      addLabel(gifElement);
-    }
+    const canvas = document.createElement('canvas');
+    canvas.width = image.naturalWidth;
+    canvas.height = image.naturalHeight;
+    canvas.getContext('2d').drawImage(image, 0, 0);
+    resolve(canvas);
   };
+});
+
+const pauseGif = async function (gifElement) {
+  const canvas = await createCanvas(gifElement.currentSrc);
+  if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
+    canvas.className = gifElement.className;
+    canvas.classList.add(canvasClass);
+    gifElement.parentNode.append(canvas);
+    addLabel(gifElement);
+  }
 };
 
 const processGifs = function (gifElements) {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -112,20 +112,24 @@ const processGifs = function (gifElements) {
 
 const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.gifv?(?=["']\))/g;
 
-const createPausedUrl = (sourceUrl) => new Promise(resolve => {
-  const image = new Image();
-  image.crossOrigin = 'anonymous';
-  image.src = sourceUrl;
-  image.onload = () => {
-    const canvas = document.createElement('canvas');
-    canvas.width = image.naturalWidth;
-    canvas.height = image.naturalHeight;
-    canvas.getContext('2d').drawImage(image, 0, 0);
-    canvas.toBlob(blob =>
-      resolve(URL.createObjectURL(blob))
-    );
-  };
-});
+const pausedUrlCache = {};
+const createPausedUrl = (sourceUrl) => {
+  pausedUrlCache[sourceUrl] ??= new Promise(resolve => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.src = sourceUrl;
+    image.onload = () => {
+      const canvas = document.createElement('canvas');
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      canvas.getContext('2d').drawImage(image, 0, 0);
+      canvas.toBlob(blob =>
+        resolve(URL.createObjectURL(blob))
+      );
+    };
+  });
+  return pausedUrlCache[sourceUrl];
+};
 
 const processBackgroundGifs = function (gifBackgroundElements) {
   gifBackgroundElements.forEach(async gifBackgroundElement => {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -109,21 +109,14 @@ const processGifs = function (gifElements) {
 const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.gifv?(?=["']\))/g;
 
 const pausedUrlCache = {};
-const createPausedUrl = (sourceUrl) => {
-  pausedUrlCache[sourceUrl] ??= new Promise(resolve => {
-    const image = new Image();
-    image.crossOrigin = 'anonymous';
-    image.src = sourceUrl;
-    image.onload = () => {
-      const canvas = document.createElement('canvas');
-      canvas.width = image.naturalWidth;
-      canvas.height = image.naturalHeight;
-      canvas.getContext('2d').drawImage(image, 0, 0);
+const createPausedUrl = sourceUrl => {
+  pausedUrlCache[sourceUrl] ??= new Promise(resolve =>
+    createCanvas(sourceUrl).then(canvas =>
       canvas.toBlob(blob =>
         resolve(URL.createObjectURL(blob))
-      );
-    };
-  });
+      )
+    )
+  );
   return pausedUrlCache[sourceUrl];
 };
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -63,26 +63,21 @@ const addLabel = (element, inside = false) => {
   }
 };
 
-const createCanvas = src => new Promise(resolve => {
+const pauseGif = function (gifElement) {
   const image = new Image();
-  image.src = src;
+  image.src = gifElement.currentSrc;
   image.onload = () => {
-    const canvas = document.createElement('canvas');
-    canvas.width = image.naturalWidth;
-    canvas.height = image.naturalHeight;
-    canvas.getContext('2d').drawImage(image, 0, 0);
-    resolve(canvas);
+    if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
+      const canvas = document.createElement('canvas');
+      canvas.width = image.naturalWidth;
+      canvas.height = image.naturalHeight;
+      canvas.className = gifElement.className;
+      canvas.classList.add(canvasClass);
+      canvas.getContext('2d').drawImage(image, 0, 0);
+      gifElement.parentNode.append(canvas);
+      addLabel(gifElement);
+    }
   };
-});
-
-const pauseGif = async function (gifElement) {
-  const canvas = await createCanvas(gifElement.currentSrc);
-  if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
-    canvas.className = gifElement.className;
-    canvas.classList.add(canvasClass);
-    gifElement.parentNode.append(canvas);
-    addLabel(gifElement);
-  }
 };
 
 const processGifs = function (gifElements) {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -105,18 +105,18 @@ const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.gifv?(?=["']\))/g;
 const pausedUrlCache = {};
 const createPausedUrl = (sourceUrl) => {
   pausedUrlCache[sourceUrl] ??= new Promise(resolve => {
-    const image = new Image();
-    image.crossOrigin = 'anonymous';
-    image.src = sourceUrl;
-    image.onload = () => {
-      const canvas = document.createElement('canvas');
-      canvas.width = image.naturalWidth;
-      canvas.height = image.naturalHeight;
-      canvas.getContext('2d').drawImage(image, 0, 0);
-      canvas.toBlob(blob =>
-        resolve(URL.createObjectURL(blob))
-      );
-    };
+    fetch(sourceUrl, { headers: { Accept: 'image/webp,*/*' } })
+      .then(response => response.blob())
+      .then(blob => createImageBitmap(blob))
+      .then(imageBitmap => {
+        const canvas = document.createElement('canvas');
+        canvas.width = imageBitmap.width;
+        canvas.height = imageBitmap.height;
+        canvas.getContext('2d').drawImage(imageBitmap, 0, 0);
+        canvas.toBlob(blob =>
+          resolve(URL.createObjectURL(blob))
+        );
+      });
   });
   return pausedUrlCache[sourceUrl];
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -133,10 +133,6 @@ const processBackgroundGifs = function (gifBackgroundElements) {
     if (sourceUrl) {
       gifBackgroundElement.style.setProperty(
         pausedBackgroundImageVar,
-        'linear-gradient(rgb(var(--secondary-accent), 0.1), rgb(var(--secondary-accent), 0.1))'
-      );
-      gifBackgroundElement.style.setProperty(
-        pausedBackgroundImageVar,
         sourceValue.replaceAll(sourceUrlRegex, await createPausedUrl(sourceUrl))
       );
       addLabel(gifBackgroundElement, true);

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -117,7 +117,7 @@ const updateBackgroundStyle = () => {
     .join('\n');
 };
 
-const createPausedCssValue = (sourceValue, sourceUrl) => new Promise(resolve => {
+const createPausedUrl = (sourceUrl) => new Promise(resolve => {
   const image = new Image();
   image.crossOrigin = 'anonymous';
   image.src = sourceUrl;
@@ -126,10 +126,9 @@ const createPausedCssValue = (sourceValue, sourceUrl) => new Promise(resolve => 
     canvas.width = image.naturalWidth;
     canvas.height = image.naturalHeight;
     canvas.getContext('2d').drawImage(image, 0, 0);
-    canvas.toBlob(blob => {
-      const blobUrl = URL.createObjectURL(blob);
-      resolve(sourceValue.replaceAll(sourceUrlRegex, blobUrl));
-    });
+    canvas.toBlob(blob =>
+      resolve(URL.createObjectURL(blob))
+    );
   };
 });
 
@@ -140,7 +139,7 @@ const processBackgroundGifs = function (gifBackgroundElements) {
 
     if (sourceUrl) {
       const id = await sha256(sourceValue);
-      pausedBackgroundImageValues[id] ??= await createPausedCssValue(sourceValue, sourceUrl);
+      pausedBackgroundImageValues[id] ??= sourceValue.replaceAll(sourceUrlRegex, await createPausedUrl(sourceUrl));
       updateBackgroundStyle();
 
       gifBackgroundElement.dataset.disableGifsId = id;

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -133,6 +133,10 @@ const processBackgroundGifs = function (gifBackgroundElements) {
     if (sourceUrl) {
       gifBackgroundElement.style.setProperty(
         pausedBackgroundImageVar,
+        'linear-gradient(rgb(var(--secondary-accent), 0.1), rgb(var(--secondary-accent), 0.1))'
+      );
+      gifBackgroundElement.style.setProperty(
+        pausedBackgroundImageVar,
         sourceValue.replaceAll(sourceUrlRegex, await createPausedUrl(sourceUrl))
       );
       addLabel(gifBackgroundElement, true);

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -7,7 +7,6 @@ const canvasClass = 'xkit-paused-gif-placeholder';
 const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const pausedBackgroundImageVar = '--xkit-paused-gif-background-image';
-const backgroundGifClass = 'xkit-paused-background-gif';
 
 export const styleElement = buildStyle(`
 .${labelClass} {
@@ -50,15 +49,6 @@ export const styleElement = buildStyle(`
 
 [style*="${pausedBackgroundImageVar}"]:not(:hover) {
   background-image: var(${pausedBackgroundImageVar}) !important;
-}
-
-.${backgroundGifClass}:not(:hover) {
-  background-image: none !important;
-  background-color: rgb(var(--secondary-accent));
-}
-
-.${backgroundGifClass}:not(:hover) > div {
-  color: rgb(var(--black));
 }
 `);
 
@@ -141,10 +131,8 @@ const processBackgroundGifs = function (gifBackgroundElements) {
         pausedBackgroundImageVar,
         sourceValue.replaceAll(sourceUrlRegex, await createPausedUrl(sourceUrl))
       );
-    } else {
-      gifBackgroundElement.classList.add(backgroundGifClass);
+      addLabel(gifBackgroundElement, true);
     }
-    addLabel(gifBackgroundElement, true);
   });
 };
 
@@ -191,7 +179,6 @@ export const clean = async function () {
   );
 
   $(`.${canvasClass}, .${labelClass}`).remove();
-  $(`.${backgroundGifClass}`).removeClass(backgroundGifClass);
   [...document.querySelectorAll(`img[style*="${pausedBackgroundImageVar}"]`)]
     .forEach(element => element.style.removeProperty(pausedBackgroundImageVar));
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

I was going to say this is kind of pointless—if you're going to Tumblr TV you want to see animations, right?—but actually, no, there's a big difference between seeing one piece of video content you clicked on and having many things constantly animating as you navigate.

Based on #1681.

**Edit:** Currently causes annoying white backgrounds on transparent gifs in the "recommended" element; I guess I'll finally bother to make [a PR](https://github.com/AprilSylph/XKit-Rewritten/pull/1707) to fix this. A bit difficult to test, as the vast majority of recommendations aren't transparent.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

