### PR TITLE
Themed Posts: Adjust identical background/foreground colors.

### DIFF
--- a/src/features/themed_posts.js
+++ b/src/features/themed_posts.js
@@ -51,9 +51,24 @@ const processPosts = async function (postElements) {
           linkColor
         } = theme;
 
+        const hexToRGBAdjusted = color => {
+          if (color === backgroundColor) {
+            const cssSign = val => `(sqrt(pow(${val}, 2)) / ${val})`;
+
+            const isDarkThreshold = 0.5;
+            const negativeIfDark = cssSign(`(l - ${isDarkThreshold})`);
+
+            const adjustmentAmount = 0.1;
+            const newColor = `oklch(from ${color} calc(l - ${adjustmentAmount} * ${negativeIfDark}) c h)`;
+            const adjusted = `from ${newColor} r g b`;
+            if (CSS.supports('color', `rgb(${adjusted})`)) return adjusted;
+          }
+          return hexToRGB(color);
+        };
+
         const backgroundColorRGB = hexToRGB(backgroundColor);
-        const titleColorRGB = hexToRGB(titleColor);
-        const linkColorRGB = hexToRGB(linkColor);
+        const titleColorRGB = hexToRGBAdjusted(titleColor);
+        const linkColorRGB = hexToRGBAdjusted(linkColor);
 
         styleElement.textContent += `
           [data-xkit-themed="${name}"] {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

I am immeasurably pissed that this doesn't actually work. You should have heard me when I figured out that you could do it.

On supporting browser versions, this makes the text/accent colors used by Themed Posts 10% lighter or darker if they exactly match the background depending on whether they're light or dark, with the "is it light or dark; go the opposite way" logic implemented in pure CSS. Without [sign()](https://developer.mozilla.org/en-US/docs/Web/CSS/sign).

This doesn't work because Tumblr uses the legacy `rgba(var(--someVariable), 0.5)` syntax instead of `rgba(var(--someVariable) / 0.5)` and you can't mix and match modern and legacy syntax.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

