### PR TITLE
Quick Reblog, Quick Tags: Possibly prevent tag input typing lag

### DIFF
--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -116,11 +116,15 @@ const doSmartQuotes = ({ currentTarget }) => {
 const checkLength = ({ currentTarget }) => {
   const { value } = currentTarget;
   const tags = value.split(',').map(tag => tag.trim());
-  if (tags.some(tag => tag.length > 140)) {
-    tagsInput.setCustomValidity('Tag is longer than 140 characters!');
+
+  const validityMessage = tags.some(tag => tag.length > 140)
+    ? 'Tag is longer than 140 characters!'
+    : '';
+
+  if (currentTarget.dataset.validityMessage !== validityMessage) {
+    currentTarget.dataset.validityMessage = validityMessage;
+    tagsInput.setCustomValidity(validityMessage);
     tagsInput.reportValidity();
-  } else {
-    tagsInput.setCustomValidity('');
   }
 };
 

--- a/src/features/quick_tags.js
+++ b/src/features/quick_tags.js
@@ -43,11 +43,15 @@ popupInput.addEventListener('input', doSmartQuotes);
 const checkLength = ({ currentTarget }) => {
   const { value } = currentTarget;
   const tags = value.split(',').map(tag => tag.trim());
-  if (tags.some(tag => tag.length > 140)) {
-    popupInput.setCustomValidity('Tag is longer than 140 characters!');
+
+  const validityMessage = tags.some(tag => tag.length > 140)
+    ? 'Tag is longer than 140 characters!'
+    : '';
+
+  if (currentTarget.dataset.validityMessage !== validityMessage) {
+    currentTarget.dataset.validityMessage = validityMessage;
+    popupInput.setCustomValidity(validityMessage);
     popupInput.reportValidity();
-  } else {
-    popupInput.setCustomValidity('');
   }
 };
 popupInput.addEventListener('input', checkLength);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Rather than calling the `setCustomValidity` function on the tag input boxes in Quick Reblog and Quick Tags on each user keystroke, this only calls the function when it's necessary to change the validity state.

This is an attempt to fix #1736, though I'm not confident it will work; `setCustomValidity` seems kind of unlikely to be expensive enough to cause noticeable lag, but I see no other likely candidates.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that the "Tag is longer than 140 characters!" message appears when the action of typing into the tag input box results in a sufficiently long tag and disappears when it no longer does so (backspace, control-a -> backspace).
- Confirm that typing a long tag into a tag input box, then moving the box to a different post and typing into the now-empty box, works as expected.
