### PR TITLE
fix(Quick Reblog, Quick Tags): Prevent popovers being covered by next post in older browsers (z-index)

### DIFF
--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -30,11 +30,11 @@
   }
 }
 
-#quick-reblog.below {
+#quick-reblog[data-position="below"] {
   inset: 100% 50% auto auto;
   transform: translate(calc(50% + var(--horizontal-offset, 0%)), var(--icon-spacing));
 }
-#quick-reblog.above {
+#quick-reblog[data-position="above"] {
   inset: auto 50% 100% auto;
   transform: translate(calc(50% + var(--horizontal-offset, 0%)), calc(0px - var(--icon-spacing)));
 }

--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -1,6 +1,5 @@
 #quick-reblog {
   position: absolute;
-  z-index: 97;
   box-shadow: 0 0 15px 0 rgba(0,0,0,.5);
   padding: 2px;
   border-radius: 3px;

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -9,8 +9,9 @@ import { notify } from '../../utils/notifications.js';
 import { dom } from '../../utils/dom.js';
 import { showErrorModal } from '../../utils/modals.js';
 import { keyToCss } from '../../utils/css_map.js';
+import { postPopoverClass } from '../../utils/post_popovers.js';
 
-const popupElement = dom('div', { id: 'quick-reblog' }, { click: event => event.stopPropagation() });
+const popupElement = dom('div', { id: 'quick-reblog', class: postPopoverClass }, { click: event => event.stopPropagation() });
 const blogSelector = dom('select');
 const blogAvatar = dom('div', { class: 'avatar' });
 const blogSelectorContainer = dom('div', { class: 'select-container' }, null, [blogAvatar, blogSelector]);

--- a/src/features/quick_tags/index.css
+++ b/src/features/quick_tags/index.css
@@ -21,13 +21,13 @@
   font-weight: normal;
 }
 
-#quick-tags-post-option.below {
+#quick-tags-post-option[data-position="below"] {
   top: 100%;
   right: 50%;
   transform: translate(50%, 12px);
 }
 
-#quick-tags-post-option.above {
+#quick-tags-post-option[data-position="above"] {
   bottom: 100%;
   right: 50%;
   transform: translate(50%, -12px);
@@ -42,11 +42,11 @@
   }
 }
 
-#quick-tags.below {
+#quick-tags[data-position="below"] {
   inset: 100% 50% auto auto;
   transform: translate(calc(50% + var(--horizontal-offset, 0%)), var(--icon-spacing));
 }
-#quick-tags.above {
+#quick-tags[data-position="above"] {
   inset: auto 50% 100% auto;
   transform: translate(calc(50% + var(--horizontal-offset, 0%)), calc(0px - var(--icon-spacing)));
 }

--- a/src/features/quick_tags/index.css
+++ b/src/features/quick_tags/index.css
@@ -1,7 +1,6 @@
 #quick-tags,
 #quick-tags-post-option {
   position: absolute;
-  z-index: 97;
 
   display: flex;
   flex-direction: column;

--- a/src/features/quick_tags/index.js
+++ b/src/features/quick_tags/index.js
@@ -6,6 +6,7 @@ import { modalCancelButton, modalCompleteButton, showErrorModal, showModal } fro
 import { onNewPosts, pageModifications } from '../../utils/mutations.js';
 import { notify } from '../../utils/notifications.js';
 import { registerPostOption, unregisterPostOption } from '../../utils/post_actions.js';
+import { postPopoverClass } from '../../utils/post_popovers.js';
 import { getPreferences } from '../../utils/preferences.js';
 import { timelineObject, editPostFormTags } from '../../utils/react_props.js';
 import { apiFetch, createEditRequestBody, isNpfCompatible } from '../../utils/tumblr_helpers.js';
@@ -21,7 +22,7 @@ let autoTagAsker;
 
 let controlButtonTemplate;
 
-const popupElement = dom('div', { id: 'quick-tags' });
+const popupElement = dom('div', { id: 'quick-tags', class: postPopoverClass });
 const popupInput = dom(
   'input',
   {

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -128,7 +128,7 @@ const getClosestWithOverflow = element => {
 };
 
 export const appendWithoutOverflow = (element, target, defaultPosition = 'below') => {
-  element.className = defaultPosition;
+  element.dataset.position = defaultPosition;
   element.style.removeProperty('--horizontal-offset');
 
   target.appendChild(element);
@@ -138,7 +138,7 @@ export const appendWithoutOverflow = (element, target, defaultPosition = 'below'
   const elementRect = element.getBoundingClientRect();
 
   if (elementRect.bottom > document.documentElement.clientHeight) {
-    element.className = 'above';
+    element.dataset.position = 'above';
   }
   if (elementRect.right > preventOverflowTargetRect.right - 15) {
     element.style.setProperty('--horizontal-offset', `${preventOverflowTargetRect.right - 15 - elementRect.right}px`);

--- a/src/utils/post_popovers.js
+++ b/src/utils/post_popovers.js
@@ -1,0 +1,18 @@
+import { buildStyle } from './interface.js';
+import { keyToCss } from './css_map.js';
+
+export const postPopoverClass = 'xkit-control-button-popover';
+
+document.documentElement.append(
+  buildStyle(`
+    .${postPopoverClass} {
+      z-index: 97;
+    }
+
+    footer${keyToCss('postFooter')}:has(.${postPopoverClass}) {
+      /* applies layering when stacking context is created here in older browsers; see https://github.com/AprilSylph/XKit-Rewritten/issues/1876 */
+      position: relative;
+      z-index: 97;
+    }
+  `)
+);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As described in the linked issue, the z-indexes on Quick Reblog and Quick Tags' popover elements do not apply on older browsers with Tumblr's new footer because the new footer uses container queries, which in older browsers created a stacking context, making the whole footer have (from the relevant perspective) the same z-index, i,e. not on top of the following post on the timeline.

This is one way of fixing this: we can apply the z-index to the footer. Does this cause some minor regressions? Yes:

<img width="739" alt="image" src="https://github.com/user-attachments/assets/6b1183ba-1c27-4725-b0a7-3560d0a0c236" />
 

Resolves #1876.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

todo

