### PR TITLE
chore: prevent holding broken npm packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
   "dependencyDashboard": false,
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
+      "minimumReleaseAge": "3 days"
+    },
+    {
       "groupName": "vendored dependencies",
       "matchManagers": ["npm"],
       "matchDepTypes": ["dependencies"],


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- Relates to #1856
- See [Configuration Options - Renovate Docs § `minimumReleaseAge`](https://docs.renovatebot.com/configuration-options/#minimumreleaseage)

> #### Prevent holding broken npm packages
> npm packages less than 72 hours (3 days) old can be unpublished from the npm registry, which could result in a service impact if you have already updated to it. Set `minimumReleaseAge` to `3 days` for npm packages to prevent relying on a package that can be removed from the registry[.]

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Run `npx --yes --package renovate -- renovate-config-validator`
    - [ ] **Expected result**:
      ```
       INFO: Validating renovate.json
       INFO: Config validated successfully
      ```