### PR TITLE
No Recommended: Hide posts from non-joined communities in For You

### DIFF
--- a/src/features/no_recommended.json
+++ b/src/features/no_recommended.json
@@ -13,6 +13,11 @@
       "label": "Hide experimental types of recommended posts",
       "default": true
     },
+    "hide_recommended_community_posts": {
+      "type": "checkbox",
+      "label": "Hide posts from non-followed communities in For You",
+      "default": false
+    },
     "hide_answertime": {
       "type": "checkbox",
       "label": "Hide the answertime banner",

--- a/src/features/no_recommended.json
+++ b/src/features/no_recommended.json
@@ -15,7 +15,7 @@
     },
     "hide_recommended_community_posts": {
       "type": "checkbox",
-      "label": "Hide posts from non-followed communities in For You",
+      "label": "Hide posts from non-joined communities in For You",
       "default": false
     },
     "hide_answertime": {

--- a/src/features/no_recommended/hide_recommended_community_posts.js
+++ b/src/features/no_recommended/hide_recommended_community_posts.js
@@ -1,0 +1,29 @@
+import { buildStyle, filterPostElements, getTimelineItemWrapper } from '../../utils/interface.js';
+import { onNewPosts } from '../../utils/mutations.js';
+import { timelineObject } from '../../utils/react_props.js';
+import { forYouTimelineFilter } from '../../utils/timeline_id.js';
+import { joinedCommunityUuids } from '../../utils/user.js';
+
+const hiddenAttribute = 'data-no-recommended-community-posts-hidden';
+const timeline = forYouTimelineFilter;
+const includeFiltered = true;
+
+export const styleElement = buildStyle(`[${hiddenAttribute}] article { display: none; }`);
+
+const processPosts = postElements =>
+  filterPostElements(postElements, { timeline, includeFiltered }).forEach(async postElement => {
+    const { community } = await timelineObject(postElement);
+    if (community && !joinedCommunityUuids.includes(community.uuid)) {
+      getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
+    }
+  });
+
+export const main = async function () {
+  onNewPosts.addListener(processPosts);
+};
+
+export const clean = async function () {
+  onNewPosts.removeListener(processPosts);
+
+  $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
+};


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds a No Recommended option that hides posts from non-followed communities in the For You feed, something which Tumblr doesn't have a config option for. Many users find that this type of recommendation, at least at the moment, often isn't relevant to their interests. (Maybe that'll change with increased use of communities, but at least in my experience there simply doesn't seem to be enough communities content for pretty much any of it to be relevant to me.)

Note that Tumblr _does_ have an option not to add posts from communities you **do** follow in the **Following** feed; it's near the bottom of https://www.tumblr.com/settings/dashboard. We naturally won't add an XKit option to do this, as that would be redundant.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that the new No Recommended option works as specified on https://www.tumblr.com/dashboard/stuff_for_you.
- Confirm that the new No Recommended option works as specified on a For You feed in Tumblr Patio.