### PR TITLE
AccessKit Disable GIFs: Improve labels on GIF dividers

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -60,10 +60,9 @@ export const styleElement = buildStyle(`
 
 const addLabel = (element, inside = false) => {
   if (element.parentNode.querySelector(`.${labelClass}`) === null) {
-    const gifLabel = document.createElement('p');
-    gifLabel.className = element.clientWidth && element.clientWidth < 150
-      ? `${labelClass} mini`
-      : labelClass;
+    const gifLabel = dom('p', { class: labelClass });
+    element.clientWidth && element.clientWidth <= 150 && gifLabel.classList.add('mini');
+    element.clientHeight && element.clientHeight <= 50 && gifLabel.classList.add('mini');
 
     inside ? element.append(gifLabel) : element.parentNode.append(gifLabel);
   }

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -23,6 +23,7 @@ export const styleElement = buildStyle(`
   font-size: 1rem;
   font-weight: bold;
   line-height: 1em;
+  pointer-events: none;
 }
 
 .${labelClass}::before {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -34,6 +34,11 @@ export const styleElement = buildStyle(`
   font-size: 0.6rem;
 }
 
+.${labelClass}.hr {
+  top: 50%;
+  transform: translateY(-50%);
+}
+
 .${canvasClass} {
   position: absolute;
   visibility: visible;
@@ -63,6 +68,7 @@ const addLabel = (element, inside = false) => {
     const gifLabel = dom('p', { class: labelClass });
     element.clientWidth && element.clientWidth <= 150 && gifLabel.classList.add('mini');
     element.clientHeight && element.clientHeight <= 50 && gifLabel.classList.add('mini');
+    element.clientHeight && element.clientHeight <= 30 && gifLabel.classList.add('hr');
 
     inside ? element.append(gifLabel) : element.parentNode.append(gifLabel);
   }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This improves the size and layout of GIF labels on images with a low height value, such as those used as `<hr>`-style dividers, particularly in the roleplay community.

Labels that escape their parent images' bounding boxes won't flicker when hovered, small labels are applied to images based on height as well as width, and labels are centered vertically on small elements.

Resolves #678.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

There are some example divider/banner images reblogged in https://www.tumblr.com/communities/test-community-46174.
