### PR TITLE
fix(Quick Reblog, Quick Tags): Prevent popovers being covered by next post in older browsers (no container)

### DIFF
--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -83,6 +83,17 @@ ${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) {
 ${keyToCss('engagementAction', 'targetWrapperFlex')}:has(> #quick-reblog) ${keyToCss('tooltip')} {
   display: none;
 }
+
+footer${keyToCss('postFooter')} {
+  /**
+   * Prevents a stacking context being created here and breaking layering in older browsers.
+   * This unfortunately breaks Tumblr's breakpoint-specific styling (smaller text in footer buttons in masonry view in peepr).
+   *
+   * @see https://github.com/w3c/csswg-drafts/issues/10544
+   * @see https://github.com/AprilSylph/XKit-Rewritten/issues/1876
+   */
+  container-type: unset;
+}
 `);
 
 const onBlogSelectorChange = () => {

--- a/src/features/quick_tags/index.js
+++ b/src/features/quick_tags/index.js
@@ -1,6 +1,7 @@
 import { cloneControlButton, createControlButtonTemplate, insertControlButton } from '../../utils/control_buttons.js';
+import { keyToCss } from '../../utils/css_map.js';
 import { dom } from '../../utils/dom.js';
-import { appendWithoutOverflow, filterPostElements, getTimelineItemWrapper, postSelector } from '../../utils/interface.js';
+import { appendWithoutOverflow, buildStyle, filterPostElements, getTimelineItemWrapper, postSelector } from '../../utils/interface.js';
 import { megaEdit } from '../../utils/mega_editor.js';
 import { modalCancelButton, modalCompleteButton, showErrorModal, showModal } from '../../utils/modals.js';
 import { onNewPosts, pageModifications } from '../../utils/mutations.js';
@@ -20,6 +21,19 @@ let answerTag;
 let autoTagAsker;
 
 let controlButtonTemplate;
+
+export const styleElement = buildStyle(`
+footer${keyToCss('postFooter')} {
+  /**
+   * Prevents a stacking context being created here and breaking layering in older browsers.
+   * This unfortunately breaks Tumblr's breakpoint-specific styling (smaller text in footer buttons in masonry view in peepr).
+   *
+   * @see https://github.com/w3c/csswg-drafts/issues/10544
+   * @see https://github.com/AprilSylph/XKit-Rewritten/issues/1876
+   */
+  container-type: unset;
+}
+`);
 
 const popupElement = dom('div', { id: 'quick-tags' });
 const popupInput = dom(


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As described in the linked issue, the z-indexes on Quick Reblog and Quick Tags' popover elements do not apply on older browsers with Tumblr's new footer because the new footer uses container queries, which in older browsers created a stacking context, making the whole footer have (from the relevant perspective) the same z-index, i,e. not on top of the following post on the timeline.

This is one way of fixing this: we can delete the container. Does this cause some minor regressions? Yes: Tumblr uses container queries to make smaller text in footer buttons in masonry view in peepr.
 
Resolves #1876.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

todo