### PR TITLE
Timestamps: Improve layout on narrow posts/in queue

### DIFF
--- a/src/features/timestamps.css
+++ b/src/features/timestamps.css
@@ -1,6 +1,8 @@
 .xkit-timestamp {
   margin-right: auto;
+  flex: 0 5000 auto;
 
+  line-height: 1;
   font-weight: normal;
   text-decoration: none;
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adjusts the layout for the deprecated Timestamps feature's bottom-of-posts timestamps where there is a lack of horizontal space: on posts in multiple-column views (with or without one of the footer options currently being tested; timestamps does nothing on the other one) and on the queue page.

`white-space: nowrap; overflow-x: hidden;` is also an option.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
todo: screenshots
