### PR TITLE
AccessKit Disable GIFs: Optionally delay GIF downloading until hover; refactor labels

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -6,7 +6,7 @@ import { buildStyle, postSelector } from '../../utils/interface.js';
 const canvasClass = 'xkit-paused-gif-placeholder';
 const pausedPosterAttribute = 'data-paused-gif-use-poster';
 const hoverContainerAttribute = 'data-paused-gif-hover-container';
-const labelClass = 'xkit-paused-gif-label';
+const labelAttribute = 'data-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
 
@@ -14,7 +14,7 @@ const hovered = `:is(:hover, [${hoverContainerAttribute}]:hover *)`;
 const parentHovered = `:is(:hover > *, [${hoverContainerAttribute}]:hover *)`;
 
 export const styleElement = buildStyle(`
-.${labelClass} {
+[${labelAttribute}]::after {
   position: absolute;
   top: 1ch;
   right: 1ch;
@@ -23,6 +23,7 @@ export const styleElement = buildStyle(`
   padding: 0.6ch;
   border-radius: 3px;
 
+  content: "GIF";
   background-color: rgb(var(--black));
   color: rgb(var(--white));
   font-size: 1rem;
@@ -30,16 +31,12 @@ export const styleElement = buildStyle(`
   line-height: 1em;
   pointer-events: none;
 }
-
-.${labelClass}::before {
-  content: "GIF";
-}
-
-.${labelClass}.mini {
+[${labelAttribute}="mini"]::after {
   font-size: 0.6rem;
 }
 
-.${labelClass}.hr {
+[${labelAttribute}="hr"]::after {
+  font-size: 0.6rem;
   top: 50%;
   transform: translateY(-50%);
 }
@@ -52,11 +49,11 @@ export const styleElement = buildStyle(`
 }
 
 .${canvasClass}${parentHovered},
-.${labelClass}${parentHovered},
+[${labelAttribute}]${hovered}::after,
 [${pausedPosterAttribute}]:not(${hovered}) > div > ${keyToCss('knightRiderLoader')} {
   display: none;
 }
-${keyToCss('background')} .${labelClass} {
+${keyToCss('background')}[${labelAttribute}]::after {
   /* prevent double labels in recommended post cards */
   display: none;
 }
@@ -79,13 +76,13 @@ ${keyToCss('background')} .${labelClass} {
 `);
 
 const addLabel = (element, inside = false) => {
-  if (element.parentNode.querySelector(`.${labelClass}`) === null) {
-    const gifLabel = dom('p', { class: labelClass });
-    element.clientWidth && element.clientWidth <= 150 && gifLabel.classList.add('mini');
-    element.clientHeight && element.clientHeight <= 50 && gifLabel.classList.add('mini');
-    element.clientHeight && element.clientHeight <= 30 && gifLabel.classList.add('hr');
+  const target = inside ? element : element.parentElement;
+  if (target && getComputedStyle(target, '::after').content === 'none') {
+    target.setAttribute(labelAttribute, '');
 
-    inside ? element.append(gifLabel) : element.parentNode.append(gifLabel);
+    target.clientWidth && target.clientWidth <= 150 && target.setAttribute(labelAttribute, 'mini');
+    target.clientHeight && target.clientHeight <= 50 && target.setAttribute(labelAttribute, 'mini');
+    target.clientHeight && target.clientHeight <= 30 && target.setAttribute(labelAttribute, 'hr');
   }
 };
 
@@ -109,10 +106,7 @@ const pauseGif = function (gifElement) {
 const processGifs = function (gifElements) {
   gifElements.forEach(gifElement => {
     if (gifElement.closest(`${keyToCss('avatarImage', 'subAvatarImage')}, .block-editor-writing-flow`)) return;
-    const pausedGifElements = [
-      ...gifElement.parentNode.querySelectorAll(`.${canvasClass}`),
-      ...gifElement.parentNode.querySelectorAll(`.${labelClass}`)
-    ];
+    const pausedGifElements = [...gifElement.parentNode.querySelectorAll(`.${canvasClass}`)];
     if (pausedGifElements.length) {
       gifElement.after(...pausedGifElements);
       return;
@@ -193,8 +187,9 @@ export const clean = async function () {
     wrapper.replaceWith(...wrapper.children)
   );
 
-  $(`.${canvasClass}, .${labelClass}`).remove();
+  $(`.${canvasClass}`).remove();
   $(`.${backgroundGifClass}`).removeClass(backgroundGifClass);
+  $(`[${labelAttribute}]`).removeAttr(labelAttribute);
   $(`[${pausedPosterAttribute}]`).removeAttr(pausedPosterAttribute);
   $(`[${hoverContainerAttribute}]`).removeAttr(hoverContainerAttribute);
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -4,10 +4,14 @@ import { dom } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
+const pausedPosterAttribute = 'data-paused-gif-use-poster';
 const hoverContainerAttribute = 'data-paused-gif-hover-container';
 const labelClass = 'xkit-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
+
+const hovered = `:is(:hover, [${hoverContainerAttribute}]:hover *)`;
+const parentHovered = `:is(:hover > *, [${hoverContainerAttribute}]:hover *)`;
 
 export const styleElement = buildStyle(`
 .${labelClass} {
@@ -47,11 +51,21 @@ export const styleElement = buildStyle(`
   background-color: rgb(var(--white));
 }
 
-*:hover > .${canvasClass},
-*:hover > .${labelClass},
-[${hoverContainerAttribute}]:hover .${canvasClass},
-[${hoverContainerAttribute}]:hover .${labelClass} {
+.${canvasClass}${parentHovered},
+.${labelClass}${parentHovered},
+[${pausedPosterAttribute}]:not(${hovered}) > div > ${keyToCss('knightRiderLoader')} {
   display: none;
+}
+${keyToCss('background')} .${labelClass} {
+  /* prevent double labels in recommended post cards */
+  display: none;
+}
+
+[${pausedPosterAttribute}]:not(${hovered}) > img${keyToCss('poster')} {
+  visibility: visible !important;
+}
+[${pausedPosterAttribute}]:not(${hovered}) > img:not(${keyToCss('poster')}) {
+  visibility: hidden !important;
 }
 
 .${backgroundGifClass}:not(:hover) {
@@ -105,6 +119,13 @@ const processGifs = function (gifElements) {
     }
 
     gifElement.decoding = 'sync';
+
+    const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
+    if (posterElement) {
+      gifElement.parentElement.setAttribute(pausedPosterAttribute, '');
+      addLabel(posterElement);
+      return;
+    }
 
     if (gifElement.complete && gifElement.currentSrc) {
       pauseGif(gifElement);
@@ -174,5 +195,6 @@ export const clean = async function () {
 
   $(`.${canvasClass}, .${labelClass}`).remove();
   $(`.${backgroundGifClass}`).removeClass(backgroundGifClass);
+  $(`[${pausedPosterAttribute}]`).removeAttr(pausedPosterAttribute);
   $(`[${hoverContainerAttribute}]`).removeAttr(hoverContainerAttribute);
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -2,6 +2,7 @@ import { pageModifications } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
 import { dom } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
+import { getPreferences } from '../../utils/preferences.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
 const pausedPosterAttribute = 'data-paused-gif-use-poster';
@@ -9,6 +10,8 @@ const hoverContainerAttribute = 'data-paused-gif-hover-container';
 const labelAttribute = 'data-paused-gif-label';
 const containerClass = 'xkit-paused-gif-container';
 const backgroundGifClass = 'xkit-paused-background-gif';
+
+let loadingMode;
 
 const hovered = `:is(:hover, [${hoverContainerAttribute}]:hover *)`;
 const parentHovered = `:is(:hover > *, [${hoverContainerAttribute}]:hover *)`;
@@ -61,8 +64,11 @@ ${keyToCss('background')}[${labelAttribute}]::after {
 [${pausedPosterAttribute}]:not(${hovered}) > img${keyToCss('poster')} {
   visibility: visible !important;
 }
-[${pausedPosterAttribute}]:not(${hovered}) > img:not(${keyToCss('poster')}) {
+[${pausedPosterAttribute}="eager"]:not(${hovered}) > img:not(${keyToCss('poster')}) {
   visibility: hidden !important;
+}
+[${pausedPosterAttribute}="lazy"]:not(${hovered}) > img:not(${keyToCss('poster')}) {
+  display: none;
 }
 
 .${backgroundGifClass}:not(:hover) {
@@ -116,7 +122,7 @@ const processGifs = function (gifElements) {
 
     const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
     if (posterElement) {
-      gifElement.parentElement.setAttribute(pausedPosterAttribute, '');
+      gifElement.parentElement.setAttribute(pausedPosterAttribute, loadingMode);
       addLabel(posterElement);
       return;
     }
@@ -155,7 +161,18 @@ const processRows = function (rowsElements) {
 const processHoverableElements = elements =>
   elements.forEach(element => element.setAttribute(hoverContainerAttribute, ''));
 
+const onStorageChanged = async function (changes, areaName) {
+  if (areaName !== 'local') return;
+
+  const { 'accesskit.preferences.disable_gifs_loading_mode': modeChanges } = changes;
+  if (modeChanges?.oldValue === undefined) return;
+
+  loadingMode = modeChanges.newValue;
+};
+
 export const main = async function () {
+  ({ disable_gifs_loading_mode: loadingMode } = await getPreferences('accesskit'));
+
   const gifImage = `
     :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img[srcset*=".gif"]:not(${keyToCss('poster')})
   `;
@@ -175,9 +192,13 @@ export const main = async function () {
     `:is(${postSelector}, ${keyToCss('blockEditorContainer')}) ${keyToCss('rows')}`,
     processRows
   );
+
+  browser.storage.onChanged.addListener(onStorageChanged);
 };
 
 export const clean = async function () {
+  browser.storage.onChanged.removeListener(onStorageChanged);
+
   pageModifications.unregister(processGifs);
   pageModifications.unregister(processBackgroundGifs);
   pageModifications.unregister(processRows);

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -104,6 +104,8 @@ const processGifs = function (gifElements) {
       return;
     }
 
+    gifElement.decoding = 'sync';
+
     if (gifElement.complete && gifElement.currentSrc) {
       pauseGif(gifElement);
     } else {

--- a/src/features/accesskit/feature.json
+++ b/src/features/accesskit/feature.json
@@ -14,6 +14,15 @@
       "label": "Pause GIFs until they are hovered over",
       "default": false
     },
+    "disable_gifs_loading_mode": {
+      "type": "select",
+      "label": "Download paused GIFs:",
+      "options": [
+        { "value": "eager", "label": "immediately" },
+        { "value": "lazy", "label": "when hovered" }
+      ],
+      "default": "eager"
+    },
     "boring_tag_chiclets": {
       "type": "checkbox",
       "label": "De-animate the Changes/Staff Picks/etc. links carousel",


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds an option (off-by-default) to AccessKit Disable GIFs to delay downloading of the animated portion of most GIFs until the user actually hovers to load them.

This is implemented in CSS by using—when there is one—Tumblr's native "poster" element as the paused image rather than making our own, hiding either the poster or the animated image depending on the hover state (#1707). Because this is synchronous, choosing to delay the animated image load is as simple as using `display:none` rather than `visibility:hidden` on the animated image. (Note that this doesn't work in the blog view in modal mode because Tumblr doesn't set `loading=lazy` there for some reason.)

To avoid having to handle edge cases where the "GIF" label would be underneath another element in certain cases, this also makes the label into an `::after` pseudo element.

As a side effect of using the poster, this fixes the layout of non-square images in recommended blog cards, which (as mentioned in #1463) can expose a second "GIF" label on the background gif; a fix is included to hide this extra label.

<img width="300" src="https://github.com/user-attachments/assets/1ee3ee14-2ddf-4f2b-8c65-a73a92bef529"> 

Supersedes #1458.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Set the new "Download paused GIFs" preference to the default "immediately" value. Scroll down e.g. https://www.tumblr.com/search/gif, wait a moment, then confirm that hovered GIFs animate immediately. Dev tools can be used to confirm that no image load happens on hover.
- Set the new "Download paused GIFs" preference to "when hovered" value. Scroll down e.g. https://www.tumblr.com/search/gif, hover a GIF, and confirm that its GIF label is briefly replaced with a loading icon before it animates. Dev tools can be used to confirm that the image load happens on hover.

<br />

- Confirm that GIFs in posts are paused and receive labels instantly.
- Confirm, particularly in Firefox, that moving the cursor onto/off of a GIF instantly animates/pauses it.
- Confirm that small GIFs (side-by-side photosets in masonry view) receive small GIF labels.
- On https://www.tumblr.com/tagged/gif in non-masonry view, find the recommended blog carousel. Confirm that GIFs in it pause/unpause correctly in both modes.

<br />

- Confirm that GIFs are paused correctly on initial page load ("hard navigate") and on soft navigate/endless scroll.
- Confirm that GIFs are paused correctly when scrolling back up an infinite scroll timeline.

<br />

- Confirm that all of the elements this feature can pause are paused correctly. (I didn't actually test this standalone; I instead tested #1744.)