### PR TITLE
AccessKit Disable GIFs: Exclude blog avatars

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -88,7 +88,7 @@ const pauseGif = function (gifElement) {
 
 const processGifs = function (gifElements) {
   gifElements.forEach(gifElement => {
-    if (gifElement.closest('.block-editor-writing-flow')) return;
+    if (gifElement.closest(`${keyToCss('avatarImage')}, .block-editor-writing-flow`)) return;
     const pausedGifElements = [
       ...gifElement.parentNode.querySelectorAll(`.${canvasClass}`),
       ...gifElement.parentNode.querySelectorAll(`.${labelClass}`)


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This prevents AccessKit Disable GIFs from processing blog avatar elements in posts, preventing "GIF" labels from being added to avatars that aren't animated, but have the GIF filetype.

This being a good idea is based on the assumption that Tumblr successfully prevents users from uploading animated avatar images. (Of course, if that fails we'd want to add a bunch of CSS selectors to _consistently_ pause avatar images; right now only the new header element used in communities is affected.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable AccessKit Disable GIFs and confirm that the blog avatar in https://www.tumblr.com/communities/test-community-46174/post/778120974205878272/post-from-a-blog-with-a-gif-avatar does not have a Disable GIFs label.
