### PR TITLE
Shorten Posts: Fix button/tags covering tab bar and search box/dropdown

### DIFF
--- a/src/features/shorten_posts.css
+++ b/src/features/shorten_posts.css
@@ -17,7 +17,6 @@
 button.xkit-shorten-posts-expand {
   position: absolute;
   bottom: 0;
-  z-index: 2;
 
   display: flex;
   justify-content: center;
@@ -37,7 +36,6 @@ button.xkit-shorten-posts-expand {
 .xkit-shorten-posts-tags {
   position: absolute;
   bottom: var(--expand-button-total-height);
-  z-index: 2;
 
   box-sizing: border-box;
   max-height: calc((var(--shortened-post-height) - var(--expand-button-total-height)) / 2);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This prevents the UI elements added at the bottom of a Shorten Posts shortened post from covering the dashboard tab bar and search interface atop search pages when scrolled to a position in which one overlaps the other.

Resolves #1400.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that the dashboard tab bar appears on top of the Shorten Posts expand button.
- Confirm that the dashboard tab bar appears on top of the Shorten Posts tags element.
- Confirm that the "top/latest/etc" selector atop a search page in the desktop layout appears on top of the Shorten Posts expand button.
- Confirm that the "top/latest/etc" selector atop a search page in the desktop layout appears on top of the Shorten Posts tags element.
- Confirm that the search bar atop a search page in the tablet layout appears on top of the Shorten Posts expand button.
- Confirm that the search bar atop a search page in the tablet layout appears on top of the Shorten Posts tags element.

<br \>

- Try to make an element from inside a post erroneously appear over the Shorten Posts expand button/tags element. Hopefully it can't; I didn't think of any way to.
- Confirm that Disable GIFs and Cleanfeed don't have unexpected behavior on shortened posts.