### PR TITLE
AccessKit Disable GIFs: Parse; disable animated WebP images

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -89,9 +89,13 @@ const isAnimated = memoize(async (sourceUrl) => {
     data: response.body,
     preferAnimation: true
   });
-  await decoder.decode();
-  controller.abort();
-  return decoder.tracks.selectedTrack.animated;
+  try {
+    await decoder.decode();
+    return decoder.tracks.selectedTrack.animated;
+  } finally {
+    decoder.close();
+    controller.abort();
+  }
 });
 
 const pauseGif = async function (gifElement) {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -93,10 +93,7 @@ const isAnimated = memoize(async (sourceUrl) => {
 });
 
 const pauseGif = async function (gifElement) {
-  if (!await isAnimated(gifElement.currentSrc)) {
-    console.log("this webp image isn't animated!", gifElement);
-    return;
-  }
+  if (!await isAnimated(gifElement.currentSrc)) return;
   const image = new Image();
   image.src = gifElement.currentSrc;
   image.onload = () => {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -77,8 +77,7 @@ const isAnimated = memoize(async (sourceUrl) => {
   if (typeof ImageDecoder !== 'function') return isAnimatedDefault;
   /* globals ImageDecoder */
 
-  const controller = new AbortController();
-  const response = await fetch(sourceUrl, { signal: controller.signal });
+  const response = await fetch(sourceUrl);
 
   const contentType = response.headers.get('Content-Type');
   const supported = await ImageDecoder.isTypeSupported(contentType);

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -71,6 +71,9 @@ const addLabel = (element, inside = false) => {
 
 const isAnimatedDefault = true;
 const isAnimated = memoize(async (sourceUrl) => {
+  // treat all GIFs like they're animated
+  if (sourceUrl.includes('.gif')) return true;
+
   if (typeof ImageDecoder !== 'function') return isAnimatedDefault;
   /* globals ImageDecoder */
 
@@ -96,7 +99,7 @@ const isAnimated = memoize(async (sourceUrl) => {
 });
 
 const pauseGif = async function (gifElement) {
-  if (!gifElement.parentElement.querySelector(keyToCss('poster')) && !await isAnimated(gifElement.currentSrc)) return;
+  if (!await isAnimated(gifElement.currentSrc)) return;
   const image = new Image();
   image.src = gifElement.currentSrc;
   image.onload = () => {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -87,7 +87,7 @@ const isAnimated = memoize(async (sourceUrl) => {
     preferAnimation: true
   });
   try {
-    await decoder.decode();
+    await decoder.tracks.ready;
     return decoder.tracks.selectedTrack.animated;
   } finally {
     decoder.close();

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -2,6 +2,7 @@ import { pageModifications } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
 import { dom } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
+import { memoize } from '../../utils/memoize.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
 const labelClass = 'xkit-paused-gif-label';
@@ -69,7 +70,7 @@ const addLabel = (element, inside = false) => {
 };
 
 const isAnimatedDefault = true;
-const isAnimated = async (sourceUrl) => {
+const isAnimated = memoize(async (sourceUrl) => {
   // treat all GIFs like they're animated
   if (sourceUrl.includes('.gif')) return true;
 
@@ -89,7 +90,7 @@ const isAnimated = async (sourceUrl) => {
   });
   await decoder.decode();
   return decoder.tracks.selectedTrack.animated;
-};
+});
 
 const pauseGif = async function (gifElement) {
   if (!await isAnimated(gifElement.currentSrc)) {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -71,9 +71,6 @@ const addLabel = (element, inside = false) => {
 
 const isAnimatedDefault = true;
 const isAnimated = memoize(async (sourceUrl) => {
-  // treat all GIFs like they're animated
-  if (sourceUrl.includes('.gif')) return true;
-
   if (typeof ImageDecoder !== 'function') return isAnimatedDefault;
   /* globals ImageDecoder */
 
@@ -99,7 +96,7 @@ const isAnimated = memoize(async (sourceUrl) => {
 });
 
 const pauseGif = async function (gifElement) {
-  if (!await isAnimated(gifElement.currentSrc)) return;
+  if (!gifElement.parentElement.querySelector(keyToCss('poster')) && !await isAnimated(gifElement.currentSrc)) return;
   const image = new Image();
   image.src = gifElement.currentSrc;
   image.onload = () => {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -77,7 +77,8 @@ const isAnimated = memoize(async (sourceUrl) => {
   if (typeof ImageDecoder !== 'function') return isAnimatedDefault;
   /* globals ImageDecoder */
 
-  const response = await fetch(sourceUrl);
+  const controller = new AbortController();
+  const response = await fetch(sourceUrl, { signal: controller.signal });
 
   const contentType = response.headers.get('Content-Type');
   const supported = await ImageDecoder.isTypeSupported(contentType);
@@ -89,6 +90,7 @@ const isAnimated = memoize(async (sourceUrl) => {
     preferAnimation: true
   });
   await decoder.decode();
+  controller.abort();
   return decoder.tracks.selectedTrack.animated;
 });
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -89,13 +89,8 @@ const isAnimated = memoize(async (sourceUrl) => {
     data: response.body,
     preferAnimation: true
   });
-  try {
-    await decoder.tracks.ready;
-    return decoder.tracks.selectedTrack.animated;
-  } finally {
-    decoder.close();
-    controller.abort();
-  }
+  await decoder.tracks.ready;
+  return decoder.tracks.selectedTrack.animated;
 });
 
 const pauseGif = async function (gifElement) {

--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -1,0 +1,19 @@
+export const memoize = (func) => {
+  const cache = new Map();
+  return (arg) => {
+    if (!cache.has(arg)) {
+      cache.set(arg, func(arg));
+    }
+    return cache.get(arg);
+  };
+};
+
+export const weakMemoize = (func) => {
+  const cache = new WeakMap();
+  return (arg) => {
+    if (!cache.has(arg)) {
+      cache.set(arg, func(arg));
+    }
+    return cache.get(arg);
+  };
+};


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This applies Disable GIFs to animated WebP images—but not, if possible, to non-animated WebP images—by downloading them and parsing them with the new and not-amazingly-documented [WebCodecs API](https://developer.mozilla.org/en-US/docs/Web/API/WebCodecs_API).

Supersedes #1402 (which vendored a library to do this) and #1563 (which put labels on webp images regardless of whether they were animated or not).

Resolves #1401.

### Technical notes

Unlike the "create an image element, set its source, and read its data once it loads" method of obtaining image data used by Disable GIFs currently (and used in #1681), the fetch call used here doesn't seem to reuse the browser image cache, and I didn't manage to change this using cache headers or anything. So I think that checking whether an image is animated using this method has a server load cost as well as a time cost. This therefore intentionally and potentially incorrectly assumes that any gif (or gifv) image is animated and skips the check, only running it on webp images, which are currently pretty rare.

`ImageDecoder` is feature detected; when tested in Firefox 128, this falls back to trying to de-animate all webp images (or  to ignoring webp images if `isAnimatedDefault = false` is set; this is kind of arbitrary).

I also thought about processing images as if they're animated while simultaneously checking whether they're animated, waiting for both to finish, then removing the processing if the image was actually stationary. This would reduce processing latency (the amount of time the user sees the animated image) compared to the current sequential async code paths. That's a bit complicated, though.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Animated WebP: https://www.tumblr.com/changes/758172275271991296/threaded-replies-are-here
Animated GIF: https://www.tumblr.com/@radar/757906400962920448, https://www.tumblr.com/april-codes/700206746833240064
Non-animated GIF: https://www.tumblr.com/@radar/753920129042153472
Non-animated WebP: https://www.tumblr.com/minmos/744793127262601216/front-facing-egrets-making-me-lose-control-of, https://www.tumblr.com/@radar/755279084134744066, https://www.tumblr.com/@radar/750568043810340864

Confirm that:
- animated WebP images in posts are paused
- non-animated WebP images in posts are not paused
- animated GIF images in posts are paused
- non-animated GIF images in posts... are still incorrectly paused, as it would be too expensive to check every GIF