### PR TITLE
Quick Reblog: Fix already-reblogged button coloration in notes view

### DIFF
--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -185,10 +185,6 @@
 
 #quick-reblog .action-buttons.community-selected button:not([data-state="published"]) { display: none; }
 
-footer.published svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--green)); }
-footer.queue svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--purple)); }
-footer.draft svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--red)); }
-
 :is(.published, .queue, .draft) :is(a[role="button"], button[class=""]) {
   position: relative;
 }

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -83,6 +83,10 @@ ${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) {
 ${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) ${keyToCss('tooltip')} {
   display: none;
 }
+
+footer.published ${keyToCss('footerRow', 'footerContent')} svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--green)); }
+footer.queue ${keyToCss('footerRow', 'footerContent')} svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--purple)); }
+footer.draft ${keyToCss('footerRow', 'footerContent')} svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--red)); }
 `);
 
 const onBlogSelectorChange = () => {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

On accounts without footer changes, the reblog icon in the mode selector in the notes view was colored green if the user has reblogged the post with quick reblog, etc. This makes sure the coloration is only applied to the correct button.

Not sure if there is a more elegant way to do this.

Resolves #1845.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

On all 3 footer variations:
- Confirm that the reblog button changes color when Quick Reblog is used to reblog a post.
- Confirm that nothing in the notes view changes color when Quick Reblog is used to reblog a post.

