### PR TITLE
Vanilla Video: Add toggle to enable/disable in Tumblr TV

### DIFF
--- a/src/features/vanilla_video.js
+++ b/src/features/vanilla_video.js
@@ -5,6 +5,7 @@ import { keyToCss } from '../utils/css_map.js';
 const vanillaVideoClass = 'xkit-vanilla-video-player';
 
 let defaultVolume;
+let tumblrTvEnable;
 
 const cloneVideoElements = videoElements => videoElements.forEach(videoElement => {
   if (videoElement.previousElementSibling?.classList.contains(vanillaVideoClass)) return;
@@ -32,8 +33,14 @@ const cloneVideoElements = videoElements => videoElements.forEach(videoElement =
 
 export const onStorageChanged = async function (changes, areaName) {
   const {
+    'vanilla_video.preferences.tumblrTvEnable': tumblrTvEnableChanges,
     'vanilla_video.preferences.defaultVolume': defaultVolumeChanges
   } = changes;
+
+  if (tumblrTvEnableChanges && tumblrTvEnableChanges.oldValue !== undefined) {
+    clean().then(main);
+    return;
+  }
 
   if (defaultVolumeChanges && defaultVolumeChanges.oldValue !== undefined) {
     ({ newValue: defaultVolume } = defaultVolumeChanges);
@@ -41,8 +48,10 @@ export const onStorageChanged = async function (changes, areaName) {
 };
 
 export const main = async function () {
-  ({ defaultVolume } = await getPreferences('vanilla_video'));
-  pageModifications.register(`${keyToCss('videoPlayer')} video:not(.${vanillaVideoClass})`, cloneVideoElements);
+  ({ defaultVolume, tumblrTvEnable } = await getPreferences('vanilla_video'));
+
+  const notOnTumblrTv = `:not(${keyToCss('slide')} ${keyToCss('take')} *)`;
+  pageModifications.register(`${keyToCss('videoPlayer')} video:not(.${vanillaVideoClass})${tumblrTvEnable ? '' : notOnTumblrTv}`, cloneVideoElements);
 };
 
 export const clean = async function () {

--- a/src/features/vanilla_video.json
+++ b/src/features/vanilla_video.json
@@ -20,6 +20,11 @@
         { "value": "100", "label": "100%" }
       ],
       "default": "100"
+    },
+    "tumblrTvEnable": {
+      "type": "checkbox",
+      "label": "Enable on Tumblr TV",
+      "default": true
     }
   }
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Vanilla Video prevents video autoplay, which kind of goes against the idea of the Tumblr TV thingy. This adds a toggle to its preferences so that the user can disable it specifically there if they want to. I set it to be enabled by default, because that's probably what most XKit users would expect?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that the toggle turns Vanilla Video on and off inside the Tumblr TV interface.

