### PR TITLE
Quick Tags, Trim Reblogs: Fix features on accounts with new footer variants

### DIFF
--- a/src/content_scripts/control_buttons.css
+++ b/src/content_scripts/control_buttons.css
@@ -60,3 +60,11 @@
     width: 48px;
   }
 }
+
+.xkit-controls-row {
+  margin: 0 12px;
+  padding: 6px 0;
+  display: flex;
+  justify-content: flex-end;
+  border-bottom: 1px solid rgba(var(--black), .13);
+}

--- a/src/content_scripts/control_buttons.css
+++ b/src/content_scripts/control_buttons.css
@@ -1,4 +1,5 @@
 .xkit-control-button-container {
+  display: inline-block;
   position: relative;
 
   margin-left: 20px;
@@ -36,22 +37,22 @@
   fill: rgba(var(--black), 0.4);
 }
 
-.xkit-controls-row .xkit-control-button-container {
+.xkit-control-button-container.in-new-footer {
   margin-left: 0;
 }
 
-.xkit-controls-row .xkit-control-button-container .xkit-control-button {
+.xkit-control-button-container.in-new-footer .xkit-control-button {
   border-radius: 9999px;
   width: 40px;
   height: 40px;
 }
 
 @media (max-width: 990px) {
-  :not(.xkit-controls-row) > .xkit-control-button-container {
+  .xkit-control-button-container.in-legacy-footer {
     margin-left: 0;
   }
 
-  :not(.xkit-controls-row) > .xkit-control-button-container .xkit-control-button {
+  .xkit-control-button-container.in-legacy-footer .xkit-control-button {
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/content_scripts/control_buttons.css
+++ b/src/content_scripts/control_buttons.css
@@ -36,12 +36,22 @@
   fill: rgba(var(--black), 0.4);
 }
 
+.xkit-controls-row .xkit-control-button-container {
+  margin-left: 0;
+}
+
+.xkit-controls-row .xkit-control-button-container .xkit-control-button {
+  border-radius: 9999px;
+  width: 40px;
+  height: 40px;
+}
+
 @media (max-width: 990px) {
-  .xkit-control-button-container {
+  :not(.xkit-controls-row) > .xkit-control-button-container {
     margin-left: 0;
   }
 
-  .xkit-control-button {
+  :not(.xkit-controls-row) > .xkit-control-button-container .xkit-control-button {
     display: flex;
     justify-content: center;
     align-items: center;

--- a/src/features/quick_tags.js
+++ b/src/features/quick_tags.js
@@ -1,5 +1,4 @@
-import { cloneControlButton, createControlButtonTemplate } from '../utils/control_buttons.js';
-import { keyToCss } from '../utils/css_map.js';
+import { cloneControlButton, createControlButtonTemplate, insertControlButton } from '../utils/control_buttons.js';
 import { dom } from '../utils/dom.js';
 import { appendWithoutOverflow, filterPostElements, getTimelineItemWrapper, postSelector } from '../utils/interface.js';
 import { megaEdit } from '../utils/mega_editor.js';
@@ -15,7 +14,6 @@ const symbolId = 'ri-price-tag-3-line';
 const buttonClass = 'xkit-quick-tags-button';
 const excludeClass = 'xkit-quick-tags-done';
 const tagsClass = 'xkit-quick-tags-tags';
-const controlIconSelector = keyToCss('controlIcon');
 
 let originalPostTag;
 let answerTag;
@@ -202,19 +200,15 @@ const processPostOptionBundleClick = function ({ target }) {
   editPostFormTags({ add: bundleTags });
 };
 
-const processPosts = postElements => filterPostElements(postElements).forEach(postElement => {
+const processPosts = postElements => filterPostElements(postElements).forEach(async postElement => {
   const tags = editedTagsMap.get(getTimelineItemWrapper(postElement));
   tags && addFakeTagsToFooter(postElement, tags);
 
-  const existingButton = postElement.querySelector(`.${buttonClass}`);
-  if (existingButton !== null) { return; }
-
-  const editButton = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"]:has(use[href="#managed-icon__edit"])`);
-  if (!editButton) { return; }
-
-  const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: togglePopupDisplay });
-  const controlIcon = editButton.closest(controlIconSelector);
-  controlIcon.before(clonedControlButton);
+  const { state, canEdit } = await timelineObject(postElement);
+  if (canEdit && ['ask', 'submission'].includes(state) === false) {
+    const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: togglePopupDisplay });
+    insertControlButton(postElement, clonedControlButton, buttonClass);
+  }
 });
 
 popupElement.addEventListener('click', processBundleClick);

--- a/src/features/trim_reblogs.js
+++ b/src/features/trim_reblogs.js
@@ -1,4 +1,4 @@
-import { createControlButtonTemplate, cloneControlButton } from '../utils/control_buttons.js';
+import { createControlButtonTemplate, cloneControlButton, insertControlButton } from '../utils/control_buttons.js';
 import { keyToCss } from '../utils/css_map.js';
 import { dom } from '../utils/dom.js';
 import { filterPostElements, postSelector } from '../utils/interface.js';
@@ -14,7 +14,6 @@ const reblogPreviewClass = 'xkit-trim-reblogs-preview';
 const avatarPreviewClass = 'xkit-trim-reblogs-avatar-preview';
 const textPreviewClass = 'xkit-trim-reblogs-text-preview';
 
-const controlIconSelector = keyToCss('controlIcon');
 const reblogSelector = keyToCss('reblog');
 
 let controlButtonTemplate;
@@ -156,19 +155,13 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
 };
 
 const processPosts = postElements => filterPostElements(postElements).forEach(async postElement => {
-  const existingButton = postElement.querySelector(`.${buttonClass}`);
-  if (existingButton !== null) { return; }
-
-  const editButton = postElement.querySelector(`footer ${controlIconSelector} a[href*="/edit/"]:has(use[href="#managed-icon__edit"])`);
-  if (!editButton) { return; }
-
-  const controlIcon = editButton.closest(controlIconSelector);
-
-  const { trail = [], content = [] } = await timelineObject(postElement);
+  const { state, canEdit, trail = [], content = [] } = await timelineObject(postElement);
   const items = trail.length + (content.length ? 1 : 0);
 
-  const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: event => onButtonClicked(event).catch(showErrorModal) }, items < 2);
-  controlIcon.before(clonedControlButton);
+  if (canEdit && ['ask', 'submission'].includes(state) === false) {
+    const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: event => onButtonClicked(event).catch(showErrorModal) }, items < 2);
+    insertControlButton(postElement, clonedControlButton, buttonClass);
+  }
 });
 
 export const main = async function () {

--- a/src/utils/control_buttons.js
+++ b/src/utils/control_buttons.js
@@ -1,6 +1,5 @@
 import { keyToCss } from './css_map.js';
 import { dom } from './dom.js';
-import { buildStyle } from './interface.js';
 import { timelineObject } from './react_props.js';
 import { buildSvg } from './remixicon.js';
 

--- a/src/utils/control_buttons.js
+++ b/src/utils/control_buttons.js
@@ -76,18 +76,19 @@ export const insertControlButton = async (postElement, clonedControlButton, butt
   if (existingButton !== null) { return; }
 
   const { community } = await timelineObject(postElement);
+  const legacyEditControlIcon = postElement.querySelector(`${keyToCss('controlIcon')}:has(a[href*="/edit/"] use[href="#managed-icon__edit"])`);
+  const newEditControlIcon = postElement.querySelector('a[href*="/edit/"]:has(use[href="#managed-icon__ds-pencil-outline-24"])');
 
   if (community) {
     // not yet implemented
+  } else if (legacyEditControlIcon) {
+    clonedControlButton.classList.add('in-legacy-footer');
+    legacyEditControlIcon.before(clonedControlButton);
+  } else if (newEditControlIcon) {
+    clonedControlButton.classList.add('in-new-footer');
+    newEditControlIcon.before(clonedControlButton);
   } else {
-    const secondaryControlsElement =
-      [...postElement.querySelectorAll(`${keyToCss('footerRow')}:has(+ ${keyToCss('footerRow')}) ${keyToCss('controls')}`)].at(-1) ||
-      addSecondaryFooterRow(postElement);
-
-    const editControlIcon = secondaryControlsElement.querySelector(`${keyToCss('controlIcon')}:has(a[href*="/edit/"] use[href="#managed-icon__edit"])`);
-
-    editControlIcon
-      ? editControlIcon.before(clonedControlButton)
-      : secondaryControlsElement.prepend(clonedControlButton);
+    clonedControlButton.classList.add('in-new-footer');
+    addSecondaryFooterRow(postElement).prepend(clonedControlButton);
   }
 };

--- a/src/utils/control_buttons.js
+++ b/src/utils/control_buttons.js
@@ -1,4 +1,7 @@
+import { keyToCss } from './css_map.js';
 import { dom } from './dom.js';
+import { buildStyle } from './interface.js';
+import { timelineObject } from './react_props.js';
 import { buildSvg } from './remixicon.js';
 
 // Remove outdated buttons when loading module
@@ -35,4 +38,57 @@ export const cloneControlButton = function (template, events, disabled = false) 
   Object.entries(events).forEach(([type, listener]) => newButton.addEventListener(type, listener));
   newButton.disabled = disabled;
   return newButtonContainer;
+};
+
+/**
+ * Adds a secondary footer row above the footer control buttons, similar to the one in the pre-2025 footer layout on editable posts.
+ * @param {HTMLElement} postElement - The target post element
+ * @returns {HTMLDivElement} The inserted element
+ */
+const addSecondaryFooterRow = postElement => {
+  const secondaryFooterRowClass = 'xkit-controls-row';
+
+  const element =
+    postElement.querySelector(`.${secondaryFooterRowClass}`) ||
+    dom('div', {
+      class: secondaryFooterRowClass,
+      style: `
+        margin: 0 12px;
+        padding: 6px 0;
+        display: flex;
+        justify-content: flex-end;
+        border-bottom: 1px solid rgba(var(--black), .13);
+      `
+    });
+
+  element.isConnected || postElement.querySelector('footer').prepend(element);
+  return element;
+};
+
+/**
+ * Inserts a control button into the post footer.
+ * @param {HTMLElement} postElement - The target post element
+ * @param {HTMLDivElement} clonedControlButton - Control button element to insert
+ * @param {string} buttonClass - Button HTML class
+ * @returns {Promise<void>} Resolves when finished
+ */
+export const insertControlButton = async (postElement, clonedControlButton, buttonClass) => {
+  const existingButton = postElement.querySelector(`.${buttonClass}`);
+  if (existingButton !== null) { return; }
+
+  const { community } = await timelineObject(postElement);
+
+  if (community) {
+    // not yet implemented
+  } else {
+    const secondaryControlsElement =
+      [...postElement.querySelectorAll(`${keyToCss('footerRow')}:has(+ ${keyToCss('footerRow')}) ${keyToCss('controls')}`)].at(-1) ||
+      addSecondaryFooterRow(postElement);
+
+    const editControlIcon = secondaryControlsElement.querySelector(`${keyToCss('controlIcon')}:has(a[href*="/edit/"] use[href="#managed-icon__edit"])`);
+
+    editControlIcon
+      ? editControlIcon.before(clonedControlButton)
+      : secondaryControlsElement.prepend(clonedControlButton);
+  }
 };

--- a/src/utils/control_buttons.js
+++ b/src/utils/control_buttons.js
@@ -39,26 +39,17 @@ export const cloneControlButton = function (template, events, disabled = false) 
   return newButtonContainer;
 };
 
+const secondaryFooterRowClass = 'xkit-controls-row';
+
 /**
  * Adds a secondary footer row above the footer control buttons, similar to the one in the pre-2025 footer layout on editable posts.
  * @param {HTMLElement} postElement - The target post element
  * @returns {HTMLDivElement} The inserted element
  */
 const addSecondaryFooterRow = postElement => {
-  const secondaryFooterRowClass = 'xkit-controls-row';
-
   const element =
     postElement.querySelector(`.${secondaryFooterRowClass}`) ||
-    dom('div', {
-      class: secondaryFooterRowClass,
-      style: `
-        margin: 0 12px;
-        padding: 6px 0;
-        display: flex;
-        justify-content: flex-end;
-        border-bottom: 1px solid rgba(var(--black), .13);
-      `
-    });
+    dom('div', { class: secondaryFooterRowClass });
 
   element.isConnected || postElement.querySelector('footer').prepend(element);
   return element;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This is a way to fix Quick Tags and Trim Reblogs, the features that add control buttons to posts, on accounts with the two new post footer variants. Control buttons are added in an additional secondary row above the footer control buttons, as in the current footer layout, which must be added by a new util function.

If we use this method, we should make sure that this code is easy to copy into and can be compatible with XKit 7 in case we ever get around to performing the same fix on it.

Note that this CSS might be a little imprecise (for example, I split the difference between some mobile/non-mobile spacing values, iirc; I was in a bit of rush to get an MVP out). We're not directly reproducing a layout that exists; feel free to weigh in.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

On all footer variations:
- Confirm that Quick Tags/Trim Reblogs buttons are added to regular editable posts.
- Confirm that Quick Tags/Trim Reblogs buttons are added to drafts.
- Confirm that Quick Tags/Trim Reblogs buttons are added to queued posts.
- Confirm that Quick Tags/Trim Reblogs buttons have reasonable spacing and tap targets in the desktop/tablet layout.
- Confirm that Quick Tags/Trim Reblogs buttons have reasonable spacing and tap targets in the mobile layout.
- Confirm that Quick Tags/Trim Reblogs buttons are not added to community posts.
- Confirm that Quick Tags/Trim Reblogs buttons are not added to asks, private answers, and submissions in the inbox.

Note: I haven't done a full round of testing on this after my last few changes, unless I've crossed out this line in the description.