### PR TITLE
AccessKit Disable GIFs: Speed up pausing using "poster" source

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -68,9 +68,9 @@ const addLabel = (element, inside = false) => {
   }
 };
 
-const pauseGif = function (gifElement) {
+const pauseGif = function (gifElement, src) {
   const image = new Image();
-  image.src = gifElement.currentSrc;
+  image.src = src;
   image.onload = () => {
     if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
       const canvas = document.createElement('canvas');
@@ -97,10 +97,11 @@ const processGifs = function (gifElements) {
       return;
     }
 
-    if (gifElement.complete && gifElement.currentSrc) {
-      pauseGif(gifElement);
+    const srcElement = gifElement.parentElement.querySelector(keyToCss('poster')) ?? gifElement;
+    if (srcElement.complete && srcElement.currentSrc) {
+      pauseGif(gifElement, srcElement.currentSrc);
     } else {
-      gifElement.onload = () => pauseGif(gifElement);
+      srcElement.onload = () => pauseGif(gifElement, srcElement.currentSrc);
     }
   });
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Without significant architectural changes, this improves the speed at which AccessKit Disable GIFs pauses images, typically making it faster than GIF loading itself and thus making the pausing effect appear "instant," by fetching the smaller already-paused poster source instead of the larger animated source.

This gracefully falls back to the current behavior when Tumblr doesn't provide a poster (ex: animated webp images).

This technique is generally compatible with my other Disable GIFs PRs; most (including all non-draft ones) should merge cleanly, one requires implementation of this technique by hand, and one would entirely remove all of the code that this modifies, making it irrelevant.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that Disable GIFs functions correctly.
- Confirm that, after the initial page load, Disable GIFs generally pauses GIFs as they appear on the page without a period during which the GIF is animated.
- Confirm that hovering a GIF that Disable GIFs has paused, but which still has the loader element in the top right, hides the GIF label and doesn't cause any erroneous visuals (image disappearing, flickering). Network throttling can help test this.

