### PR TITLE
Options UI: Fix disabled label wrap

### DIFF
--- a/src/action/configuration.css
+++ b/src/action/configuration.css
@@ -139,14 +139,12 @@ label[for="filter"] {
 }
 
 .script.disabled .title::after {
-  content: "(disabled)";
-  margin-left: 0.5ch;
+  content: " (disabled)";
   font-weight: normal;
 }
 
 .script:not(.disabled)[data-deprecated="true"] .title::after {
-  content: "(deprecated)";
-  margin-left: 0.5ch;
+  content: " (deprecated)";
   font-weight: normal;
 }
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes an issue that only crops up on narrow options UI widths where the space between feature labels and the (disabled) text wasn't an option for text wrapping, making features with very long names and no space able to have slightly wonky UI alignment.

<img width="234" src="https://github.com/user-attachments/assets/e3c7db18-0299-4c5c-bce9-e0c867226c98">

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that disabled UI spacing looks good.
- Either open the options UI in its own window (https://github.com/AprilSylph/XKit-Rewritten/pull/1193#issuecomment-1676173160) and use browser zoom to simulate a very small options window, or load XKit Rewritten into the iPadOS simulator or onto an iPad. Confirm that UI wraps well.
