### PR TITLE
Quick Reblog: Fix touchscreen long press context menu prevention

### DIFF
--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -324,7 +324,6 @@ const updateRememberedBlog = async ({ currentTarget: { value: selectedBlog } }) 
 const MOZ_SOURCE_TOUCH = 5;
 
 const preventLongPressMenu = ({ currentTarget, originalEvent: event }) => {
-  console.log(currentTarget, currentTarget.matches(reblogButtonSelector));
   if (!currentTarget.matches(reblogButtonSelector)) return;
 
   const isTouchEvent = event.pointerType === 'touch';


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

In #893, we added code to Quick Reblog that prevents the right-click context menu from appearing when a user with a touchscreen device long-presses a post's reblog button so that the Quick Reblog popup can appear instead. I tried to fix this code on certain accounts in #1823, but my fix was erroneous and breaks it on all accounts. This is the correct fix.

The problem is that we are using a JQuery delegated event listener for `preventLongPressMenu`. JQuery sets the currentTarget property on its synthetic event to the selected element, but the native event is actually on `document.body`.

Resolves #1844 (unless it doesn't; see below)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

You know, I'm not actually clear on whether this section is supposed to indicate that the PR author performed the listed tests or not.

Confirm that long-pressing the reblog button with Quick Tags enabled does not create/open a context menu:

- [x] In Chromium desktop, in responsive design mode simulating a touchscreen
- [x] In Firefox desktop, in responsive design mode simulating a touchscreen
- [ ] In Firefox for android

Confirm that long-pressing the reblog button with Quick Tags enabled opens the Quick Reblog menu:

- [x] In Chromium desktop, in responsive design mode simulating a touchscreen
- ❌ In Firefox desktop, in responsive design mode simulating a touchscreen
- [ ] In Firefox for android(?)

Depending on the results of this testing, #1849 may prove to be necessary?
