### PR TITLE
Vanilla Videos: Fix non square pixel video aspect ratio

### DIFF
--- a/src/features/vanilla_video.js
+++ b/src/features/vanilla_video.js
@@ -20,6 +20,7 @@ const cloneVideoElements = videoElements => videoElements.forEach(videoElement =
 
   if (videoElement.width && videoElement.height) {
     newVideoElement.style.setProperty('aspect-ratio', `${videoElement.width} / ${videoElement.height}`);
+    newVideoElement.addEventListener('loadedmetadata', () => newVideoElement.style.removeProperty('aspect-ratio'), { once: true });
   }
 
   const videoSources = [...videoElement.children];


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Vanilla Videos currently creates video elements with the incorrect height when a source video has non-square pixels. This fixes this by removing the (usually correct, but sometimes erroneous) aspect ratio override that causes the issue once it's no longer needed to prevent virtual scroller bugs.

I actually kind of predicted that this would be necessary in #1652, which added the code in question:

> In theory, we could probably add an onload function that removes the CSS property this adds, ensuring that if for some reason the width/height values set on the video element by redpop differ from the actual resulting video's size they'll be ignored.

I admittedly didn't do much research into the events we could use here. `loadedmetadata` seemed to work, so...

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- With this PR, enable Vanilla Videos and confirm that https://www.tumblr.com/transienturl/777134194463817728 is displayed with the correct height.

<br />

- In Chrome, with this PR, enable Vanilla Videos and scroll rapidly up and down on https://www.tumblr.com/search/video. Confirm that posts do not overlap each other.
- For comparison, comment the entire `if (videoElement.width && videoElement.height)` block and repeat. Confirm that posts do sometimes overlap each other. The fix thus still works.

