### PR TITLE
Themed Posts: fix theming not being applied to posts

### DIFF
--- a/src/features/themed_posts.js
+++ b/src/features/themed_posts.js
@@ -61,6 +61,10 @@ const processPosts = async function (postElements) {
             --black: ${titleColorRGB};
             --deprecated-accent: ${linkColorRGB};
             --color-primary-link: rgb(var(--deprecated-accent));
+            --content-panel: rgb(var(--white));
+            --content-fg: rgb(var(--black));
+            --content-fg-secondary: rgba(var(--black), 0.5);
+            --content-tint: rgba(var(--black), 0.05);
           }
         `;
       }


### PR DESCRIPTION
### Description

This fixes an issue where posts now use different color variables (that aren't themed) that was brought with Tumblr's recent UI update.

![Снимок экрана_20250408_181316](https://github.com/user-attachments/assets/e4996edb-d589-4781-8429-de6a2023e9a7) (before)
![Снимок экрана_20250408_181057](https://github.com/user-attachments/assets/a693db50-74c9-4579-94ea-d875c79adc36) (after)


Fixes #1764 and #1768



### Testing steps

