### PR TITLE
fix(Popup): Clear storage optionally on backup restore

### DIFF
--- a/src/action/backup.css
+++ b/src/action/backup.css
@@ -19,7 +19,7 @@
   margin: 0;
 }
 
-#backup label {
+#backup label, #backup p {
   margin: 0;
 }
 

--- a/src/action/popup.html
+++ b/src/action/popup.html
@@ -64,6 +64,7 @@
           <div class="content">
             <label for="local-storage-import">Paste the contents of your saved backup here.</label>
             <textarea id="local-storage-import" rows="10" spellcheck="false"></textarea>
+            <p id="overwrite-warning"><b>Note:</b> This will overwrite your existing configuration!</p>
             <button id="restore-local"></button>
           </div>
         </details>

--- a/src/action/render_backup.js
+++ b/src/action/render_backup.js
@@ -3,15 +3,17 @@ const localCopyButton = document.getElementById('copy-local');
 const localDownloadButton = document.getElementById('download-local');
 
 const localImportTextarea = document.getElementById('local-storage-import');
+const localOverwriteWarning = document.getElementById('overwrite-warning');
 const localRestoreButton = document.getElementById('restore-local');
 
 const sleep = ms => new Promise(resolve => setTimeout(() => resolve(), ms));
 
-const updateLocalExportDisplay = async function () {
+const onStorageChanged = async function () {
   const storageLocal = await browser.storage.local.get();
   const stringifiedStorage = JSON.stringify(storageLocal, null, 2);
 
   localExportDisplayElement.textContent = stringifiedStorage;
+  localOverwriteWarning.hidden = stringifiedStorage === '{}';
 };
 
 const localCopy = async function () {
@@ -79,8 +81,8 @@ const localRestore = async function () {
 };
 
 const renderLocalBackup = async function () {
-  updateLocalExportDisplay();
-  browser.storage.local.onChanged.addListener(updateLocalExportDisplay);
+  onStorageChanged();
+  browser.storage.local.onChanged.addListener(onStorageChanged);
 
   localCopyButton.addEventListener('click', localCopy);
   localDownloadButton.addEventListener('click', localExport);

--- a/src/action/render_backup.js
+++ b/src/action/render_backup.js
@@ -57,6 +57,8 @@ const localRestore = async function () {
     localRestoreButton.disabled = true;
 
     const parsedStorage = JSON.parse(importText);
+
+    await browser.storage.local.clear();
     await browser.storage.local.set(parsedStorage);
 
     localRestoreButton.classList.add('success');


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This ensures that when one imports a backup of their preferences, keys not in the backup get removed, as one might expect.

Resolves #1191.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Export your data, if you're testing this with your real data. Toggle some preferences to generate some data if you aren't. Copy your data.
- Paste `{}` into the restore box. Confirm that restoring removes all of your data.
- Paste your current data into the restore box. Confirm that restoring works as expected.
- Confirm that an informative message is shown if data will be overwritten.
