### PR TITLE
chore(Shorten Posts): mark feature as deprecated

### DIFF
--- a/src/features/shorten_posts/feature.json
+++ b/src/features/shorten_posts/feature.json
@@ -26,5 +26,6 @@
       ],
       "default": "1"
     }
-  }
+  },
+  "deprecated": true
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Deprecates the Shorten Posts feature in favour of the on-by-default "Shorten long posts" option available in Tumblr's own [dashboard settings](https://www.tumblr.com/settings/dashboard).

I actually meant to do this a lot sooner, as I saw it become a point of confusion even among fellow Tumblr staff to have the dashboard setting disabled but still have post shortening happen.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon with a blank configuration
2. Look for Shorten Posts in the control panel
    - [ ] **Expected result**: The feature is not listed
3. Enable the feature via importing this config in the Backup tab:
    ```json
    { "enabledScripts": ["shorten_posts"] }
    ```
4. Go back to the Configuration tab
    - [ ] **Expected result**: Shorten Posts is listed and enabled, with the "(deprecated)" title suffix
5. Disable the feature
6. Close and reopen the control panel
    - [ ] **Expected result**: Shorten Posts is now listed and can be enabled normally