### PR TITLE
Meatballs util: Refactor; remove duplicate code

### DIFF
--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -77,16 +77,15 @@ const addTypedMeatballItems = async ({ meatballMenu, type, reactData, reactDataK
   Object.keys(meatballItems[type]).sort().forEach(id => {
     const { label, onclick, filter } = meatballItems[type][id];
 
-    const meatballItemButton = dom(
-      'button',
-      {
-        class: 'xkit-meatball-button',
-        [`data-xkit-${type}-meatball-button`]: id,
-        hidden: true
-      },
-      { click: onclick },
-      ['\u22EF']
-    );
+    const meatballItemButton = dom('button', {
+      class: 'xkit-meatball-button',
+      [`data-xkit-${type}-meatball-button`]: id,
+      hidden: true
+    }, {
+      click: onclick
+    }, [
+      '\u22EF'
+    ]);
     meatballItemButton[reactDataKey] = reactData;
 
     if (label instanceof Function) {

--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -8,8 +8,10 @@ import { blogData, timelineObject } from './react_props.js';
 const postHeaderSelector = `${postSelector} article > header`;
 const blogHeaderSelector = `[style*="--blog-title-color"] > div > div > header, ${keyToCss('blogCardHeaderBar')}`;
 
-const meatballItems = {};
-const blogMeatballItems = {};
+const meatballItems = {
+  post: {},
+  blog: {}
+};
 
 /**
  * Add a custom button to posts' meatball menus.
@@ -20,12 +22,12 @@ const blogMeatballItems = {};
  * @param {Function} [options.postFilter] - Filter function, called with the timelineObject data of the post element being actioned on. Must return true for button to be added
  */
 export const registerMeatballItem = function ({ id, label, onclick, postFilter }) {
-  meatballItems[id] = { label, onclick, filter: postFilter };
+  meatballItems.post[id] = { label, onclick, filter: postFilter };
   pageModifications.trigger(addMeatballItems);
 };
 
 export const unregisterMeatballItem = id => {
-  delete meatballItems[id];
+  delete meatballItems.post[id];
   $(`[data-xkit-post-meatball-button="${id}"]`).remove();
 };
 
@@ -38,12 +40,12 @@ export const unregisterMeatballItem = id => {
  * @param {Function} [options.blogFilter] - Filter function, called with the blog data of the menu element being actioned on. Must return true for button to be added. Some blog data fields, such as "followed", are not available in blog cards.
  */
 export const registerBlogMeatballItem = function ({ id, label, onclick, blogFilter }) {
-  blogMeatballItems[id] = { label, onclick, filter: blogFilter };
+  meatballItems.blog[id] = { label, onclick, filter: blogFilter };
   pageModifications.trigger(addMeatballItems);
 };
 
 export const unregisterBlogMeatballItem = id => {
-  delete blogMeatballItems[id];
+  delete meatballItems.blog[id];
   $(`[data-xkit-blog-meatball-button="${id}"]`).remove();
 };
 
@@ -52,8 +54,7 @@ const addMeatballItems = meatballMenus => meatballMenus.forEach(async meatballMe
   if (inPostHeader) {
     addTypedMeatballItems({
       meatballMenu,
-      meatballItems,
-      buttonDataAttr: 'data-xkit-post-meatball-button',
+      type: 'post',
       reactData: await timelineObject(meatballMenu),
       reactDataKey: '__timelineObjectData'
     });
@@ -63,25 +64,24 @@ const addMeatballItems = meatballMenus => meatballMenus.forEach(async meatballMe
   if (inBlogHeader) {
     addTypedMeatballItems({
       meatballMenu,
-      meatballItems: blogMeatballItems,
-      buttonDataAttr: 'data-xkit-blog-meatball-button',
+      type: 'blog',
       reactData: await blogData(meatballMenu),
       reactDataKey: '__blogData'
     });
   }
 });
 
-const addTypedMeatballItems = async ({ meatballMenu, meatballItems, buttonDataAttr, reactData, reactDataKey }) => {
-  $(meatballMenu).children(`[${buttonDataAttr}]`).remove();
+const addTypedMeatballItems = async ({ meatballMenu, type, reactData, reactDataKey }) => {
+  $(meatballMenu).children(`[data-xkit-${type}-meatball-button]`).remove();
 
-  Object.keys(meatballItems).sort().forEach(id => {
-    const { label, onclick, filter } = meatballItems[id];
+  Object.keys(meatballItems[type]).sort().forEach(id => {
+    const { label, onclick, filter } = meatballItems[type][id];
 
     const meatballItemButton = dom(
       'button',
       {
         class: 'xkit-meatball-button',
-        [buttonDataAttr]: id,
+        [`data-xkit-${type}-meatball-button`]: id,
         [reactDataKey]: reactData,
         hidden: true
       },

--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -82,12 +82,12 @@ const addTypedMeatballItems = async ({ meatballMenu, type, reactData, reactDataK
       {
         class: 'xkit-meatball-button',
         [`data-xkit-${type}-meatball-button`]: id,
-        [reactDataKey]: reactData,
         hidden: true
       },
       { click: onclick },
       ['\u22EF']
     );
+    meatballItemButton[reactDataKey] = reactData;
 
     if (label instanceof Function) {
       const labelResult = label(reactData);

--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -26,7 +26,7 @@ export const registerMeatballItem = function ({ id, label, onclick, postFilter }
 
 export const unregisterMeatballItem = id => {
   delete meatballItems[id];
-  $(`[data-xkit-meatball-button="${id}"]`).remove();
+  $(`[data-xkit-post-meatball-button="${id}"]`).remove();
 };
 
 /**
@@ -53,7 +53,7 @@ const addMeatballItems = meatballMenus => meatballMenus.forEach(async meatballMe
     addTypedMeatballItems({
       meatballMenu,
       meatballItems,
-      buttonDataAttr: 'data-xkit-meatball-button',
+      buttonDataAttr: 'data-xkit-post-meatball-button',
       reactData: await timelineObject(meatballMenu),
       reactDataKey: '__timelineObjectData'
     });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This cleans up a big chunk of copy-pasted code that was added to the meatballs util in #910, making the addition of meatball menu items generic over different types (post, blog). This makes it easier to add additional types of meatball menu to target (#1662).


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that PostBlock/Mirror Posts meatball items work correctly.
- Confirm that NotificationBlock meatball items only appear on user posts and work correctly.
- Merge #677 into this PR and confirm that blog meatball items work correctly.

