### PR TITLE
Adjust menu backup section layout for chromium compatibility

### DIFF
--- a/src/action/backup.css
+++ b/src/action/backup.css
@@ -1,7 +1,13 @@
 #backup details {
+  padding: 1ch;
+}
+
+#backup details > .content {
+  margin-top: 0.5em;
+
   display: flex;
   flex-direction: column;
-  padding: 1ch;
+  gap: 0.5em;
 }
 
 #backup details[open] ~ details summary ~ * {
@@ -14,7 +20,7 @@
 }
 
 #backup label {
-  margin: 1em 0;
+  margin: 0;
 }
 
 #backup pre {
@@ -33,7 +39,7 @@
   overflow-wrap: break-word;
   padding: 1ch;
   border: none;
-  margin: 1em 0;
+  margin: 0;
 
   background-color: rgb(var(--passive-grey));
   color: rgb(var(--black));

--- a/src/action/popup.html
+++ b/src/action/popup.html
@@ -46,17 +46,21 @@
       <section id="backup">
         <details id="export" open>
           <summary><h4>Export</h4></summary>
-          <pre id="local-storage-export"></pre>
-          <div class="buttons-container">
-            <button id="copy-local">Copy All</button>
-            <button id="download-local">Download</button>
+          <div class="content">
+            <pre id="local-storage-export"></pre>
+            <div class="buttons-container">
+              <button id="copy-local">Copy All</button>
+              <button id="download-local">Download</button>
+            </div>
           </div>
         </details>
         <details id="import">
           <summary><h4>Import</h4></summary>
-          <label for="local-storage-import">Paste the contents of your saved backup here.</label>
-          <textarea id="local-storage-import" rows="10" spellcheck="false"></textarea>
-          <button id="restore-local"></button>
+          <div class="content">
+            <label for="local-storage-import">Paste the contents of your saved backup here.</label>
+            <textarea id="local-storage-import" rows="10" spellcheck="false"></textarea>
+            <button id="restore-local"></button>
+          </div>
         </details>
       </section>
       <section id="links">


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Fun fact: setting `display: flex` or setting margin on the child of a `details` element in chromium doesn't seem to work. (I see `slot` in chromium devtools; maybe `details` is implemented as a custom element?) Anyway, this results in slightly incorrect spacing in the backup section of the XKit Rewritten menu, and is kind of a pain if you try to add an element to it.

<img width="374" src="https://github.com/user-attachments/assets/17e19187-8b86-4688-ad98-f49755d2fbcf" />

This PR is... I dunno, one way to solve this. There may be better ones. As mentioned a number of times, I consider myself a CSS layout... intermediate, I guess, at best?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that the backup section of the XKit Rewritten menu has correct-looking layout in both Firefox and Chrome when either/neither element is expanded. 