### PR TITLE
Quick Reblog: Fix popup on accounts with new footer variant

### DIFF
--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -190,9 +190,9 @@ div:first-child + span + #quick-reblog,
 
 #quick-reblog .action-buttons.community-selected button:not([data-state="published"]) { display: none; }
 
-footer.published a[href*="/reblog/"] svg use { --icon-color-primary: rgb(var(--green)); }
-footer.queue a[href*="/reblog/"] svg use { --icon-color-primary: rgb(var(--purple)); }
-footer.draft a[href*="/reblog/"] svg use { --icon-color-primary: rgb(var(--red)); }
+footer.published svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--green)); }
+footer.queue svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--purple)); }
+footer.draft svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--red)); }
 
 :is(.published, .queue, .draft) :is(a[role="button"], button[class=""]) {
   position: relative;

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -10,7 +10,7 @@ import { dom } from '../../utils/dom.js';
 import { showErrorModal } from '../../utils/modals.js';
 import { keyToCss } from '../../utils/css_map.js';
 
-const popupElement = dom('div', { id: 'quick-reblog' }, { click: event => event.stopPropagation() });
+const popupElement = dom('div', { id: 'quick-reblog' }, { click: event => { event.preventDefault(); event.stopPropagation(); } });
 const blogSelector = dom('select');
 const blogAvatar = dom('div', { class: 'avatar' });
 const blogSelectorContainer = dom('div', { class: 'select-container' }, null, [blogAvatar, blogSelector]);

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -68,7 +68,8 @@ const quickTagsStorageKey = 'quick_tags.preferences.tagBundles';
 const blogHashes = new Map();
 const avatarUrls = new Map();
 
-const reblogButtonSelector = `${postSelector} footer a[href*="/reblog/"]`;
+const buttonSelector = `${postSelector} footer a, ${postSelector} footer button`;
+const reblogButtonSelector = `${postSelector} footer :is(a[href*="/reblog/"], button:has(use[href="#managed-icon__ds-reblog-24"]))`;
 const buttonDivSelector = `${keyToCss('controls')} > *, ${keyToCss('engagementAction')}`;
 
 export const styleElement = buildStyle(`
@@ -135,6 +136,8 @@ tagsInput.addEventListener('input', doSmartQuotes);
 tagsInput.addEventListener('input', checkLength);
 
 const showPopupOnHover = ({ currentTarget }) => {
+  if (!currentTarget.matches(reblogButtonSelector)) return;
+
   clearTimeout(timeoutID);
 
   appendWithoutOverflow(popupElement, currentTarget.closest(buttonDivSelector), popupPosition);
@@ -313,6 +316,8 @@ const updateRememberedBlog = async ({ currentTarget: { value: selectedBlog } }) 
 const MOZ_SOURCE_TOUCH = 5;
 
 const preventLongPressMenu = ({ originalEvent: event }) => {
+  if (!event.currentTarget.matches(reblogButtonSelector)) return;
+
   const isTouchEvent = event.pointerType === 'touch';
   const firefoxIsTouchEvent = event.mozInputSource === MOZ_SOURCE_TOUCH;
 
@@ -373,8 +378,8 @@ export const main = async function () {
   quickTagsList.hidden = !quickTagsIntegration;
   tagsInput.hidden = !showTagsInput;
 
-  $(document.body).on('mouseenter', reblogButtonSelector, showPopupOnHover);
-  $(document.body).on('contextmenu', reblogButtonSelector, preventLongPressMenu);
+  $(document.body).on('mouseenter', buttonSelector, showPopupOnHover);
+  $(document.body).on('contextmenu', buttonSelector, preventLongPressMenu);
 
   if (quickTagsIntegration) {
     browser.storage.onChanged.addListener(updateQuickTags);
@@ -387,8 +392,8 @@ export const main = async function () {
 };
 
 export const clean = async function () {
-  $(document.body).off('mouseenter', reblogButtonSelector, showPopupOnHover);
-  $(document.body).off('contextmenu', reblogButtonSelector, preventLongPressMenu);
+  $(document.body).off('mouseenter', buttonSelector, showPopupOnHover);
+  $(document.body).off('contextmenu', buttonSelector, preventLongPressMenu);
   popupElement.remove();
 
   blogSelector.removeEventListener('change', updateRememberedBlog);

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -1,7 +1,7 @@
 import { sha256 } from '../../utils/crypto.js';
 import { timelineObject } from '../../utils/react_props.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
-import { postSelector, filterPostElements, postType, appendWithoutOverflow, buildStyle } from '../../utils/interface.js';
+import { postSelector, filterPostElements, postType, appendWithoutOverflow, buildStyle, getPopoverWrapper } from '../../utils/interface.js';
 import { joinedCommunities, joinedCommunityUuids, primaryBlog, userBlogs } from '../../utils/user.js';
 import { getPreferences } from '../../utils/preferences.js';
 import { onNewPosts } from '../../utils/mutations.js';
@@ -69,7 +69,7 @@ const blogHashes = new Map();
 const avatarUrls = new Map();
 
 const reblogButtonSelector = `${postSelector} footer a[href*="/reblog/"]`;
-const buttonDivSelector = `${keyToCss('controls')} > *, ${keyToCss('engagementAction')}`;
+const buttonDivSelector = `${keyToCss('controls', 'engagementControls')} > *, ${keyToCss('engagementAction')}`;
 
 export const styleElement = buildStyle(`
 ${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) {
@@ -137,7 +137,7 @@ tagsInput.addEventListener('input', checkLength);
 const showPopupOnHover = ({ currentTarget }) => {
   clearTimeout(timeoutID);
 
-  appendWithoutOverflow(popupElement, currentTarget.closest(buttonDivSelector), popupPosition);
+  appendWithoutOverflow(popupElement, getPopoverWrapper(currentTarget), popupPosition);
   popupElement.parentNode.addEventListener('mouseleave', removePopupOnLeave);
 
   const thisPost = currentTarget.closest(postSelector);

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -140,7 +140,7 @@ const showPopupOnHover = ({ currentTarget }) => {
 
   clearTimeout(timeoutID);
 
-  appendWithoutOverflow(popupElement, currentTarget.closest(buttonDivSelector), popupPosition);
+  appendWithoutOverflow(popupElement, currentTarget.closest(buttonDivSelector) ?? currentTarget.parentElement, popupPosition);
   popupElement.parentNode.addEventListener('mouseleave', removePopupOnLeave);
 
   const thisPost = currentTarget.closest(postSelector);

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -70,7 +70,7 @@ const avatarUrls = new Map();
 
 const buttonSelector = `${postSelector} footer a, ${postSelector} footer button`;
 const reblogButtonSelector = `${postSelector} footer :is(a[href*="/reblog/"], button:has(use[href="#managed-icon__ds-reblog-24"]))`;
-const buttonDivSelector = `${keyToCss('controls')} > *, ${keyToCss('engagementAction')}`;
+const buttonDivSelector = `${keyToCss('controls', 'reblogsControl', 'engagementControls')} > *`;
 
 export const styleElement = buildStyle(`
 ${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) {

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -69,7 +69,7 @@ const blogHashes = new Map();
 const avatarUrls = new Map();
 
 const buttonSelector = `${postSelector} footer a, ${postSelector} footer button`;
-const reblogButtonSelector = `${postSelector} footer :is(a[href*="/reblog/"], button:has(use[href="#managed-icon__ds-reblog-24"]))`;
+const reblogButtonSelector = `${postSelector} footer :is(a[href*="/reblog/"], button:not([aria-disabled="true"]):has(use[href="#managed-icon__ds-reblog-24"]))`;
 const buttonDivSelector = `${keyToCss('controls', 'reblogsControl', 'engagementControls')} > *`;
 
 export const styleElement = buildStyle(`

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -1,7 +1,7 @@
 import { sha256 } from '../../utils/crypto.js';
 import { timelineObject } from '../../utils/react_props.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
-import { postSelector, filterPostElements, postType, appendWithoutOverflow, buildStyle, getPopoverWrapper } from '../../utils/interface.js';
+import { postSelector, filterPostElements, postType, appendWithoutOverflow, buildStyle } from '../../utils/interface.js';
 import { joinedCommunities, joinedCommunityUuids, primaryBlog, userBlogs } from '../../utils/user.js';
 import { getPreferences } from '../../utils/preferences.js';
 import { onNewPosts } from '../../utils/mutations.js';
@@ -69,7 +69,7 @@ const blogHashes = new Map();
 const avatarUrls = new Map();
 
 const reblogButtonSelector = `${postSelector} footer a[href*="/reblog/"]`;
-const buttonDivSelector = `${keyToCss('controls', 'engagementControls')} > *, ${keyToCss('engagementAction')}`;
+const buttonDivSelector = `${keyToCss('controls')} > *, ${keyToCss('engagementAction')}`;
 
 export const styleElement = buildStyle(`
 ${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) {
@@ -137,7 +137,7 @@ tagsInput.addEventListener('input', checkLength);
 const showPopupOnHover = ({ currentTarget }) => {
   clearTimeout(timeoutID);
 
-  appendWithoutOverflow(popupElement, getPopoverWrapper(currentTarget), popupPosition);
+  appendWithoutOverflow(popupElement, currentTarget.closest(buttonDivSelector), popupPosition);
   popupElement.parentNode.addEventListener('mouseleave', removePopupOnLeave);
 
   const thisPost = currentTarget.closest(postSelector);

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -10,7 +10,7 @@ import { dom } from '../../utils/dom.js';
 import { showErrorModal } from '../../utils/modals.js';
 import { keyToCss } from '../../utils/css_map.js';
 
-const popupElement = dom('div', { id: 'quick-reblog' }, { click: event => { event.preventDefault(); event.stopPropagation(); } });
+const popupElement = dom('div', { id: 'quick-reblog' }, { click: event => event.stopPropagation() });
 const blogSelector = dom('select');
 const blogAvatar = dom('div', { class: 'avatar' });
 const blogSelectorContainer = dom('div', { class: 'select-container' }, null, [blogAvatar, blogSelector]);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes an issue on a new slight variant of one of the post footers that's floating around where clicks within the quick reblog popup would trigger the reblog button and open the reblog interface.

Resolves #1822.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

On all 3 footer variations:

- Confirm that the Quick Reblog modal appears when hovering over the reblog button.
- Confirm that the Quick Reblog modal **doesn't** appear when hovering over the reblog button of a post with reblogs disabled.
- Confirm that clicking the blog selector, text boxes, quick tags buttons, and submit buttons in the Quick Reblog modal only do what they're supposed to.
- Confirm that the reblog button changes color when Quick Reblog is used to reblog a post.

Note that the reblog button will become highlighted when mousing over the Quick Reblog popup in one split notes variant but not the other.
