### PR TITLE
No Recommended: Fix blog/community hiding with Tumblr Savior enabled

### DIFF
--- a/src/features/no_recommended/hide_blog_carousels.js
+++ b/src/features/no_recommended/hide_blog_carousels.js
@@ -18,8 +18,11 @@ const hideBlogCarousels = carousels =>
     const { elements } = await timelineObject(carousel);
     if (elements.some(({ objectType }) => objectType === 'blog')) {
       const timelineItem = getTimelineItemWrapper(carousel);
-      if (timelineItem.previousElementSibling.querySelector(keyToCss('titleObject'))) {
-        timelineItem.setAttribute(hiddenAttribute, '');
+      timelineItem.setAttribute(hiddenAttribute, '');
+      if (
+        timelineItem.previousElementSibling.querySelector(keyToCss('titleObject')) ||
+        timelineItem.previousElementSibling.dataset.cellId?.startsWith('timelineObject:title')
+      ) {
         timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
       }
     }

--- a/src/features/no_recommended/hide_blog_carousels.js
+++ b/src/features/no_recommended/hide_blog_carousels.js
@@ -18,11 +18,11 @@ const hideBlogCarousels = carousels =>
     const { elements } = await timelineObject(carousel);
     if (elements.some(({ objectType }) => objectType === 'blog')) {
       const timelineItem = getTimelineItemWrapper(carousel);
-      timelineItem.setAttribute(hiddenAttribute, '');
       if (
         timelineItem.previousElementSibling.querySelector(keyToCss('titleObject')) ||
         timelineItem.previousElementSibling.dataset.cellId?.startsWith('timelineObject:title')
       ) {
+        timelineItem.setAttribute(hiddenAttribute, '');
         timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
       }
     }

--- a/src/features/no_recommended/hide_community_carousels.js
+++ b/src/features/no_recommended/hide_community_carousels.js
@@ -18,11 +18,11 @@ const hideCommunityCarousels = carousels =>
     const { elements } = await timelineObject(carousel);
     if (elements.some(({ objectType }) => objectType === 'community_card')) {
       const timelineItem = getTimelineItemWrapper(carousel);
-      timelineItem.setAttribute(hiddenAttribute, '');
       if (
         timelineItem.previousElementSibling.querySelector(keyToCss('titleObject')) ||
         timelineItem.previousElementSibling.dataset.cellId?.startsWith('timelineObject:title')
       ) {
+        timelineItem.setAttribute(hiddenAttribute, '');
         timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
       }
     }

--- a/src/features/no_recommended/hide_community_carousels.js
+++ b/src/features/no_recommended/hide_community_carousels.js
@@ -18,8 +18,11 @@ const hideCommunityCarousels = carousels =>
     const { elements } = await timelineObject(carousel);
     if (elements.some(({ objectType }) => objectType === 'community_card')) {
       const timelineItem = getTimelineItemWrapper(carousel);
-      if (timelineItem.previousElementSibling.querySelector(keyToCss('titleObject'))) {
-        timelineItem.setAttribute(hiddenAttribute, '');
+      timelineItem.setAttribute(hiddenAttribute, '');
+      if (
+        timelineItem.previousElementSibling.querySelector(keyToCss('titleObject')) ||
+        timelineItem.previousElementSibling.dataset.cellId?.startsWith('timelineObject:title')
+      ) {
         timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
       }
     }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes the "Hide recommended communities between posts" and "Hide recommended blogs between posts" features of No Recommended when certain other extension features are enabled, such as Tumblr Savior's "Hide timeline objects" setting, and endless scrolling is enabled.

It may improve the reliability of both features with endless scrolling in general.

Resolves #1724.

### Technical details

As noted in the linked issue, Tumblr's virtual scroller may remove the "titleObject" element from the DOM before our code processes the carousel element. We thus need to not rely on its presence.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

These features are a pain to test because the elements they hide don't always show up and will show up less if you repeatedly view a timeline they're allowed to appear on. The For You tab seems to have some carousels a bit more reliably.

- Confirm that blog and community carousels are hidden by the relevant features with endless scrolling on.
- Confirm that blog and community carousels are hidden by the relevant features with endless scrolling off.
- Enable endless scrolling, apply the CSS `.rZlUD[data-cell-id*="timelineObject"] {display:none!important;}` or install Tumblr Savior and enable its rule which does so, and confirm that blog and community carousels are hidden by the relevant features.