### PR TITLE
chore: (re-)enable `import-x` recommended lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,5 +1,5 @@
 import jsdoc from 'eslint-plugin-jsdoc';
-import neostandard from 'neostandard';
+import neostandard, { plugins } from 'neostandard';
 
 export default [
   /**
@@ -21,13 +21,14 @@ export default [
   }),
 
   /**
-   * Prevent circular imports. Relies on `import-x` plugin via neostandard.
+   * Use recommended `import-x` lint rules. Additionallly, prevent cyclical imports.
+   * @see https://github.com/un-ts/eslint-plugin-import-x/blob/master/src/config/flat/recommended.ts
    * @see https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-cycle.md
    */
-  { rules: { 'import-x/no-cycle': 'error' } },
+  { rules: { ...plugins['import-x'].flatConfigs.recommended.rules, 'import-x/no-cycle': 'error' } },
 
   /**
-   * Import eslint-plugin-jsdoc and use its recommended config.
+   * Import `eslint-plugin-jsdoc` and use its recommended config.
    * @see https://github.com/gajus/eslint-plugin-jsdoc?tab=readme-ov-file#readme
    */
   jsdoc.configs['flat/recommended'],


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Re-enables `import/recommended` (now actually `import-x/recommended`) (actually not that either because the format for reusable eslint configs is completely different now) lint rules that were previously removed in #1815.

I was a little too trusting of `neostandard`'s rules. Turns out, it doesn't even enable the `no-unresolved` lint rule, which I found to be kind of important for implementing the new directory structure for `src/features/`, as discussed in #1816.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Code review and green CI is enough.