### PR TITLE
AccessKit Disable GIFs: Blur animated images while processing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "webextension-polyfill": "^0.12.0"
       },
       "devDependencies": {
+        "@types/dom-webcodecs": "^0.1.13",
         "chrome-webstore-upload-cli": "^3.3.1",
         "eslint": "^8.57.1",
         "eslint-config-semistandard": "^17.0.0",
@@ -472,6 +473,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/dom-webcodecs": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/@types/dom-webcodecs/-/dom-webcodecs-0.1.13.tgz",
+      "integrity": "sha512-O5hkiFIcjjszPIYyUSyvScyvrBoV3NOEEZx/pMlsu44TKzWNkLVBBxnxJz42in5n3QIolYOcBYFCPZZ0h8SkwQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "web-ext build"
   },
   "devDependencies": {
+    "@types/dom-webcodecs": "^0.1.13",
     "chrome-webstore-upload-cli": "^3.3.1",
     "eslint": "^8.57.1",
     "eslint-config-semistandard": "^17.0.0",

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -40,6 +40,10 @@ export const styleElement = buildStyle(`
 img:is([${posterAttribute}], [style*="${pausedContentVar}"]):not(${hovered}) ~ div > ${keyToCss('knightRiderLoader')} {
   display: none;
 }
+${keyToCss('background')} > .${labelClass} {
+  /* prevent double labels in recommended post cards */
+  display: none;
+}
 
 [${posterAttribute}]:not(${hovered}) {
   visibility: visible !important;

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -167,6 +167,19 @@ const processBackgroundGifs = function (gifBackgroundElements) {
   });
 };
 
+const reprocessObserver = new MutationObserver(mutations =>
+  mutations.forEach(({ target }) => {
+    if (target.matches('[style*=".gif"], [style*=".webp"]')) {
+      processBackgroundGifs([target]);
+    } else {
+      target.style.removeProperty(pausedBackgroundImageVar);
+      target.querySelector(`.${labelClass}`)?.remove();
+    }
+  })
+);
+const processTumblrTvCards = cards =>
+  cards.forEach(card => reprocessObserver.observe(card, { attributeFilter: ['style'] }));
+
 const processRows = function (rowsElements) {
   rowsElements.forEach(rowsElement => {
     [...rowsElement.children].forEach(row => {
@@ -222,6 +235,11 @@ export const main = async function () {
   `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 
+  pageModifications.register(
+    keyToCss('videoHubCardWrapper'), // tumblr tv channels section: https://www.tumblr.com/dashboard/tumblr_tv
+    processTumblrTvCards
+  );
+
   const hoverableElement = `
     ${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}, /* recommended blog carousel entry */
     div:has(> a${keyToCss('cover')}):has(${keyToCss('communityCategoryImage')}), /* tumblr communities browse page entry: https://www.tumblr.com/communities/browse */
@@ -242,6 +260,7 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(processGifs);
   pageModifications.unregister(processBackgroundGifs);
+  pageModifications.unregister(processTumblrTvCards);
   pageModifications.unregister(processRows);
   pageModifications.unregister(processHoverableElements);
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -76,6 +76,7 @@ img[style*="${pausedContentVar}"]:not(${hovered}) {
 }
 [${loadingBackgroundImageAttribute}]:not(:hover) {
   contain: paint;
+  filter: unset !important;
 }
 
 [${hoverFixAttribute}] {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -8,6 +8,7 @@ const posterAttribute = 'data-paused-gif-placeholder';
 const pausedContentVar = '--xkit-paused-gif-content';
 const pausedBackgroundImageVar = '--xkit-paused-gif-background-image';
 const hoverContainerAttribute = 'data-paused-gif-hover-container';
+const hoverFixAttribute = 'data-paused-gif-hover-fix';
 const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 
@@ -35,6 +36,10 @@ export const styleElement = buildStyle(`
 .${labelClass}.mini {
   font-size: 0.6rem;
 }
+${keyToCss('blogCard')} ${keyToCss('headerImage')}${keyToCss('small')} .${labelClass} {
+  font-size: 0.8rem;
+  top: calc(140px - 1em - 2.2ch);
+}
 
 .${labelClass}${hovered},
 img:is([${posterAttribute}], [style*="${pausedContentVar}"]):not(${hovered}) ~ div > ${keyToCss('knightRiderLoader')} {
@@ -58,6 +63,11 @@ img[style*="${pausedContentVar}"]:not(${hovered}) {
 [style*="${pausedBackgroundImageVar}"]:not(${hovered}) {
   background-image: var(${pausedBackgroundImageVar}) !important;
 }
+
+[${hoverFixAttribute}] {
+  position: relative;
+  pointer-events: auto !important;
+}
 `);
 
 const addLabel = (element, inside = false) => {
@@ -66,7 +76,7 @@ const addLabel = (element, inside = false) => {
     [...target.querySelectorAll(`.${labelClass}`)].forEach(existingLabel => existingLabel.remove());
 
     const gifLabel = document.createElement('p');
-    gifLabel.className = target.clientWidth && target.clientWidth < 150
+    gifLabel.className = target.clientWidth && target.clientWidth <= 150
       ? `${labelClass} mini`
       : labelClass;
 
@@ -110,6 +120,7 @@ const createPausedUrl = memoize(async sourceUrl => {
 
 const processGifs = function (gifElements) {
   gifElements.forEach(async gifElement => {
+    if (!gifElement.matches('[srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]')) return;
     if (gifElement.closest('.block-editor-writing-flow')) return;
 
     const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
@@ -126,12 +137,21 @@ const processGifs = function (gifElements) {
     }
     addLabel(gifElement);
     gifElement.decoding = 'sync';
+
+    gifElement.closest(keyToCss(
+      'albumImage', // post audio element
+      'imgLink' // trending tag: https://www.tumblr.com/explore/trending
+    ))?.setAttribute(hoverFixAttribute, '');
   });
 };
 
 const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.(?:gif|gifv|webp)(?=["']\))/g;
 const processBackgroundGifs = function (gifBackgroundElements) {
   gifBackgroundElements.forEach(async gifBackgroundElement => {
+    // tumblr tv 'videoHubCardWrapper' video cards may be initially rendered with the wrong background
+    if (gifBackgroundElement.matches(keyToCss('videoHubCardWrapper'))) await new Promise(requestAnimationFrame);
+    if (!gifBackgroundElement.matches('[style*=".gif"], [style*=".webp"]')) return;
+
     const sourceValue = gifBackgroundElement.style.backgroundImage;
     const sourceUrl = sourceValue.match(sourceUrlRegex)?.[0];
     if (!sourceUrl) return;
@@ -144,6 +164,11 @@ const processBackgroundGifs = function (gifBackgroundElements) {
       sourceValue.replaceAll(sourceUrlRegex, pausedUrl)
     );
     addLabel(gifBackgroundElement, true);
+
+    gifBackgroundElement.closest(keyToCss(
+      'media', // old activity item: "liked your post", "reblogged your post", "mentioned you in a post"
+      'activityMedia' // new activity item: "replied to your post", "replied to you in a post"
+    ))?.setAttribute(hoverFixAttribute, '');
   });
 };
 
@@ -168,19 +193,50 @@ const processHoverableElements = elements =>
 
 export const main = async function () {
   const gifImage = `
-    :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img:is([srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]):not(${keyToCss('poster')})
+    :is(
+      figure, /* post image/imageset; recommended blog carousel entry; blog view sidebar "more like this"; post in grid view; blog card modal post entry */
+      main.labs, /* labs settings header: https://www.tumblr.com/settings/labs */
+      ${keyToCss(
+        'linkCard', // post link element
+        'albumImage', // post audio element
+        'messageImage', // direct message attached image
+        'messagePost', // direct message linked post
+        'typeaheadRow', // modal search dropdown entry
+        'tagImage', // search page sidebar related tags, recommended tag carousel entry: https://www.tumblr.com/search/gif, https://www.tumblr.com/explore/recommended-for-you
+        'headerBanner', // blog view header
+        'headerImage', // modal blog card header, activity page "biggest fans" header
+        'topPost', // activity page top post
+        'colorfulListItemWrapper', // trending tag: https://www.tumblr.com/explore/trending
+        'videoHubsFeatured', // tumblr tv recommended card: https://www.tumblr.com/dashboard/tumblr_tv
+        'takeoverBanner' // advertisement
+      )}
+    ) img:not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
 
   const gifBackgroundImage = `
-    ${keyToCss('communityHeaderImage', 'bannerImage')}:is([style*=".gif"], [style*=".webp"])
+    ${keyToCss(
+      'media', // old activity item: "liked your post", "reblogged your post", "mentioned you in a post"
+      'activityMedia', // new activity item: "replied to your post", "replied to you in a post"
+      'communityHeaderImage', // search page tags section header: https://www.tumblr.com/search/gif?v=tag
+      'bannerImage', // tagged page sidebar header: https://www.tumblr.com/tagged/gif
+      'tagChicletWrapper', // "trending" / "your tags" timeline carousel entry: https://www.tumblr.com/dashboard/trending, https://www.tumblr.com/dashboard/hubs
+      'communityCategoryImage', // tumblr communities browse page entry: https://www.tumblr.com/communities/browse, https://www.tumblr.com/communities/browse/movies
+      'videoHubCardWrapper' // tumblr tv channels section: https://www.tumblr.com/dashboard/tumblr_tv
+    )}[style]
   `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 
-  pageModifications.register(
-    `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}`,
-    processHoverableElements
-  );
+  const hoverableElement = `
+    ${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}, /* recommended blog carousel entry */
+    div:has(> a${keyToCss('cover')}):has(${keyToCss('communityCategoryImage')}), /* tumblr communities browse page entry: https://www.tumblr.com/communities/browse */
+    ${keyToCss('linkCard')} ${keyToCss('withImage')}, /* post link element */
+    ${keyToCss(
+      'gridTimelineObject', // likes page or patio grid view post: https://www.tumblr.com/likes
+      'videoHubsFeatured' // tumblr tv recommended card: https://www.tumblr.com/dashboard/tumblr_tv
+    )}
+  `;
+  pageModifications.register(hoverableElement, processHoverableElements);
 
   pageModifications.register(
     `:is(${postSelector}, ${keyToCss('blockEditorContainer')}) ${keyToCss('rows')}`,
@@ -201,6 +257,7 @@ export const clean = async function () {
   $(`.${labelClass}`).remove();
   $(`[${posterAttribute}]`).removeAttr(posterAttribute);
   $(`[${hoverContainerAttribute}]`).removeAttr(hoverContainerAttribute);
+  $(`[${hoverFixAttribute}]`).removeAttr(hoverFixAttribute);
   [...document.querySelectorAll(`img[style*="${pausedContentVar}"]`)]
     .forEach(element => element.style.removeProperty(pausedContentVar));
   [...document.querySelectorAll(`[style*="${pausedBackgroundImageVar}"]`)]

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -48,7 +48,7 @@ ${keyToCss('background')} > .${labelClass} {
 [${posterAttribute}]:not(${hovered}) {
   visibility: visible !important;
 }
-img:has(~ [${posterAttribute}]):not(${hovered}) {
+img:has(~ [${posterAttribute}]:not(${hovered})) {
   visibility: hidden !important;
 }
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -58,10 +58,7 @@ export const styleElement = buildStyle(`
 }
 `);
 
-const blogCarouselBackgroundSelector = `${keyToCss('background')} > *`;
-
 const addLabel = (element, inside = false) => {
-  if (element.matches(blogCarouselBackgroundSelector)) return;
   if (element.parentNode.querySelector(`.${labelClass}`) === null) {
     const gifLabel = document.createElement('p');
     gifLabel.className = element.clientWidth && element.clientWidth < 150

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -4,6 +4,7 @@ import { dom } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
+const hoverContainerAttribute = 'data-paused-gif-hover-container';
 const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
@@ -42,8 +43,8 @@ export const styleElement = buildStyle(`
 
 *:hover > .${canvasClass},
 *:hover > .${labelClass},
-.${containerClass}:hover .${canvasClass},
-.${containerClass}:hover .${labelClass} {
+[${hoverContainerAttribute}]:hover .${canvasClass},
+[${hoverContainerAttribute}]:hover .${labelClass} {
   display: none;
 }
 
@@ -57,7 +58,10 @@ export const styleElement = buildStyle(`
 }
 `);
 
+const blogCarouselBackgroundSelector = `${keyToCss('background')} > *`;
+
 const addLabel = (element, inside = false) => {
+  if (element.matches(blogCarouselBackgroundSelector)) return;
   if (element.parentNode.querySelector(`.${labelClass}`) === null) {
     const gifLabel = document.createElement('p');
     gifLabel.className = element.clientWidth && element.clientWidth < 150
@@ -120,13 +124,16 @@ const processRows = function (rowsElements) {
       if (row.previousElementSibling?.classList?.contains(containerClass)) {
         row.previousElementSibling.append(row);
       } else {
-        const wrapper = dom('div', { class: containerClass });
+        const wrapper = dom('div', { class: containerClass, [hoverContainerAttribute]: '' });
         row.replaceWith(wrapper);
         wrapper.append(row);
       }
     });
   });
 };
+
+const processHoverableElements = elements =>
+  elements.forEach(element => element.setAttribute(hoverContainerAttribute, ''));
 
 export const main = async function () {
   const gifImage = `
@@ -140,6 +147,11 @@ export const main = async function () {
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 
   pageModifications.register(
+    `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}`,
+    processHoverableElements
+  );
+
+  pageModifications.register(
     `:is(${postSelector}, ${keyToCss('blockEditorContainer')}) ${keyToCss('rows')}`,
     processRows
   );
@@ -149,6 +161,7 @@ export const clean = async function () {
   pageModifications.unregister(processGifs);
   pageModifications.unregister(processBackgroundGifs);
   pageModifications.unregister(processRows);
+  pageModifications.unregister(processHoverableElements);
 
   [...document.querySelectorAll(`.${containerClass}`)].forEach(wrapper =>
     wrapper.replaceWith(...wrapper.children)
@@ -156,4 +169,5 @@ export const clean = async function () {
 
   $(`.${canvasClass}, .${labelClass}`).remove();
   $(`.${backgroundGifClass}`).removeClass(backgroundGifClass);
+  $(`[${hoverContainerAttribute}]`).removeAttr(hoverContainerAttribute);
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -120,7 +120,6 @@ const createPausedUrl = memoize(async sourceUrl => {
 
 const processGifs = function (gifElements) {
   gifElements.forEach(async gifElement => {
-    if (!gifElement.matches('[srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]')) return;
     if (gifElement.closest('.block-editor-writing-flow')) return;
 
     const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
@@ -148,10 +147,6 @@ const processGifs = function (gifElements) {
 const sourceUrlRegex = /(?<=url\(["'])[^)]*?\.(?:gif|gifv|webp)(?=["']\))/g;
 const processBackgroundGifs = function (gifBackgroundElements) {
   gifBackgroundElements.forEach(async gifBackgroundElement => {
-    // tumblr tv 'videoHubCardWrapper' video cards may be initially rendered with the wrong background
-    if (gifBackgroundElement.matches(keyToCss('videoHubCardWrapper'))) await new Promise(requestAnimationFrame);
-    if (!gifBackgroundElement.matches('[style*=".gif"], [style*=".webp"]')) return;
-
     const sourceValue = gifBackgroundElement.style.backgroundImage;
     const sourceUrl = sourceValue.match(sourceUrlRegex)?.[0];
     if (!sourceUrl) return;
@@ -210,7 +205,7 @@ export const main = async function () {
         'videoHubsFeatured', // tumblr tv recommended card: https://www.tumblr.com/dashboard/tumblr_tv
         'takeoverBanner' // advertisement
       )}
-    ) img:not(${keyToCss('poster')})
+    ) img:is([srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
 
@@ -223,7 +218,7 @@ export const main = async function () {
       'tagChicletWrapper', // "trending" / "your tags" timeline carousel entry: https://www.tumblr.com/dashboard/trending, https://www.tumblr.com/dashboard/hubs
       'communityCategoryImage', // tumblr communities browse page entry: https://www.tumblr.com/communities/browse, https://www.tumblr.com/communities/browse/movies
       'videoHubCardWrapper' // tumblr tv channels section: https://www.tumblr.com/dashboard/tumblr_tv
-    )}[style]
+    )}:is([style*=".gif"], [style*=".webp"])
   `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<img src="https://github.com/user-attachments/assets/511e57b8-5be2-4d9a-8709-85823247f27d">

Fun bit of CSS experimentation. This applies a temporary blur effect to images with GIF backgrounds that will be animated only for a moment while we're processing them. Like #1128 and #960, care is taken not to apply the effect when the extension is first loaded or the feature is switched on to avoid an unblurred -> blurred -> unblurred chain. Not sure this is really any better than not doing it, but it's cute.

Have you heard of the [contain](https://developer.mozilla.org/en-US/docs/Web/CSS/contain) CSS property? I sure hadn't.

Branch based off of #1729.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

