### PR TITLE
fix: Modal UI broken in mobile/tablet browser widths

### DIFF
--- a/src/utils/modals.js
+++ b/src/utils/modals.js
@@ -17,7 +17,10 @@ export const showModal = ({ title, message = [], buttons = [] }) => {
     id: 'xkit-modal',
     tabindex: '-1',
     role: 'dialog',
-    'aria-modal': 'true'
+    'aria-modal': 'true',
+
+    // prevents Tumblr's trapFocusInsideGlass function from stealing focus when opened from mobile drawer
+    'data-skip-glass-focus-trap': ''
   }, null, [
     dom('style', null, null, ['body { overflow: hidden; }']),
     title ? dom('h3', { class: 'title' }, null, [title]) : '',


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Just as in https://github.com/new-xkit/XKit/pull/2101, this fixes an issue where Tumblr's code would steal focus from and break form input elements in our modal overlay UI because it was trying to prioritize its own. In this case, it was when something like Tag Replacer or Mass Deleter/Privater/Unliker was opened from the sidebar menu where they are in mobile device/tablet viewport widths.

Resolves #1759.

Thanks to Gideon on the New XKit discord for reporting this!

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that Tag Replacer/Mass [whatever] features work in <990px and <540px viewport widths.

