### PR TITLE
Tweaks: Fix "hide control button tooltips" tweak in split-notes footer

### DIFF
--- a/src/features/tweaks/hide_footer_tooltips.js
+++ b/src/features/tweaks/hide_footer_tooltips.js
@@ -4,7 +4,7 @@ import { buildStyle } from '../../utils/interface.js';
 export const styleElement = buildStyle(`
 article footer ${keyToCss('controlIcon')} ${keyToCss('tooltip')},
 article footer ${keyToCss('controlIcon')} ${keyToCss('tooltip')} ~ *,
-article footer ${keyToCss('controls', 'engagementControls')} ${keyToCss('tooltip')} {
+article footer ${keyToCss('controls', 'footerControl')} ${keyToCss('tooltip')} {
   display: none;
 }
 `);

--- a/src/features/tweaks/hide_footer_tooltips.js
+++ b/src/features/tweaks/hide_footer_tooltips.js
@@ -2,9 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle } from '../../utils/interface.js';
 
 export const styleElement = buildStyle(`
-article footer ${keyToCss('controlIcon')} ${keyToCss('tooltip')},
-article footer ${keyToCss('controlIcon')} ${keyToCss('tooltip')} ~ *,
-article footer ${keyToCss('controls', 'footerControl')} ${keyToCss('tooltip')} {
+article footer :is(${keyToCss('tooltip')}, ${keyToCss('tooltip')} ~ *) {
   display: none;
 }
 `);

--- a/src/features/tweaks/hide_footer_tooltips.js
+++ b/src/features/tweaks/hide_footer_tooltips.js
@@ -3,7 +3,8 @@ import { buildStyle } from '../../utils/interface.js';
 
 export const styleElement = buildStyle(`
 article footer ${keyToCss('controlIcon')} ${keyToCss('tooltip')},
-article footer ${keyToCss('controlIcon')} ${keyToCss('tooltip')} ~ * {
+article footer ${keyToCss('controlIcon')} ${keyToCss('tooltip')} ~ *,
+article footer ${keyToCss('controls', 'engagementControls')} ${keyToCss('tooltip')} {
   display: none;
 }
 `);

--- a/src/features/tweaks/hide_footer_tooltips.js
+++ b/src/features/tweaks/hide_footer_tooltips.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle } from '../../utils/interface.js';
 
 export const styleElement = buildStyle(`
-article footer :is(${keyToCss('tooltip')}, ${keyToCss('tooltip')} ~ *) {
+article footer ${keyToCss('footerRow', 'footerContent')} :is(${keyToCss('tooltip')}, ${keyToCss('tooltip')} ~ *) {
   display: none;
 }
 `);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes the "hide footer tooltips" tweak on accounts with the new split-notes post footer.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that the tweak hides tooltips on all footer variations.