### PR TITLE
Quick Tags: Improve drag sort compatibility

### DIFF
--- a/src/features/quick_tags/options/index.js
+++ b/src/features/quick_tags/options/index.js
@@ -27,6 +27,7 @@ const saveNewBundle = async event => {
 Sortable.create(bundlesList, {
   dataIdAttr: 'id',
   handle: '.drag-handle',
+  forceFallback: true,
   store: {
     set: async sortable => {
       const { [storageKey]: tagBundles = [] } = await browser.storage.local.get(storageKey);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Not sure exactly what this does, but this enables the [forceFallback option in SortableJS](https://github.com/SortableJS/Sortable#forcefallback-option), which may make it more compatible in unusual situations.

Resolves #1858, hopefully.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

As in #1749:

- Confirm that tag bundles can be dragged to rearrange them in the options UI and that the drag action rotates the bundle order in the tag popup.
- Confirm that scrolling is not affected negatively on mobile devices.

Not sure how to find the kind of bugs that the linked issue is about besides "try to screw with it a lot."