### PR TITLE
feat(AccessKit Disable GIFs): Pause animated webp images

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -3,6 +3,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { dom } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
 import { getPreferences } from '../../utils/preferences.js';
+import { memoize } from '../../utils/memoize.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
 const pausedPosterAttribute = 'data-paused-gif-use-poster';
@@ -92,7 +93,30 @@ const addLabel = (element, inside = false) => {
   }
 };
 
-const pauseGif = function (gifElement) {
+/**
+ * Fetches the selected image and tests if it is animated. On older browsers without ImageDecoder
+ * support, GIF images are assumed to be animated and WebP images are assumed to not be animated.
+ */
+const isAnimated = memoize(async sourceUrl => {
+  const response = await fetch(sourceUrl, { headers: { Accept: 'image/webp,*/*' } });
+  const contentType = response.headers.get('Content-Type');
+
+  if (typeof ImageDecoder === 'function' && await ImageDecoder.isTypeSupported(contentType)) {
+    const decoder = new ImageDecoder({
+      type: contentType,
+      data: response.body,
+      preferAnimation: true
+    });
+    await decoder.decode();
+    return decoder.tracks.selectedTrack.animated;
+  } else {
+    return !sourceUrl.endsWith('.webp');
+  }
+});
+
+const pauseGif = async function (gifElement) {
+  if (gifElement.currentSrc.endsWith('.webp') && !(await isAnimated(gifElement.currentSrc))) return;
+
   const image = new Image();
   image.src = gifElement.currentSrc;
   image.onload = () => {
@@ -186,7 +210,7 @@ export const main = async function () {
         'topPost', // activity page top post
         'takeoverBanner' // advertisement
       )}
-    ) img[srcset*=".gif"]:not(${keyToCss('poster')})
+    ) img:is([srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This applies Disable GIFs to animated WebP images—but not, if possible, to non-animated WebP images—by downloading them and parsing them with the new [WebCodecs API](https://developer.mozilla.org/en-US/docs/Web/API/WebCodecs_API).

This intentionally keeps our current behavior of assuming, sometimes incorrectly, that any gif (or gifv) image is animated, as checking if an image is animated involves fetching it, which is kind of expensive.

ImageDecoder is feature detected; in Firefox 128, this falls back to not affecting webp images.

Supersedes #1402 (which vendored a library to do this), #1563 (which paused and put labels on webp images regardless of whether they were animated or not), and #1709 (earlier, essentially-equivalent version of this PR).

Resolves #1401.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Animated WebP: https://www.tumblr.com/changes/758172275271991296/threaded-replies-are-here
Animated GIF: https://www.tumblr.com/@radar/757906400962920448, https://www.tumblr.com/april-codes/700206746833240064
Non-animated GIF: https://www.tumblr.com/@radar/753920129042153472
Non-animated WebP: https://www.tumblr.com/minmos/744793127262601216/front-facing-egrets-making-me-lose-control-of, https://www.tumblr.com/@radar/755279084134744066, https://www.tumblr.com/@radar/750568043810340864

Confirm that:
- animated WebP images in posts are paused
- non-animated WebP images in posts are not paused
- animated GIF images in posts are paused
- non-animated GIF images in posts... are still incorrectly paused, as it would be too expensive to check every GIF.