### PR TITLE
Refactor: Use browser.storage.local.onChanged.addListener

### DIFF
--- a/src/action/render_backup.js
+++ b/src/action/render_backup.js
@@ -78,11 +78,7 @@ const localRestore = async function () {
 
 const renderLocalBackup = async function () {
   updateLocalExportDisplay();
-  browser.storage.onChanged.addListener((changes, areaName) => {
-    if (areaName === 'local') {
-      updateLocalExportDisplay();
-    }
-  });
+  browser.storage.local.onChanged.addListener(updateLocalExportDisplay);
 
   localCopyButton.addEventListener('click', localCopy);
   localDownloadButton.addEventListener('click', localExport);

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -33,21 +33,19 @@
       document.documentElement.append(styleElement);
     }
 
-    restartListeners[name] = async (changes, areaName) => {
-      if (areaName !== 'local') return;
-
+    restartListeners[name] = async (changes) => {
       const { enabledScripts } = changes;
       if (enabledScripts && !enabledScripts.newValue.includes(name)) return;
 
       if (onStorageChanged instanceof Function) {
-        onStorageChanged(changes, areaName);
+        onStorageChanged(changes);
       } else if (Object.keys(changes).some(key => key.startsWith(`${name}.preferences`) && changes[key].oldValue !== undefined)) {
         await clean?.();
         await main?.();
       }
     };
 
-    browser.storage.onChanged.addListener(restartListeners[name]);
+    browser.storage.local.onChanged.addListener(restartListeners[name]);
   };
 
   const destroyScript = async function (name) {
@@ -67,15 +65,11 @@
       styleElement.remove();
     }
 
-    browser.storage.onChanged.removeListener(restartListeners[name]);
+    browser.storage.local.onChanged.removeListener(restartListeners[name]);
     delete restartListeners[name];
   };
 
-  const onStorageChanged = async function (changes, areaName) {
-    if (areaName !== 'local') {
-      return;
-    }
-
+  const onStorageChanged = async function (changes) {
     const { enabledScripts } = changes;
 
     if (enabledScripts) {
@@ -110,7 +104,7 @@
   const init = async function () {
     $('style.xkit, link.xkit').remove();
 
-    browser.storage.onChanged.addListener(onStorageChanged);
+    browser.storage.local.onChanged.addListener(onStorageChanged);
 
     const [
       installedScripts,

--- a/src/features/accesskit.js
+++ b/src/features/accesskit.js
@@ -23,7 +23,7 @@ const destroyOption = async function (name) {
   }
 };
 
-export const onStorageChanged = async function (changes, areaName) {
+export const onStorageChanged = async function (changes) {
   if (Object.keys(changes).some(key => key.startsWith('accesskit') && changes[key].oldValue !== undefined)) {
     const preferences = await getPreferences('accesskit');
 

--- a/src/features/accesskit/visible_alt_text.js
+++ b/src/features/accesskit/visible_alt_text.js
@@ -49,9 +49,7 @@ const processImages = function (imageElements) {
   }
 };
 
-const onStorageChanged = async function (changes, areaName) {
-  if (areaName !== 'local') return;
-
+const onStorageChanged = async function (changes) {
   const { 'accesskit.preferences.visible_alt_text_mode': modeChanges } = changes;
   if (modeChanges?.oldValue === undefined) return;
 
@@ -65,12 +63,12 @@ export const main = async function () {
   ({ visible_alt_text_mode: mode } = await getPreferences('accesskit'));
 
   pageModifications.register(`article ${imageBlockSelector} img[alt]`, processImages);
-  browser.storage.onChanged.addListener(onStorageChanged);
+  browser.storage.local.onChanged.addListener(onStorageChanged);
 };
 
 export const clean = async function () {
   pageModifications.unregister(processImages);
-  browser.storage.onChanged.removeListener(onStorageChanged);
+  browser.storage.local.onChanged.removeListener(onStorageChanged);
 
   $(`.${processedClass} figcaption`).remove();
   $(`.${processedClass}`).removeClass(processedClass);

--- a/src/features/no_recommended.js
+++ b/src/features/no_recommended.js
@@ -23,7 +23,7 @@ const destroyOption = async function (name) {
   }
 };
 
-export const onStorageChanged = async function (changes, areaName) {
+export const onStorageChanged = async function (changes) {
   if (Object.keys(changes).some(key => key.startsWith('no_recommended') && changes[key].oldValue !== undefined)) {
     const preferences = await getPreferences('no_recommended');
 

--- a/src/features/notificationblock.js
+++ b/src/features/notificationblock.js
@@ -95,7 +95,7 @@ const unblockPostFilter = async ({ id, rebloggedRootId }) => {
   return blockedPostTargetIDs.includes(rootId);
 };
 
-export const onStorageChanged = (changes, areaName) => {
+export const onStorageChanged = (changes) => {
   if (Object.keys(changes).includes(storageKey)) {
     blockedPostTargetIDs = changes[storageKey].newValue;
     styleElement.textContent = buildCss();

--- a/src/features/postblock.js
+++ b/src/features/postblock.js
@@ -49,7 +49,7 @@ const blockPost = async rootID => {
   browser.storage.local.set({ [storageKey]: blockedPostRootIDs });
 };
 
-export const onStorageChanged = async function (changes, areaName) {
+export const onStorageChanged = async function (changes) {
   if (Object.keys(changes).includes(storageKey)) {
     ({ newValue: blockedPostRootIDs = [] } = changes[storageKey]);
     pageModifications.trigger(processPosts);

--- a/src/features/postblock/options/index.js
+++ b/src/features/postblock/options/index.js
@@ -32,8 +32,8 @@ const renderBlockedPosts = async function () {
   }
 };
 
-browser.storage.onChanged.addListener((changes, areaName) => {
-  if (areaName === 'local' && Object.keys(changes).includes(storageKey)) {
+browser.storage.local.onChanged.addListener((changes) => {
+  if (Object.keys(changes).includes(storageKey)) {
     renderBlockedPosts();
   }
 });

--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -282,8 +282,8 @@ const renderQuickTags = async function () {
   });
 };
 
-const updateQuickTags = (changes, areaName) => {
-  if (areaName === 'local' && Object.keys(changes).includes(quickTagsStorageKey)) {
+const updateQuickTags = (changes) => {
+  if (Object.keys(changes).includes(quickTagsStorageKey)) {
     renderQuickTags();
   }
 };
@@ -371,7 +371,7 @@ export const main = async function () {
   $(document.body).on('contextmenu', reblogButtonSelector, preventLongPressMenu);
 
   if (quickTagsIntegration) {
-    browser.storage.onChanged.addListener(updateQuickTags);
+    browser.storage.local.onChanged.addListener(updateQuickTags);
     renderQuickTags();
   }
 
@@ -387,7 +387,7 @@ export const clean = async function () {
 
   blogSelector.removeEventListener('change', updateRememberedBlog);
 
-  browser.storage.onChanged.removeListener(updateQuickTags);
+  browser.storage.local.onChanged.removeListener(updateQuickTags);
   onNewPosts.removeListener(processPosts);
 };
 

--- a/src/features/quick_tags.js
+++ b/src/features/quick_tags.js
@@ -102,7 +102,7 @@ const processPostForm = async function ([selectedTagsElement]) {
   }
 };
 
-export const onStorageChanged = async function (changes, areaName) {
+export const onStorageChanged = async function (changes) {
   if (Object.keys(changes).some(key => key.startsWith('quick_tags'))) {
     if (Object.keys(changes).includes(storageKey)) populatePopups();
 

--- a/src/features/quick_tags/options/index.js
+++ b/src/features/quick_tags/options/index.js
@@ -90,8 +90,8 @@ const renderBundles = async function () {
   }));
 };
 
-browser.storage.onChanged.addListener((changes, areaName) => {
-  if (areaName === 'local' && Object.keys(changes).includes(storageKey)) {
+browser.storage.local.onChanged.addListener((changes) => {
+  if (Object.keys(changes).includes(storageKey)) {
     bundlesList.textContent = '';
     renderBundles();
   }

--- a/src/features/seen_posts.js
+++ b/src/features/seen_posts.js
@@ -79,7 +79,7 @@ const onSoftRefresh = loaderElements => {
   dimPosts(refreshedPostElements, true);
 };
 
-export const onStorageChanged = async function (changes, areaName) {
+export const onStorageChanged = async function (changes) {
   const {
     'seen_posts.preferences.hideSeenPosts': hideSeenPostsChanges,
     'seen_posts.preferences.onlyDimAvatars': onlyDimAvatarsChanges,

--- a/src/features/tag_tracking_plus.js
+++ b/src/features/tag_tracking_plus.js
@@ -130,7 +130,7 @@ const processPosts = async function (postElements) {
   }
 };
 
-export const onStorageChanged = async (changes, areaName) => {
+export const onStorageChanged = async (changes) => {
   const {
     [storageKey]: timestampsChanges,
     'tag_tracking_plus.preferences.onlyShowNew': onlyShowNewChanges

--- a/src/features/timestamps.js
+++ b/src/features/timestamps.js
@@ -214,7 +214,7 @@ const preferenceHandlers = {
   }
 };
 
-export const onStorageChanged = async function (changes, areaName) {
+export const onStorageChanged = async function (changes) {
   ({ alwaysShowYear, headerTimestamps, isoFormat, reblogTimestamps } = await getPreferences('timestamps'));
 
   const changesKeys = Object.keys(changes);

--- a/src/features/tweaks.js
+++ b/src/features/tweaks.js
@@ -23,7 +23,7 @@ const destroyTweak = async function (name) {
   }
 };
 
-export const onStorageChanged = async function (changes, areaName) {
+export const onStorageChanged = async function (changes) {
   if (Object.keys(changes).some(key => key.startsWith('tweaks') && changes[key].oldValue !== undefined)) {
     const preferences = await getPreferences('tweaks');
 

--- a/src/features/vanilla_audio.js
+++ b/src/features/vanilla_audio.js
@@ -24,7 +24,7 @@ const addAudioControls = nativePlayers => nativePlayers.forEach(nativePlayer => 
   nativePlayer.parentNode.appendChild(audioClone);
 });
 
-export const onStorageChanged = async function (changes, areaName) {
+export const onStorageChanged = async function (changes) {
   const {
     'vanilla_audio.preferences.defaultVolume': defaultVolumeChanges
   } = changes;

--- a/src/features/vanilla_video.js
+++ b/src/features/vanilla_video.js
@@ -31,7 +31,7 @@ const cloneVideoElements = videoElements => videoElements.forEach(videoElement =
   videoElement.before(newVideoElement);
 });
 
-export const onStorageChanged = async function (changes, areaName) {
+export const onStorageChanged = async function (changes) {
   const {
     'vanilla_video.preferences.defaultVolume': defaultVolumeChanges
   } = changes;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As of Firefox 101, as per https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/storage/StorageArea/onChanged, we should be able to use `browser.storage.local.onChanged.addListener` rather than using `browser.storage.onChanged.addListener` and checking if the second callback parameter is `'local'`.

In addition to being a nice refactor, this appears—weirdly enough—to be a bugfix on Safari 18.1.1 on iOS in my testing, because Safari is giving `undefined` as the second callback parameter when I use `browser.storage.onChanged.addListener`, which breaks all of our storage listeners.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- [] Confirm that changing extension preferences works in Chromium.
- [] Confirm that changing extension preferences works in Firefox.
- [] Confirm that changing extension preferences works in Safari.
