### PR TITLE
AccessKit Disable GIFs: Pause additional elements

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -178,18 +178,13 @@ export const main = async function () {
   const gifImage = `
     :is(
       figure, /* post image/imageset; recommended blog carousel entry; blog view sidebar "more like this"; post in grid view; blog card modal post entry */
-      /* main.labs, /* labs settings header: https://www.tumblr.com/settings/labs */
       ${keyToCss(
         'linkCard', // post link element
-        // 'albumImage', // post audio element
         'messageImage', // direct message attached image
         'messagePost', // direct message linked post
         'typeaheadRow', // modal search dropdown entry
         'tagImage', // search page sidebar related tags, recommended tag carousel entry: https://www.tumblr.com/search/gif, https://www.tumblr.com/explore/recommended-for-you
-        // 'headerBanner', // blog view header
-        // 'headerImage', // modal blog card header, activity page "biggest fans" header
         'topPost', // activity page top post
-        // 'colorfulListItemWrapper', // trending tag: https://www.tumblr.com/explore/trending
         'takeoverBanner' // advertisement
       )}
     ) img:is([srcset*=".gif"], [src*=".gif"]):not(${keyToCss('poster')})

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -46,6 +46,8 @@ export const styleElement = buildStyle(`
 
 .${canvasClass} {
   position: absolute;
+  top: 0;
+  left: 0;
   visibility: visible;
 
   background-color: rgb(var(--white));
@@ -76,7 +78,7 @@ ${keyToCss('background')}[${labelAttribute}]::after {
   background-color: rgb(var(--secondary-accent));
 }
 
-.${backgroundGifClass}:not(:hover) > div {
+.${backgroundGifClass}:not(:hover) > :is(div, span) {
   color: rgb(var(--black));
 }
 `);
@@ -174,17 +176,37 @@ export const main = async function () {
   ({ disable_gifs_loading_mode: loadingMode } = await getPreferences('accesskit'));
 
   const gifImage = `
-    :is(figure, ${keyToCss('tagImage', 'takeoverBanner')}) img[srcset*=".gif"]:not(${keyToCss('poster')})
+    :is(
+      figure, /* post image/imageset; recommended blog carousel entry; blog view sidebar "more like this"; post in grid view; blog card modal post entry */
+      /* main.labs, /* labs settings header: https://www.tumblr.com/settings/labs */
+      ${keyToCss(
+        'linkCard', // post link element
+        // 'albumImage', // post audio element
+        'messageImage', // direct message attached image
+        'messagePost', // direct message linked post
+        'typeaheadRow', // modal search dropdown entry
+        'tagImage', // search page sidebar related tags, recommended tag carousel entry: https://www.tumblr.com/search/gif, https://www.tumblr.com/explore/recommended-for-you
+        // 'headerBanner', // blog view header
+        // 'headerImage', // modal blog card header, activity page "biggest fans" header
+        'topPost', // activity page top post
+        // 'colorfulListItemWrapper', // trending tag: https://www.tumblr.com/explore/trending
+        'takeoverBanner' // advertisement
+      )}
+    ) img:is([srcset*=".gif"], [src*=".gif"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
 
   const gifBackgroundImage = `
-    ${keyToCss('communityHeaderImage', 'bannerImage')}[style*=".gif"]
+    ${keyToCss(
+      'communityHeaderImage', // search page tags section header: https://www.tumblr.com/search/gif?v=tag
+      'bannerImage', // tagged page sidebar header: https://www.tumblr.com/tagged/gif
+      'tagChicletWrapper' // "trending" / "your tags" timeline carousel entry: https://www.tumblr.com/dashboard/trending, https://www.tumblr.com/dashboard/hubs
+    )}[style*=".gif"]
   `;
   pageModifications.register(gifBackgroundImage, processBackgroundGifs);
 
   pageModifications.register(
-    `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}`,
+    `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}`, // recommended blog carousel entry: https://www.tumblr.com/tagged/gif
     processHoverableElements
   );
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -175,7 +175,9 @@ export const main = async function () {
 
   const gifImage = `
     :is(
-      figure, /* post image/imageset; recommended blog carousel entry; blog view sidebar "more like this"; post in grid view; blog card modal post entry */
+      ${
+        'figure' // post image/imageset; recommended blog carousel entry; blog view sidebar "more like this"; post in grid view; blog card modal post entry
+      }
       ${keyToCss(
         'linkCard', // post link element
         'typeaheadRow', // modal search dropdown entry

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -46,8 +46,6 @@ export const styleElement = buildStyle(`
 
 .${canvasClass} {
   position: absolute;
-  top: 0;
-  left: 0;
   visibility: visible;
 
   background-color: rgb(var(--white));
@@ -180,14 +178,12 @@ export const main = async function () {
       figure, /* post image/imageset; recommended blog carousel entry; blog view sidebar "more like this"; post in grid view; blog card modal post entry */
       ${keyToCss(
         'linkCard', // post link element
-        'messageImage', // direct message attached image
-        'messagePost', // direct message linked post
         'typeaheadRow', // modal search dropdown entry
         'tagImage', // search page sidebar related tags, recommended tag carousel entry: https://www.tumblr.com/search/gif, https://www.tumblr.com/explore/recommended-for-you
         'topPost', // activity page top post
         'takeoverBanner' // advertisement
       )}
-    ) img:is([srcset*=".gif"], [src*=".gif"]):not(${keyToCss('poster')})
+    ) img[srcset*=".gif"]:not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -102,6 +102,7 @@ const pauseGif = function (gifElement) {
       canvas.height = image.naturalHeight;
       canvas.className = gifElement.className;
       canvas.classList.add(canvasClass);
+      canvas.setAttribute('style', gifElement.getAttribute('style'));
       canvas.getContext('2d').drawImage(image, 0, 0);
       gifElement.parentNode.append(canvas);
       addLabel(gifElement);

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -104,7 +104,7 @@ const pauseGif = function (gifElement) {
       canvas.classList.add(canvasClass);
       canvas.setAttribute('style', gifElement.getAttribute('style'));
       canvas.getContext('2d').drawImage(image, 0, 0);
-      gifElement.parentNode.append(canvas);
+      gifElement.after(canvas);
       addLabel(gifElement);
     }
   };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -177,7 +177,7 @@ export const main = async function () {
     :is(
       ${
         'figure' // post image/imageset; recommended blog carousel entry; blog view sidebar "more like this"; post in grid view; blog card modal post entry
-      }
+      },
       ${keyToCss(
         'linkCard', // post link element
         'typeaheadRow', // modal search dropdown entry


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds additional selectors for GIFs that can be paused with minimal changes to the current Disable GIFs code and comments that list the elements referred to.

Based off of the branch for #1853 and tested that way. **Note:** most/all of these don't need that PR; let me know if you'd like them tested and PR'd separately. If merging both, it reduces testing to test them together (though it might require a rebase of this branch, annoyingly).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that each element listed in the source code is paused correctly, has a label, and unpauses correctly when hovered.
- Confirm that paused carousels on https://www.tumblr.com/dashboard/trending / https://www.tumblr.com/dashboard/hubs have readable text.

Note: the GIFs in the search dropdown modal don't have labels when I test this in Safari 17.6; this happens whether I use the `<p>`-element or pseudo element label and I'm pretty certain it's a Safari bug with canvas elements.

Edit: Smoke tested in Safari 18.1.1 on iOS. Real nice for spotty connections.
