### PR TITLE
 Tweaks: Apply "hide mini-follow buttons" to new post header

### DIFF
--- a/src/features/tweaks/hide_mini_follow.js
+++ b/src/features/tweaks/hide_mini_follow.js
@@ -1,6 +1,24 @@
 import { keyToCss } from '../../utils/css_map.js';
-import { buildStyle } from '../../utils/interface.js';
+import { buildStyle, postSelector } from '../../utils/interface.js';
+import { pageModifications } from '../../utils/mutations.js';
+import { timelineObject } from '../../utils/react_props.js';
+
+const hiddenAttribute = 'data-tweaks-hide-mini-follow-hidden';
 
 export const styleElement = buildStyle(`
-article ${keyToCss('followButton')}:not(${keyToCss('postMeatballsContainer')} *) { display: none; }
+article ${keyToCss('followButton')}:not(${keyToCss('postMeatballsContainer')} *), [${hiddenAttribute}] { display: none; }
 `);
+
+const processButtons = buttons => buttons.forEach(async button => {
+  const { headerCta } = await timelineObject(button.closest(postSelector));
+  headerCta?.action?.action === 'follow' && button.setAttribute(hiddenAttribute, '');
+});
+
+export const main = async () => {
+  pageModifications.register(`${postSelector} ${keyToCss('rightContent')} > button`, processButtons);
+};
+
+export const clean = async () => {
+  pageModifications.unregister(processButtons);
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
+};


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This updates the "hide mini-follow buttons" tweak so the feature will apply to the new post header that's used in community posts if it's ever used for regular ones. (Okay, they're not really "mini" buttons anymore.)

There's no distinguishing CSS for follow buttons, so I made really sure we don't hit the wrong ones by checking the post data.

At time of writing, this code is for a UI element that doesn't exist.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

