### PR TITLE
Tweaks: Apply "restore links to individual posts" to new post header

### DIFF
--- a/src/features/tweaks/restore_attribution_links.js
+++ b/src/features/tweaks/restore_attribution_links.js
@@ -3,10 +3,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { timelineObject } from '../../utils/react_props.js';
 import { navigate } from '../../utils/tumblr_helpers.js';
 
-const postAttributionLinkSelector = `
-  header ${keyToCss('attribution')} > span:not(${keyToCss('reblogAttribution')}) a,
-  header ${keyToCss('headline')} a${keyToCss('blogLink')}
-`;
+const postAttributionLinkSelector = 'header a[rel="author"]';
 const reblogAttributionLinkSelector = `
   header ${keyToCss('rebloggedFromName')} a,
   header ${keyToCss('subheader')} a${keyToCss('blogLink')}

--- a/src/features/tweaks/restore_attribution_links.js
+++ b/src/features/tweaks/restore_attribution_links.js
@@ -3,8 +3,14 @@ import { keyToCss } from '../../utils/css_map.js';
 import { timelineObject } from '../../utils/react_props.js';
 import { navigate } from '../../utils/tumblr_helpers.js';
 
-const postAttributionLinkSelector = `header ${keyToCss('attribution')} > span:not(${keyToCss('reblogAttribution')}) a`;
-const reblogAttributionLinkSelector = `header ${keyToCss('rebloggedFromName')} a`;
+const postAttributionLinkSelector = `
+  header ${keyToCss('attribution')} > span:not(${keyToCss('reblogAttribution')}) a,
+  header ${keyToCss('headline')} a${keyToCss('blogLink')}
+`;
+const reblogAttributionLinkSelector = `
+  header ${keyToCss('rebloggedFromName')} a,
+  header ${keyToCss('subheader')} a${keyToCss('blogLink')}
+`;
 
 const onLinkClick = event => {
   event.stopPropagation();


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This updates the selectors in the "restore links to individual posts" tweak so the feature will apply to the new post header that's used in community posts if it's ever used for regular ones.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

I can confirm that this works with unreleased code, but it isn't really currently testable normally.

- Confirm that the "restore links to individual posts" tweak affects post attribution and reblog attribution links on "regular" posts.

