### PR TITLE
Quick Reblog: Fix feature on accounts with new footer variants

### DIFF
--- a/src/features/quick_reblog.css
+++ b/src/features/quick_reblog.css
@@ -14,6 +14,7 @@
   flex-direction: column;
   box-sizing: border-box;
   max-width: 250px;
+  line-height: 1;
 }
 
 #quick-reblog [hidden] {
@@ -189,9 +190,9 @@ div:first-child + span + #quick-reblog,
 
 #quick-reblog .action-buttons.community-selected button:not([data-state="published"]) { display: none; }
 
-.published :is(a[role="button"], button[class=""]) svg[style*="--black"] use { --icon-color-primary: rgb(var(--green)); }
-.queue :is(a[role="button"], button[class=""]) svg[style*="--black"] use { --icon-color-primary: rgb(var(--purple)); }
-.draft :is(a[role="button"], button[class=""]) svg[style*="--black"] use { --icon-color-primary: rgb(var(--red)); }
+.published svg use { --icon-color-primary: rgb(var(--green)); }
+.queue svg use { --icon-color-primary: rgb(var(--purple)); }
+.draft svg use { --icon-color-primary: rgb(var(--red)); }
 
 :is(.published, .queue, .draft) :is(a[role="button"], button[class=""]) {
   position: relative;

--- a/src/features/quick_reblog.css
+++ b/src/features/quick_reblog.css
@@ -190,9 +190,9 @@ div:first-child + span + #quick-reblog,
 
 #quick-reblog .action-buttons.community-selected button:not([data-state="published"]) { display: none; }
 
-.published svg use { --icon-color-primary: rgb(var(--green)); }
-.queue svg use { --icon-color-primary: rgb(var(--purple)); }
-.draft svg use { --icon-color-primary: rgb(var(--red)); }
+footer.published a[href*="/reblog/"] svg use { --icon-color-primary: rgb(var(--green)); }
+footer.queue a[href*="/reblog/"] svg use { --icon-color-primary: rgb(var(--purple)); }
+footer.draft a[href*="/reblog/"] svg use { --icon-color-primary: rgb(var(--red)); }
 
 :is(.published, .queue, .draft) :is(a[role="button"], button[class=""]) {
   position: relative;

--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -11,7 +11,7 @@ import { dom } from '../utils/dom.js';
 import { showErrorModal } from '../utils/modals.js';
 import { keyToCss } from '../utils/css_map.js';
 
-const popupElement = dom('div', { id: 'quick-reblog' });
+const popupElement = dom('div', { id: 'quick-reblog' }, { click: event => event.stopPropagation() });
 const blogSelector = dom('select');
 const blogAvatar = dom('div', { class: 'avatar' });
 const blogSelectorContainer = dom('div', { class: 'select-container' }, null, [blogAvatar, blogSelector]);

--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -6,7 +6,6 @@ import { joinedCommunities, joinedCommunityUuids, primaryBlog, userBlogs } from 
 import { getPreferences } from '../utils/preferences.js';
 import { onNewPosts } from '../utils/mutations.js';
 import { notify } from '../utils/notifications.js';
-import { translate } from '../utils/language_data.js';
 import { dom } from '../utils/dom.js';
 import { showErrorModal } from '../utils/modals.js';
 import { keyToCss } from '../utils/css_map.js';
@@ -69,10 +68,7 @@ const quickTagsStorageKey = 'quick_tags.preferences.tagBundles';
 const blogHashes = new Map();
 const avatarUrls = new Map();
 
-const reblogButtonSelector = `
-${postSelector} footer a[href*="/reblog/"],
-${postSelector} footer button[aria-label="${translate('Reblog')}"]:not([role])
-`;
+const reblogButtonSelector = `${postSelector} footer a[href*="/reblog/"]`;
 const buttonDivSelector = `${keyToCss('controls')} > *, ${keyToCss('engagementAction')}`;
 
 export const styleElement = buildStyle(`
@@ -176,13 +172,13 @@ const removePopupOnLeave = () => {
   }, 500);
 };
 
-const makeButtonReblogged = ({ buttonDiv, state }) => {
-  ['published', 'queue', 'draft'].forEach(className => buttonDiv.classList.remove(className));
-  buttonDiv.classList.add(state);
+const markPostReblogged = ({ footer, state }) => {
+  footer.classList.remove('published', 'queue', 'draft');
+  footer.classList.add(state);
 };
 
 const reblogPost = async function ({ currentTarget }) {
-  const currentReblogButton = popupElement.parentNode;
+  const footer = popupElement.closest('footer');
 
   currentTarget.blur();
   actionButtons.disabled = true;
@@ -213,7 +209,7 @@ const reblogPost = async function ({ currentTarget }) {
   try {
     const { meta, response } = await apiFetch(requestPath, { method: 'POST', body: requestBody });
     if (meta.status === 201) {
-      makeButtonReblogged({ buttonDiv: currentReblogButton, state });
+      markPostReblogged({ footer, state });
 
       if (lastPostID === postID) {
         popupElement.remove();
@@ -257,8 +253,8 @@ const processPosts = async function (postElements) {
 
     if (alreadyRebloggedList.includes(rootID)) {
       const reblogLink = postElement.querySelector(reblogButtonSelector);
-      const buttonDiv = reblogLink?.closest(buttonDivSelector);
-      if (buttonDiv) makeButtonReblogged({ buttonDiv, state: 'published' });
+      const footer = reblogLink?.closest('footer');
+      if (footer) markPostReblogged({ footer, state: 'published' });
     }
   });
 };

--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -1,7 +1,7 @@
 import { sha256 } from '../utils/crypto.js';
 import { timelineObject } from '../utils/react_props.js';
 import { apiFetch } from '../utils/tumblr_helpers.js';
-import { postSelector, filterPostElements, postType, appendWithoutOverflow } from '../utils/interface.js';
+import { postSelector, filterPostElements, postType, appendWithoutOverflow, buildStyle } from '../utils/interface.js';
 import { joinedCommunities, joinedCommunityUuids, primaryBlog, userBlogs } from '../utils/user.js';
 import { getPreferences } from '../utils/preferences.js';
 import { onNewPosts } from '../utils/mutations.js';
@@ -71,8 +71,19 @@ const avatarUrls = new Map();
 
 const reblogButtonSelector = `
 ${postSelector} footer a[href*="/reblog/"],
-${postSelector} footer button[aria-label="${translate('Reblog')}"]:not([role])
+${postSelector} footer button[aria-label="${translate('Reblog')}"]:not([role]),
+${postSelector} footer a[aria-label="${translate('Reblog')}"][href*="/reblog/"]
 `;
+const buttonDivSelector = `:is(${keyToCss('controls')} > *, ${keyToCss('engagementAction')})`;
+
+export const styleElement = buildStyle(`
+${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) {
+  position: relative;
+}
+${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) ${keyToCss('tooltip')} {
+  display: none;
+}
+`);
 
 const onBlogSelectorChange = () => {
   blogAvatar.style.backgroundImage = `url(${avatarUrls.get(blogSelector.value)})`;
@@ -131,7 +142,7 @@ tagsInput.addEventListener('input', checkLength);
 const showPopupOnHover = ({ currentTarget }) => {
   clearTimeout(timeoutID);
 
-  appendWithoutOverflow(popupElement, currentTarget.closest(keyToCss('controlIcon')), popupPosition);
+  appendWithoutOverflow(popupElement, currentTarget.closest(buttonDivSelector), popupPosition);
   popupElement.parentNode.addEventListener('mouseleave', removePopupOnLeave);
 
   const thisPost = currentTarget.closest(postSelector);
@@ -247,7 +258,7 @@ const processPosts = async function (postElements) {
 
     if (alreadyRebloggedList.includes(rootID)) {
       const reblogLink = postElement.querySelector(reblogButtonSelector);
-      const buttonDiv = reblogLink?.closest('div');
+      const buttonDiv = reblogLink?.closest(buttonDivSelector);
       if (buttonDiv) makeButtonReblogged({ buttonDiv, state: 'published' });
     }
   });

--- a/src/features/quick_reblog.js
+++ b/src/features/quick_reblog.js
@@ -71,10 +71,9 @@ const avatarUrls = new Map();
 
 const reblogButtonSelector = `
 ${postSelector} footer a[href*="/reblog/"],
-${postSelector} footer button[aria-label="${translate('Reblog')}"]:not([role]),
-${postSelector} footer a[aria-label="${translate('Reblog')}"][href*="/reblog/"]
+${postSelector} footer button[aria-label="${translate('Reblog')}"]:not([role])
 `;
-const buttonDivSelector = `:is(${keyToCss('controls')} > *, ${keyToCss('engagementAction')})`;
+const buttonDivSelector = `${keyToCss('controls')} > *, ${keyToCss('engagementAction')}`;
 
 export const styleElement = buildStyle(`
 ${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes Quick Reblog on accounts with the new split-notes post footer.

Edit: There are actually two footer variations in testing, so this should address both!

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

On all three footer variations:

- Confirm that the Quick Reblog popup appears, in the correct location, when hovering over the reblog button.
- Confirm that the Quick Reblog popup is not covered by Tumblr's control button tooltip, as the tooltip is now hidden by this feature.
- Confirm that alreadyreblogged posts have different-colored reblog icons.

Note: I haven't done a full round of testing on this after my last few changes, unless I've crossed out this line in the description.