### PR TITLE
AccessKit Disable GIFs: Fix unstretched photoset hover area

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -115,7 +115,7 @@ const processBackgroundGifs = function (gifBackgroundElements) {
 const processRows = function (rowsElements) {
   rowsElements.forEach(rowsElement => {
     [...rowsElement.children].forEach(row => {
-      if (!row.querySelector('figure')) return;
+      if (!row.querySelector(`figure:not(${keyToCss('unstretched')})`)) return;
 
       if (row.previousElementSibling?.classList?.contains(containerClass)) {
         row.previousElementSibling.append(row);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Sufficiently-narrow images are not stretched horizontally to the post container width on desktop Tumblr. This fixes a minor issue with our current code where the hover-to-animate area of a disabled unstretched GIF included the blank space to its right and any adjacent non-animated images, because we were processing them as if they're part of a photoset.

Note that at time of writing I left a bug in this: resizing the viewport across the desktop <-> tablet boundary in either direction results in slightly unintended photoset hover behavior, though it's no worse than before.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Open https://www.tumblr.com/transienttest/775813961932324864/one-gif-two-gifs-red-gif-whatever-i-cant-be with the desktop viewport width. Confirm that hover areas are correct: unstretched images are unpaused when hovered; "photosets" are unpaused when any part of them are hovered.
- Resize the viewport to the tablet or mobile viewport width. Observe that hovering is... good enough.
- Open https://www.tumblr.com/transienttest/775813961932324864/one-gif-two-gifs-red-gif-whatever-i-cant-be with the tablet or mobile viewport width. Confirm that hover areas are correct: "photosets" are unpaused when any part of them are hovered.
- Resize the viewport to the desktop viewport width. Observe that hovering is the way it was without this PR.

