### PR TITLE
Quick Tags; Quick Reblog: Prevent popovers overflowing off top of screen

### DIFF
--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -127,17 +127,22 @@ const getClosestWithOverflow = element => {
   }
 };
 
+const isVerticallyOverflowing = element => {
+  const elementRect = element.getBoundingClientRect();
+  return elementRect.bottom > document.documentElement.clientHeight || elementRect.top < 0;
+};
+
 export const appendWithoutOverflow = (element, target, defaultPosition = 'below') => {
   element.dataset.position = defaultPosition;
   element.style.removeProperty('--horizontal-offset');
 
   target.appendChild(element);
 
-  if (element.dataset.position === 'below' && element.getBoundingClientRect().bottom > document.documentElement.clientHeight) {
-    element.dataset.position = 'above';
+  if (isVerticallyOverflowing(element)) {
+    element.dataset.position = defaultPosition === 'below' ? 'above' : 'below';
   }
-  if (element.dataset.position === 'above' && element.getBoundingClientRect().top < 0) {
-    element.dataset.position = 'below';
+  if (isVerticallyOverflowing(element)) {
+    element.dataset.position = defaultPosition;
   }
 
   const preventOverflowTarget = getClosestWithOverflow(target);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

We currently move the Quick Reblog/Quick Tags popovers to the "above" position if they would go below the bottom of the screen. This also does the reverse, moving them to the "below" position if they would go above the top of the screen.

If both positions would exit the screen, this uses the default position.

Resolves #1836.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Confirm that the Quick Reblog and Quick Tags popovers change positions to avoid both the top and bottom edges of the screen.
- Confirm that the Quick Reblog and Quick Tags popovers use the correct default positions when neither position would hit either the top or bottom edge of the screen.
