### PR TITLE
refactor: Popover position css

### DIFF
--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -30,11 +30,11 @@
   }
 }
 
-#quick-reblog.below {
+#quick-reblog[data-position="below"] {
   inset: 100% 50% auto auto;
   transform: translate(calc(50% + var(--horizontal-offset, 0%)), var(--icon-spacing));
 }
-#quick-reblog.above {
+#quick-reblog[data-position="above"] {
   inset: auto 50% 100% auto;
   transform: translate(calc(50% + var(--horizontal-offset, 0%)), calc(0px - var(--icon-spacing)));
 }

--- a/src/features/quick_tags/index.css
+++ b/src/features/quick_tags/index.css
@@ -21,13 +21,13 @@
   font-weight: normal;
 }
 
-#quick-tags-post-option.below {
+#quick-tags-post-option[data-position="below"] {
   top: 100%;
   right: 50%;
   transform: translate(50%, 12px);
 }
 
-#quick-tags-post-option.above {
+#quick-tags-post-option[data-position="above"] {
   bottom: 100%;
   right: 50%;
   transform: translate(50%, -12px);
@@ -42,11 +42,11 @@
   }
 }
 
-#quick-tags.below {
+#quick-tags[data-position="below"] {
   inset: 100% 50% auto auto;
   transform: translate(calc(50% + var(--horizontal-offset, 0%)), var(--icon-spacing));
 }
-#quick-tags.above {
+#quick-tags[data-position="above"] {
   inset: auto 50% 100% auto;
   transform: translate(calc(50% + var(--horizontal-offset, 0%)), calc(0px - var(--icon-spacing)));
 }

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -128,7 +128,7 @@ const getClosestWithOverflow = element => {
 };
 
 export const appendWithoutOverflow = (element, target, defaultPosition = 'below') => {
-  element.className = defaultPosition;
+  element.dataset.position = defaultPosition;
   element.style.removeProperty('--horizontal-offset');
 
   target.appendChild(element);
@@ -138,7 +138,7 @@ export const appendWithoutOverflow = (element, target, defaultPosition = 'below'
   const elementRect = element.getBoundingClientRect();
 
   if (elementRect.bottom > document.documentElement.clientHeight) {
-    element.className = 'above';
+    element.dataset.position = 'above';
   }
   if (elementRect.right > preventOverflowTargetRect.right - 15) {
     element.style.setProperty('--horizontal-offset', `${preventOverflowTargetRect.right - 15 - elementRect.right}px`);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This changes the below/above position flag used for the quick reblog/quick tags popups from a class to a data attribute, which is semantically easier to toggle without interfering with any other classes on the element, and should cause no observable behavior change.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that Quick Reblog and Quick Tags' popups still change positions when they would otherwise go off the top/bottom of the viewport.

