### PR TITLE
TimeFormat: Update relative timestamps in real time

### DIFF
--- a/src/features/timeformat/index.js
+++ b/src/features/timeformat/index.js
@@ -7,6 +7,8 @@ import { getPreferences } from '../../utils/preferences.js';
 let format;
 let displayRelative;
 
+let intervalId;
+
 export const styleElement = buildStyle(`
 [data-formatted-time] {
   font-size: 0px !important;
@@ -117,9 +119,15 @@ const formatTimeElements = function (timeElements) {
 export const main = async function () {
   ({ format, displayRelative } = await getPreferences('timeformat'));
   pageModifications.register(`${keyToCss('timestamp')}[datetime], ${keyToCss('timestamp')} > [datetime]`, formatTimeElements);
+
+  intervalId = setInterval(
+    () => displayRelative && document.visibilityState === 'visible' && pageModifications.trigger(formatTimeElements),
+    60 * 1000
+  );
 };
 
 export const clean = async function () {
+  clearInterval(intervalId);
   pageModifications.unregister(formatTimeElements);
   $('[data-formatted-time]').removeAttr('data-formatted-time');
   $('[data-formatted-relative-time]').removeAttr('data-formatted-relative-time');


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

I had such a neat idea to do this using `WeakRef`s. Then I realized that that was entirely unnecessary.

Anyway, this makes the relative timestamps added by TimeFormat, e.g. "12 minutes ago," update every minute.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable TimeFormat and its relative time option.
- Confirm that a post from less than one hour ago's relative timestamp updates to stay within a minute of the correct value.
