### PR TITLE
feat: add new element creation utils

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -5,8 +5,8 @@
 /**
  * Create elements with simple syntax
  * @param {string} tagName - Type of element to create
- * @param {Record<string, string>} [attributes] - Property-value pairs to set as HTML/XML attributes (e.g. { href: '/' })
- * @param {Record<string, () => void>} [events] - Property-value pairs to set as event listeners (e.g. { click: () => {} })
+ * @param {Attributes} [attributes] - Property-value pairs to set as HTML/XML attributes (e.g. { href: '/' })
+ * @param {Events} [events] - Property-value pairs to set as event listeners (e.g. { click: () => {} })
  * @param {Children} [children] - Zero or more valid children
  * @returns {Element} Element created to specification
  */


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Adds 1) a new version of `dom()` which only requires two arguments, and 2) a dozen shorthand functions for creating every type of element we create via `dom()` across the codebase.

The first thing I've been thinking of doing for a long time now, but only started on yesterday while looking at #1803; the per-element shorthands I've been thinking about since we merged #1831.

This PR doesn't implement any usages of these functions. That will be a followup chore.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Just CI passing and code review suffices. Opinions matter here, since these will be used fairly widely—I would like to remove `dom()` entirely in favour of these new shorthands.
