### PR TITLE
chore: remove tip button references

### DIFF
--- a/src/features/tweaks/feature.json
+++ b/src/features/tweaks/feature.json
@@ -70,7 +70,7 @@
     },
     "hide_blaze_tip_labels": {
       "type": "checkbox",
-      "label": "Hide the \"blaze\" and \"tip\" button labels",
+      "label": "Hide blaze button labels",
       "default": false
     },
     "hide_filtered_posts": {

--- a/src/features/tweaks/hide_blaze_tip_labels.js
+++ b/src/features/tweaks/hide_blaze_tip_labels.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle } from '../../utils/interface.js';
 
 export const styleElement = buildStyle(`
-article ${keyToCss('igniteButton', 'tippingButton')} > svg:not([style*="#ff8a00"]) ~ ${keyToCss('label')} {
+article ${keyToCss('igniteButton')} > svg:not([style*="#ff8a00"]) ~ ${keyToCss('label')} {
   display: none;
 }
 `);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This removes a reference in Tweaks to the tip button, which was removed [last year](https://www.tumblr.com/changes/749295377342251008/tipping-is-going-away-on-june-1-2024).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that the blaze button hiding tweak still functions.