### PR TITLE
AccessKit Disable GIFs: Pause additional elements

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -39,8 +39,6 @@ export const styleElement = buildStyle(`
 
 .${canvasClass} {
   position: absolute;
-  top: 0;
-  left: 0;
   visibility: visible;
 
   background-color: rgb(var(--white));
@@ -172,14 +170,12 @@ export const main = async function () {
       figure, /* post image/imageset; recommended blog carousel entry; blog view sidebar "more like this"; post in grid view; blog card modal post entry */
       ${keyToCss(
         'linkCard', // post link element
-        'messageImage', // direct message attached image
-        'messagePost', // direct message linked post
         'typeaheadRow', // modal search dropdown entry
         'tagImage', // search page sidebar related tags, recommended tag carousel entry: https://www.tumblr.com/search/gif, https://www.tumblr.com/explore/recommended-for-you
         'topPost', // activity page top post
         'takeoverBanner' // advertisement
       )}
-    ) img:is([srcset*=".gif"], [src*=".gif"]):not(${keyToCss('poster')})
+    ) img[srcset*=".gif"]:not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -4,10 +4,14 @@ import { dom } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
+const pausedPosterAttribute = 'data-paused-gif-use-poster';
 const hoverContainerAttribute = 'data-paused-gif-hover-container';
 const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
+
+const hovered = `:is(:hover, [${hoverContainerAttribute}]:hover *)`;
+const parentHovered = `:is(:hover > *, [${hoverContainerAttribute}]:hover *)`;
 
 export const styleElement = buildStyle(`
 .${labelClass} {
@@ -41,11 +45,21 @@ export const styleElement = buildStyle(`
   background-color: rgb(var(--white));
 }
 
-*:hover > .${canvasClass},
-*:hover > .${labelClass},
-[${hoverContainerAttribute}]:hover .${canvasClass},
-[${hoverContainerAttribute}]:hover .${labelClass} {
+.${canvasClass}${parentHovered},
+.${labelClass}${parentHovered},
+[${pausedPosterAttribute}]:not(${hovered}) > div > ${keyToCss('knightRiderLoader')} {
   display: none;
+}
+${keyToCss('background')} .${labelClass} {
+  /* prevent double labels in recommended post cards */
+  display: none;
+}
+
+[${pausedPosterAttribute}]:not(${hovered}) > img${keyToCss('poster')} {
+  visibility: visible !important;
+}
+[${pausedPosterAttribute}]:not(${hovered}) > img:not(${keyToCss('poster')}) {
+  visibility: hidden !important;
 }
 
 .${backgroundGifClass}:not(:hover) {
@@ -99,6 +113,13 @@ const processGifs = function (gifElements) {
     }
 
     gifElement.decoding = 'sync';
+
+    const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
+    if (posterElement) {
+      gifElement.parentElement.setAttribute(pausedPosterAttribute, '');
+      addLabel(posterElement);
+      return;
+    }
 
     if (gifElement.complete && gifElement.currentSrc) {
       pauseGif(gifElement);
@@ -168,5 +189,6 @@ export const clean = async function () {
 
   $(`.${canvasClass}, .${labelClass}`).remove();
   $(`.${backgroundGifClass}`).removeClass(backgroundGifClass);
+  $(`[${pausedPosterAttribute}]`).removeAttr(pausedPosterAttribute);
   $(`[${hoverContainerAttribute}]`).removeAttr(hoverContainerAttribute);
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -98,6 +98,8 @@ const processGifs = function (gifElements) {
       return;
     }
 
+    gifElement.decoding = 'sync';
+
     if (gifElement.complete && gifElement.currentSrc) {
       pauseGif(gifElement);
     } else {

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -170,18 +170,13 @@ export const main = async function () {
   const gifImage = `
     :is(
       figure, /* post image/imageset; recommended blog carousel entry; blog view sidebar "more like this"; post in grid view; blog card modal post entry */
-      /* main.labs, /* labs settings header: https://www.tumblr.com/settings/labs */
       ${keyToCss(
         'linkCard', // post link element
-        // 'albumImage', // post audio element
         'messageImage', // direct message attached image
         'messagePost', // direct message linked post
         'typeaheadRow', // modal search dropdown entry
         'tagImage', // search page sidebar related tags, recommended tag carousel entry: https://www.tumblr.com/search/gif, https://www.tumblr.com/explore/recommended-for-you
-        // 'headerBanner', // blog view header
-        // 'headerImage', // modal blog card header, activity page "biggest fans" header
         'topPost', // activity page top post
-        // 'colorfulListItemWrapper', // trending tag: https://www.tumblr.com/explore/trending
         'takeoverBanner' // advertisement
       )}
     ) img:is([srcset*=".gif"], [src*=".gif"]):not(${keyToCss('poster')})

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -39,6 +39,8 @@ export const styleElement = buildStyle(`
 
 .${canvasClass} {
   position: absolute;
+  top: 0;
+  left: 0;
   visibility: visible;
 
   background-color: rgb(var(--white));
@@ -69,7 +71,7 @@ ${keyToCss('background')}[${labelAttribute}]::after {
   background-color: rgb(var(--secondary-accent));
 }
 
-.${backgroundGifClass}:not(:hover) > div {
+.${backgroundGifClass}:not(:hover) > :is(div, span) {
   color: rgb(var(--black));
 }
 `);
@@ -166,17 +168,37 @@ export const main = async function () {
   ({ disable_gifs_loading_mode: loadingMode } = await getPreferences('accesskit'));
 
   const gifImage = `
-    :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img[srcset*=".gif"]:not(${keyToCss('poster')})
+    :is(
+      figure, /* post image/imageset; recommended blog carousel entry; blog view sidebar "more like this"; post in grid view; blog card modal post entry */
+      /* main.labs, /* labs settings header: https://www.tumblr.com/settings/labs */
+      ${keyToCss(
+        'linkCard', // post link element
+        // 'albumImage', // post audio element
+        'messageImage', // direct message attached image
+        'messagePost', // direct message linked post
+        'typeaheadRow', // modal search dropdown entry
+        'tagImage', // search page sidebar related tags, recommended tag carousel entry: https://www.tumblr.com/search/gif, https://www.tumblr.com/explore/recommended-for-you
+        // 'headerBanner', // blog view header
+        // 'headerImage', // modal blog card header, activity page "biggest fans" header
+        'topPost', // activity page top post
+        // 'colorfulListItemWrapper', // trending tag: https://www.tumblr.com/explore/trending
+        'takeoverBanner' // advertisement
+      )}
+    ) img:is([srcset*=".gif"], [src*=".gif"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
 
   const gifBackgroundImage = `
-    ${keyToCss('communityHeaderImage', 'bannerImage')}[style*=".gif"]
+    ${keyToCss(
+      'communityHeaderImage', // search page tags section header: https://www.tumblr.com/search/gif?v=tag
+      'bannerImage', // tagged page sidebar header: https://www.tumblr.com/tagged/gif
+      'tagChicletWrapper' // "trending" / "your tags" timeline carousel entry: https://www.tumblr.com/dashboard/trending, https://www.tumblr.com/dashboard/hubs
+    )}[style*=".gif"]
   `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 
   pageModifications.register(
-    `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}`,
+    `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}`, // recommended blog carousel entry: https://www.tumblr.com/tagged/gif
     processHoverableElements
   );
 

--- a/src/features/accesskit/feature.json
+++ b/src/features/accesskit/feature.json
@@ -14,6 +14,15 @@
       "label": "Pause GIFs until they are hovered over",
       "default": false
     },
+    "disable_gifs_loading_mode": {
+      "type": "select",
+      "label": "Download paused GIFs:",
+      "options": [
+        { "value": "eager", "label": "immediately" },
+        { "value": "lazy", "label": "when hovered" }
+      ],
+      "default": "eager"
+    },
     "boring_tag_chiclets": {
       "type": "checkbox",
       "label": "De-animate the Changes/Staff Picks/etc. links carousel",


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds additional selectors for GIFs that can be paused with minimal changes to the current Disable GIFs code and comments that list the elements referred to.

Based off of the branch for #1740 and tested that way. **Note:** most/all of these don't need that PR; let me know if you'd like them tested and PR'd separately. If merging both, it reduces testing to test them together (though it might require a rebase of this branch, annoyingly).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that each element listed in the source code is paused correctly, has a label, and unpauses correctly when hovered.
- Confirm that paused carousels on https://www.tumblr.com/dashboard/trending / https://www.tumblr.com/dashboard/hubs have readable text.

Note: the GIFs in the search dropdown modal don't have labels when I test this in Safari 17.6; this happens whether I use the `<p>`-element or pseudo element label and I'm pretty certain it's a Safari bug with canvas elements.

Edit: Smoke tested in Safari 18.1.1 on iOS. Real nice for spotty connections.
