### PR TITLE
Extract memoize helper function

### DIFF
--- a/src/utils/memoize.js
+++ b/src/utils/memoize.js
@@ -1,0 +1,19 @@
+export const memoize = (func) => {
+  const cache = new Map();
+  return (arg) => {
+    if (!cache.has(arg)) {
+      cache.set(arg, func(arg));
+    }
+    return cache.get(arg);
+  };
+};
+
+export const weakMemoize = (func) => {
+  const cache = new WeakMap();
+  return (arg) => {
+    if (!cache.has(arg)) {
+      cache.set(arg, func(arg));
+    }
+    return cache.get(arg);
+  };
+};

--- a/src/utils/react_props.js
+++ b/src/utils/react_props.js
@@ -1,36 +1,22 @@
 import { inject } from './inject.js';
+import { weakMemoize } from './memoize.js';
 import { primaryBlogName, userBlogNames, adminBlogNames } from './user.js';
-
-const timelineObjectCache = new WeakMap();
-const notificationObjectCache = new WeakMap();
 
 /**
  * @param {Element} postElement - An on-screen post
  * @returns {Promise<object>} - The post's buried timelineObject property
  */
-export const timelineObject = async function (postElement) {
-  if (!timelineObjectCache.has(postElement)) {
-    timelineObjectCache.set(
-      postElement,
-      inject('/main_world/unbury_timeline_object.js', [], postElement)
-    );
-  }
-  return timelineObjectCache.get(postElement);
-};
+export const timelineObject = weakMemoize(postElement =>
+  inject('/main_world/unbury_timeline_object.js', [], postElement)
+);
 
 /**
  * @param {Element} notificationElement - An on-screen notification
  * @returns {Promise<object>} - The notification's buried notification property
  */
-export const notificationObject = function (notificationElement) {
-  if (!notificationObjectCache.has(notificationElement)) {
-    notificationObjectCache.set(
-      notificationElement,
-      inject('/main_world/unbury_notification.js', [], notificationElement)
-    );
-  }
-  return notificationObjectCache.get(notificationElement);
-};
+export const notificationObject = weakMemoize(notificationElement =>
+  inject('/main_world/unbury_notification.js', [], notificationElement)
+);
 
 /**
  * @param {Element} meatballMenu - An on-screen meatball menu element in a blog modal header or blog card


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This creates and uses helpers for creating memoized (cached) versions of functions with a single argument by creating a closure, similar to the way that `debounce` creates debounced versions of functions. (I found myself writing another one of these for a different PR and went, wait, hold on, why have we not just done this).

Bikesheddable: this makes a util file with two exports, one of which uses a WeakMap; it could alternatively be a single export that takes an additional config argument of some kind along with the target function. I don't think that reads as elegantly when used, though.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Smoke test the extension; I haven't done specific tests to verify that the caching still works.

