### PR TITLE
TimeFormat: Fix reply timestamp formatting

### DIFF
--- a/src/features/timeformat.js
+++ b/src/features/timeformat.js
@@ -94,7 +94,7 @@ const formatTimeElements = function (timeElements) {
     const momentDate = moment(timeElement.dateTime, moment.ISO_8601);
     timeElement.dataset.formattedTime = momentDate.format(format);
     if (displayRelative) {
-      timeElement.dataset.formattedTime += '\u2002\u00B7\u2002';
+      timeElement.dataset.formattedTime += '\u00A0\u00B7\u00A0';
       timeElement.dataset.formattedRelativeTime = constructRelativeTimeString(momentDate.unix());
     }
   });

--- a/src/features/timeformat.js
+++ b/src/features/timeformat.js
@@ -61,6 +61,11 @@ ${keyToCss('blogLinkWrapper')} + a:has(> [data-formatted-time]) {
 a > [data-formatted-relative-time]::after {
   display: inline;
 }
+
+a > [data-formatted-time][title]::before,
+a > [data-formatted-time][title]::after {
+  cursor: pointer;
+}
 `);
 
 const relativeTimeFormat = new Intl.RelativeTimeFormat(document.documentElement.lang, { style: 'long' });

--- a/src/features/timeformat.js
+++ b/src/features/timeformat.js
@@ -58,6 +58,15 @@ ${keyToCss('blogLinkWrapper')} + a:has(> [data-formatted-time]) {
   overflow-x: hidden;
 }
 
+${keyToCss('timestampLink')} [data-formatted-time]:is(:focus, :hover) {
+  text-decoration: none;
+}
+
+${keyToCss('timestampLink')} [data-formatted-time]:is(:focus, :hover)::before,
+${keyToCss('timestampLink')} [data-formatted-time]:is(:focus, :hover)::after {
+  text-decoration: underline;
+}
+
 ${keyToCss('timestampLink')} [data-formatted-relative-time]::after {
   display: inline;
 }

--- a/src/features/timeformat.js
+++ b/src/features/timeformat.js
@@ -28,8 +28,8 @@ ${keyToCss('userRow')} [data-formatted-time] {
   flex-wrap: wrap;
 }
 
-${keyToCss('userRow')} [data-formatted-time]::before,
-${keyToCss('userRow')} [data-formatted-relative-time]::after {
+${keyToCss('userRow', 'timestampLink')} [data-formatted-time]::before,
+${keyToCss('userRow', 'timestampLink')} [data-formatted-relative-time]::after {
   font-size: .875rem;
 }
 
@@ -58,12 +58,12 @@ ${keyToCss('blogLinkWrapper')} + a:has(> [data-formatted-time]) {
   overflow-x: hidden;
 }
 
-a > [data-formatted-relative-time]::after {
+${keyToCss('timestampLink')} [data-formatted-relative-time]::after {
   display: inline;
 }
 
-a > [data-formatted-time][title]::before,
-a > [data-formatted-time][title]::after {
+${keyToCss('timestampLink')} [data-formatted-time][title]::before,
+${keyToCss('timestampLink')} [data-formatted-time][title]::after {
   cursor: pointer;
 }
 `);

--- a/src/features/timeformat.js
+++ b/src/features/timeformat.js
@@ -47,13 +47,19 @@ ${keyToCss('userRow')} ${keyToCss('timestamp')}:has([data-formatted-time]) {
   flex-wrap: nowrap;
 }
 
-${keyToCss('blogLinkWrapper')}:has(+ [data-formatted-time]) {
+${keyToCss('blogLinkWrapper')}:has(+ [data-formatted-time]),
+${keyToCss('blogLinkWrapper')}:has(+ a > [data-formatted-time]) {
   flex: none;
 }
 
-${keyToCss('blogLinkWrapper')} + [data-formatted-time] {
+${keyToCss('blogLinkWrapper')} + [data-formatted-time],
+${keyToCss('blogLinkWrapper')} + a:has(> [data-formatted-time]) {
   white-space: nowrap;
   overflow-x: hidden;
+}
+
+a > [data-formatted-relative-time]::after {
+  display: inline;
 }
 `);
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes the layout improvements added in #1110 and an erroneous lack of underline beneath the relative part of the formatted time when hovered in reply timestamps that are links (currently unreleased/in-testing Tumblr code).

<img width=484 src="https://github.com/user-attachments/assets/6d922cc0-abce-4bbe-a7a7-93be03db3d1f">


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable the "append relative time" option in TimeFormat and find a reply with a relatively long blog name (such as <https://www.tumblr.com/once-more-with-gravitas/778774885212225536/ah-dangit>).
- Confirm that reply timestamps stay as a single line with and without the relevant feature flag.
- Confirm that reply timestamps are underlined consistently when hovered with the relevant feature flag.
