### PR TITLE
chore: rename "enabledScripts" to "enabledFeatures" in internal code

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -1,6 +1,8 @@
 'use strict';
 
 {
+  const enabledFeaturesKey = 'enabledScripts';
+
   const redpop = [...document.scripts].some(({ src }) => src.includes('/pop/'));
   const isReactLoaded = () => document.querySelector('[data-rh]') === null;
 
@@ -8,7 +10,7 @@
 
   const timestamp = Date.now();
 
-  const runScript = async function (name) {
+  const runFeature = async function (name) {
     const {
       main,
       clean,
@@ -36,8 +38,8 @@
     restartListeners[name] = async (changes, areaName) => {
       if (areaName !== 'local') return;
 
-      const { enabledScripts } = changes;
-      if (enabledScripts && !enabledScripts.newValue.includes(name)) return;
+      const { [enabledFeaturesKey]: enabledFeatures } = changes;
+      if (enabledFeatures && !enabledFeatures.newValue.includes(name)) return;
 
       if (onStorageChanged instanceof Function) {
         onStorageChanged(changes, areaName);
@@ -50,7 +52,7 @@
     browser.storage.onChanged.addListener(restartListeners[name]);
   };
 
-  const destroyScript = async function (name) {
+  const destroyFeature = async function (name) {
     const {
       clean,
       stylesheet,
@@ -76,25 +78,25 @@
       return;
     }
 
-    const { enabledScripts } = changes;
+    const { [enabledFeaturesKey]: enabledFeatures } = changes;
 
-    if (enabledScripts) {
-      const { oldValue = [], newValue = [] } = enabledScripts;
+    if (enabledFeatures) {
+      const { oldValue = [], newValue = [] } = enabledFeatures;
 
       const newlyEnabled = newValue.filter(x => oldValue.includes(x) === false);
       const newlyDisabled = oldValue.filter(x => newValue.includes(x) === false);
 
-      newlyEnabled.forEach(runScript);
-      newlyDisabled.forEach(destroyScript);
+      newlyEnabled.forEach(runFeature);
+      newlyDisabled.forEach(destroyFeature);
     }
   };
 
-  const getInstalledScripts = async function () {
+  const getInstalledFeatures = async function () {
     const url = browser.runtime.getURL('/features/index.json');
     const file = await fetch(url);
-    const installedScripts = await file.json();
+    const installedFeatures = await file.json();
 
-    return installedScripts;
+    return installedFeatures;
   };
 
   const initMainWorld = () => new Promise(resolve => {
@@ -113,11 +115,11 @@
     browser.storage.onChanged.addListener(onStorageChanged);
 
     const [
-      installedScripts,
-      { enabledScripts = [] }
+      installedFeatures,
+      { [enabledFeaturesKey]: enabledFeatures = [] }
     ] = await Promise.all([
-      getInstalledScripts(),
-      browser.storage.local.get('enabledScripts'),
+      getInstalledFeatures(),
+      browser.storage.local.get(enabledFeaturesKey),
       initMainWorld()
     ]);
 
@@ -127,9 +129,9 @@
      */
     await Promise.all(['css_map', 'language_data', 'user'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
 
-    installedScripts
-      .filter(scriptName => enabledScripts.includes(scriptName))
-      .forEach(runScript);
+    installedFeatures
+      .filter(featureName => enabledFeatures.includes(featureName))
+      .forEach(runFeature);
   };
 
   const waitForReactLoaded = () => new Promise(resolve => {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

#1828:

> This PR intentionally does not update the `"enabledScripts"` storage key or any of its usages, since this PR is already rather big, and by its nature of doing mass-renaming should be tested thoroughly; adding any migratory code for `"enabledScripts"` &rarr; `"enabledFeatures"` would fall outside the scope of this testing.

This PR does not update the `"enabledScripts"` storage key, but **does** update its usages by making the key a variable.

Feel free to point this at master or at #1828, or to just pull the diff as part of actually updating the storage key and discarding this, whichever you prefer!

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

See testing steps for #1828.

