### PR TITLE
AccessKit Disable GIFs: Hide animated images instead of covering them

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -81,7 +81,7 @@ const pauseGif = async function (gifElement) {
       canvas.classList.add(canvasClass);
       canvas.getContext('2d').drawImage(image, 0, 0);
       gifElement.parentNode.append(canvas);
-      addLabel(gifElement);
+      addLabel(canvas);
     }
   };
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -80,8 +80,8 @@ const pauseGif = async function (gifElement) {
       canvas.className = gifElement.className;
       canvas.classList.add(canvasClass);
       canvas.getContext('2d').drawImage(image, 0, 0);
-      addLabel(gifElement);
       gifElement.before(canvas);
+      addLabel(gifElement);
     }
   };
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -36,8 +36,6 @@ export const styleElement = buildStyle(`
 .${canvasClass} {
   position: absolute;
   visibility: visible;
-
-  background-color: rgb(var(--white));
 }
 
 *:hover > .${canvasClass},

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -67,7 +67,9 @@ const addLabel = (element, inside = false) => {
   }
 };
 
-const pauseGif = function (gifElement) {
+const pauseGif = async function (gifElement) {
+  gifElement.decode();
+
   const image = new Image();
   image.src = gifElement.currentSrc;
   image.onload = () => {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -42,7 +42,7 @@ export const styleElement = buildStyle(`
 
 .${canvasClass}${hovered},
 .${labelClass}${hovered},
-.${canvasClass} ~ img:not(${hovered}) {
+img:has(~ .${canvasClass}):not(${hovered}) {
   display: none;
 }
 
@@ -80,7 +80,7 @@ const pauseGif = async function (gifElement) {
       canvas.className = gifElement.className;
       canvas.classList.add(canvasClass);
       canvas.getContext('2d').drawImage(image, 0, 0);
-      gifElement.before(canvas);
+      gifElement.parentNode.append(canvas);
       addLabel(gifElement);
     }
   };
@@ -89,11 +89,12 @@ const pauseGif = async function (gifElement) {
 const processGifs = function (gifElements) {
   gifElements.forEach(gifElement => {
     if (gifElement.closest('.block-editor-writing-flow')) return;
-    const existingCanvasElements = gifElement.parentNode.querySelectorAll(`.${canvasClass}`);
-    const existingLabelElements = gifElement.parentNode.querySelectorAll(`.${labelClass}`);
-    if (existingCanvasElements.length || existingLabelElements.length) {
-      gifElement.before(...existingCanvasElements);
-      gifElement.after(...existingLabelElements);
+    const pausedGifElements = [
+      ...gifElement.parentNode.querySelectorAll(`.${canvasClass}`),
+      ...gifElement.parentNode.querySelectorAll(`.${labelClass}`)
+    ];
+    if (pausedGifElements.length) {
+      gifElement.after(...pausedGifElements);
       return;
     }
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -78,8 +78,8 @@ const pauseGif = function (gifElement) {
       canvas.className = gifElement.className;
       canvas.classList.add(canvasClass);
       canvas.getContext('2d').drawImage(image, 0, 0);
-      gifElement.before(canvas);
       addLabel(gifElement);
+      gifElement.before(canvas);
     }
   };
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -42,7 +42,7 @@ export const styleElement = buildStyle(`
 
 .${canvasClass}${hovered},
 .${labelClass}${hovered},
-img:has(~ .${canvasClass}):not(${hovered}) {
+.${canvasClass} ~ img:not(${hovered}) {
   display: none;
 }
 
@@ -78,7 +78,7 @@ const pauseGif = function (gifElement) {
       canvas.className = gifElement.className;
       canvas.classList.add(canvasClass);
       canvas.getContext('2d').drawImage(image, 0, 0);
-      gifElement.parentNode.append(canvas);
+      gifElement.before(canvas);
       addLabel(gifElement);
     }
   };
@@ -87,12 +87,11 @@ const pauseGif = function (gifElement) {
 const processGifs = function (gifElements) {
   gifElements.forEach(gifElement => {
     if (gifElement.closest('.block-editor-writing-flow')) return;
-    const pausedGifElements = [
-      ...gifElement.parentNode.querySelectorAll(`.${canvasClass}`),
-      ...gifElement.parentNode.querySelectorAll(`.${labelClass}`)
-    ];
-    if (pausedGifElements.length) {
-      gifElement.after(...pausedGifElements);
+    const existingCanvasElements = gifElement.parentNode.querySelectorAll(`.${canvasClass}`);
+    const existingLabelElements = gifElement.parentNode.querySelectorAll(`.${labelClass}`);
+    if (existingCanvasElements.length || existingLabelElements.length) {
+      gifElement.before(...existingCanvasElements);
+      gifElement.after(...existingLabelElements);
       return;
     }
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -8,6 +8,8 @@ const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
 
+const hovered = `:is(:hover > *, .${containerClass}:hover *)`;
+
 export const styleElement = buildStyle(`
 .${labelClass} {
   position: absolute;
@@ -38,10 +40,9 @@ export const styleElement = buildStyle(`
   visibility: visible;
 }
 
-*:hover > .${canvasClass},
-*:hover > .${labelClass},
-.${containerClass}:hover .${canvasClass},
-.${containerClass}:hover .${labelClass} {
+.${canvasClass}${hovered},
+.${labelClass}${hovered},
+img:has(~ .${canvasClass}):not(${hovered}) {
   display: none;
 }
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Right now, Disable GIFs hides most animated images when they aren't hovered by covering them with a non-animated one, and handles transparency by setting an opaque "white" background on the cover so the real, animated image can't be seen through transparent parts. This works great as long as the background is actually supposed to be "white" (which it is, in posts, even with Themed Posts). It doesn't work if one wants to apply that part of the Disable GIFs to other parts of the Tumblr UI which may have different background colors (in this case, the "recommended" element at the top of the Tumblr TV interface), and also might use a bit more CPU than the alternative.

What's the alternative? We simply hide the animated image when it's not hovered, just like we hide the cover when it is hovered. Thus, only one image is ever displayed at a time, and there's no need to implement anything special to make transparent images work.

~~This also means that we no longer care about the layer order at all, and in fact it's slightly more elegant due to the way CSS selectors work to put our canvas element before (i.e. what would have been "behind") the native animated image, similar to how Vanilla Videos inserts its replacement element before the native element and hides the native element with a `~` selector.~~ _removed for consistency with possible future development_

(Aside: #1458, which I've done a reasonable amount of testing on, already uses the main technique used here. It will merge conflict with this, but it needs some refactoring anyway, hence its draft status.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that Disable GIFs functions correctly on transparent GIFs, e.g. https://www.tumblr.com/animatedtext.
- Confirm that Disable GIFs functions in Firefox and Chromium.
- Confirm that there's no unusual delay/animation when moving the cursor onto or off of a paused GIF; there should be a seamless transition between the paused and animated images.
- Open https://www.tumblr.com/search/gif in masonry view and confirm that small GIFs, such as the related tags in the sidebar and side-by-side GIFs in photosets, have small GIF labels.