### PR TITLE
fix(Quick Reblog): restore AlreadyReblogged tick in new post footer variants

### DIFF
--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -248,13 +248,6 @@ footer:is(.published, .queue, .draft) button:has(use[href="#managed-icon__ds-reb
   left: 21px;
 }
 
-@media (max-width: 989px) {
-  footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after {
-    bottom: calc((27px / 2) - 2px);
-    right: calc((27px / 2) - 4px);
-  }
-}
-
 footer.published :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after { color: rgb(var(--green)); }
 footer.queue :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after { color: rgb(var(--purple)); }
 footer.draft :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after { color: rgb(var(--red)); }

--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -195,7 +195,25 @@ footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"
   position: relative;
 }
 
-/* Common styles for tick pseudo-element */
+/* Cut-out for tick in 2025 post footer, "split notes count" variant */
+footer:is(.published, .queue, .draft) a[href^="/reblog/"] svg:has(use[href="#managed-icon__ds-reblog-24"]) {
+  mask-image: radial-gradient(
+    calc(14.7px / 2) calc(18px / 2) at bottom 5px right 4px,
+    transparent 99%,
+    white 100%
+  );
+}
+
+/* Cut-out for tick in 2025 post footer, "single action" variant */
+footer:is(.published, .queue, .draft) button svg:has(use[href="#managed-icon__ds-reblog-24"]) {
+  mask-image: radial-gradient(
+    calc(14.7px / 2) calc(18px / 2) at bottom 4px left 21px,
+    transparent 99%,
+    white 100%
+  );
+}
+
+/* Styles for tick pseudo-element */
 footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after {
   position: absolute;
 
@@ -203,7 +221,6 @@ footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"
   padding: 2px;
   border-radius: 100%;
 
-  background-color: var(--content-panel);
   content: "\2713";
   font-family: "Favorit", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
   font-size: 14px;
@@ -214,6 +231,7 @@ footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"
 
 /* Pre-2025 post footer */
 footer:is(.published, .queue, .draft) a[href^="/reblog/"]:has(use[href="#managed-icon__reblog"])::after {
+  background-color: var(--content-panel);
   bottom: -5px;
   right: -5px;
 }

--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -197,6 +197,11 @@ footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"
 
 /* Cut-out for tick in 2025 post footer, "split notes count" variant */
 footer:is(.published, .queue, .draft) a[href^="/reblog/"] svg:has(use[href="#managed-icon__ds-reblog-24"]) {
+  -webkit-mask-image: radial-gradient(
+    calc(14.7px / 2) calc(18px / 2) at bottom 5px right 4px,
+    transparent 99%,
+    white 100%
+  );
   mask-image: radial-gradient(
     calc(14.7px / 2) calc(18px / 2) at bottom 5px right 4px,
     transparent 99%,
@@ -206,6 +211,11 @@ footer:is(.published, .queue, .draft) a[href^="/reblog/"] svg:has(use[href="#man
 
 /* Cut-out for tick in 2025 post footer, "single action" variant */
 footer:is(.published, .queue, .draft) button svg:has(use[href="#managed-icon__ds-reblog-24"]) {
+  -webkit-mask-image: radial-gradient(
+    calc(14.7px / 2) calc(18px / 2) at bottom 4px left 21px,
+    transparent 99%,
+    white 100%
+  );
   mask-image: radial-gradient(
     calc(14.7px / 2) calc(18px / 2) at bottom 4px left 21px,
     transparent 99%,

--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -185,24 +185,25 @@
 
 #quick-reblog .action-buttons.community-selected button:not([data-state="published"]) { display: none; }
 
+/* === AlreadyReblogged === */
+
 footer.published :is(button:not([role]), a[href^="/reblog/"]) use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--green)); }
 footer.queue :is(button:not([role]), a[href^="/reblog/"]) use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--purple)); }
 footer.draft :is(button:not([role]), a[href^="/reblog/"]) use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--red)); }
 
-:is(.published, .queue, .draft) :is(a[role="button"], button[class=""]) {
+footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"])) {
   position: relative;
 }
 
-:is(.published, .queue, .draft) :is(a[role="button"], button[class=""])::after {
+/* Common styles for tick pseudo-element */
+footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after {
   position: absolute;
-  bottom: -2px;
-  right: -4px;
 
   display: inline-block;
   padding: 2px;
   border-radius: 100%;
 
-  background-color: rgb(var(--white));
+  background-color: var(--content-panel);
   content: "\2713";
   font-family: "Favorit", "Helvetica Neue", "HelveticaNeue", Helvetica, Arial, sans-serif;
   font-size: 14px;
@@ -211,18 +212,36 @@ footer.draft :is(button:not([role]), a[href^="/reblog/"]) use:is([href="#managed
   line-height: 1;
 }
 
+/* Pre-2025 post footer */
+footer:is(.published, .queue, .draft) a[href^="/reblog/"]:has(use[href="#managed-icon__reblog"])::after {
+  bottom: -5px;
+  right: -5px;
+}
+
+/* 2025 post footer, "split notes count" variant */
+footer:is(.published, .queue, .draft) a[href^="/reblog/"]:has(use[href="#managed-icon__ds-reblog-24"])::after {
+  bottom: 4px;
+  right: 5px;
+}
+
+/* 2025 post footer, "single action" variant */
+footer:is(.published, .queue, .draft) button:has(use[href="#managed-icon__ds-reblog-24"])::after {
+  bottom: 4px;
+  left: 21px;
+}
+
 @media (max-width: 989px) {
-  :is(.published, .queue, .draft) :is(a[role="button"], button[class=""])::after {
+  footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after {
     bottom: calc((27px / 2) - 2px);
     right: calc((27px / 2) - 4px);
   }
 }
 
-.published :is(a[role="button"], button[class=""])::after { color: rgb(var(--green)); }
-.queue :is(a[role="button"], button[class=""])::after { color: rgb(var(--purple)); }
-.draft :is(a[role="button"], button[class=""])::after { color: rgb(var(--red)); }
+footer.published :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after { color: rgb(var(--green)); }
+footer.queue :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after { color: rgb(var(--purple)); }
+footer.draft :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after { color: rgb(var(--red)); }
 
-/* XKit 7 override */
+/* === XKit 7 override === */
 
 #x1cpostage_box {
   display: none !important;

--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -185,6 +185,10 @@
 
 #quick-reblog .action-buttons.community-selected button:not([data-state="published"]) { display: none; }
 
+footer.published :is(button:not([role]), a[href^="/reblog/"]) use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--green)); }
+footer.queue :is(button:not([role]), a[href^="/reblog/"]) use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--purple)); }
+footer.draft :is(button:not([role]), a[href^="/reblog/"]) use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--red)); }
+
 :is(.published, .queue, .draft) :is(a[role="button"], button[class=""]) {
   position: relative;
 }

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -83,10 +83,6 @@ ${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) {
 ${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) ${keyToCss('tooltip')} {
   display: none;
 }
-
-footer.published ${keyToCss('footerRow', 'footerContent')} svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--green)); }
-footer.queue ${keyToCss('footerRow', 'footerContent')} svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--purple)); }
-footer.draft ${keyToCss('footerRow', 'footerContent')} svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--red)); }
 `);
 
 const onBlogSelectorChange = () => {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- Fixes #1846

Updates Quick Reblog to restore the AlreadyReblogged tick on already-reblogged posts' reblog buttons when the user has one of the two new 2025 post footer variants, via `mask-image` magic that I stole from my past self (the new post header's avatar component uses this to display cut-outs for badges/sub-avatars too).

The magic numbers for how the mask works is... part science, part magic. The first two magic numbers are the ellipsis dimensions, which should match the tick's bounding box dimensions. The positional magic numbers are... kind of just whatever worked? To figure out how to get a perfect overlap, I temporarily added `background-color: red` to the masked SVG element and `background-color: blue` to the tick pseudo-element. Then, I just played with the position until they fit into each other perfectly. For the "single action" reblog button variant, the numbers make sense, the position values for the tick and the mask being identical; for the other new variant, the numbers are backwards for some reason. 🤷‍♀️

This is all done in pure CSS, dropping the CSS map calls introduced in #1847, thanks to the observation that there are now only three reblog button variants:
1. `footer a[href^="/reblog/"]:has(use[href="#managed-icon__reblog"])`—the pre-redesign reblog button
2. `footer a[href^="/reblog/"]:has(use[href="#managed-icon__ds-reblog-24"])`—the "split notes count" reblog button
3. `footer button:has(use[href="#managed-icon__ds-reblog-24"])`—the "single action" reblog button

None of these selectors should target anything in the notes view; only the pre-redesign notes view has a reblog icon, and it's not part of a link. When combining these selectors to target all of them in one go, the `button` selector part must be swapped out for `button:not([role])` so as not to target the `button[role="tab"]` containing the old reblog icon in the pre-redesign notes view.

Oh, and this removes the outdated CSS that changes the tick position on mobile-sized viewports. Now that we're putting the tick on the reblog anchor/button directly, instead of the control button container, the difference in the container size on mobile doesn't affect us anymore. In fact, in attempting to still account for it, the tick just goes in the wrong corner.

Before | After
-|-
<img width="362" height="112" alt="Screen Shot 2025-07-24 at 14 07 50" src="https://github.com/user-attachments/assets/83f05346-8c7b-42d5-a6a1-1c109ab47a1c" /> | <img width="362" height="112" alt="Screen Shot 2025-07-24 at 14 08 09" src="https://github.com/user-attachments/assets/b476bf50-b790-4944-a917-8edaf2f99208" />
<img width="384" height="96" alt="Screen Shot 2025-07-24 at 14 10 41" src="https://github.com/user-attachments/assets/4299ccb0-f50f-4798-b40e-6873b71a6682" /> | <img width="384" height="96" alt="Screen Shot 2025-07-24 at 14 10 56" src="https://github.com/user-attachments/assets/93ea3136-9d2a-4c10-afc9-bd42b9d77de8" />
<img width="1080" height="128" alt="Screen Shot 2025-07-24 at 14 08 45" src="https://github.com/user-attachments/assets/985e8556-4f56-4074-ba7f-c82e8f297830" /> | <img width="1080" height="128" alt="Screen Shot 2025-07-24 at 14 09 01" src="https://github.com/user-attachments/assets/e41e9a6f-85fc-40e7-81d7-94dd560f1d4f" />
<img width="1080" height="128" alt="Screen Shot 2025-07-24 at 14 09 31" src="https://github.com/user-attachments/assets/af9215aa-fcbb-4e38-bc1c-116858bc29d9" /> | <img width="1080" height="128" alt="Screen Shot 2025-07-24 at 14 09 51" src="https://github.com/user-attachments/assets/159474d2-18fa-4612-9009-8fdfa5a624d1" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Enable Quick Reblog
3. Reblog a post using Quick Reblog
    - [ ] **Expected result**: The reblog button in the post footer turns green/purple/red
    - [ ] **Expected result**: A tick is added to the reblog button
    - [ ] **Expected result**: The tick does not touch or overlap with the reblog button; the bottom-right corner of the icon disappears to make room for the tick
4. Confirm that the above holds true on all known post footer variants
    - [ ] Pre-redesign
    - [ ] `postFooterSplitNotesCount`
    - [ ] `postFooterSplitNotesCountSingleAction`
