### PR TITLE
chore: Rename Changes/Shop/etc. carousel in options UI

### DIFF
--- a/src/features/accesskit.json
+++ b/src/features/accesskit.json
@@ -16,7 +16,7 @@
     },
     "boring_tag_chiclets": {
       "type": "checkbox",
-      "label": "De-animate the Changes/Shop/etc. links carousel",
+      "label": "De-animate the Changes/Staff Picks/etc. links carousel",
       "default": false
     },
     "disable_animations": {

--- a/src/features/tweaks.json
+++ b/src/features/tweaks.json
@@ -34,7 +34,7 @@
     },
     "caught_up_line": {
       "type": "checkbox",
-      "label": "Turn the Changes/Shop/etc. links carousel into a separating line",
+      "label": "Turn the Changes/Staff Picks/etc. links carousel into a separating line",
       "default": false
     },
     "no_focus_shadow": {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

> Side note, we need to update our verbiage from "Changes/Shop/etc. links carousel" in AccessKit and Tweaks... there's no more Tumblr shop link in that carousel.

_Originally posted by @AprilSylph in https://github.com/AprilSylph/XKit-Rewritten/discussions/1745#discussioncomment-12582154_

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that the changes to labels look reasonable in the options UI.

<img width="394" src="https://github.com/user-attachments/assets/af712c58-93a0-49a6-ba44-b60804de6426">


