### PR TITLE
Add control button hover effect

### DIFF
--- a/src/content_scripts/control_buttons.css
+++ b/src/content_scripts/control_buttons.css
@@ -61,6 +61,10 @@
   }
 }
 
+.xkit-control-button-container.in-new-footer .xkit-control-button:not([disabled]):hover {
+  background-color: rgba(var(--black), 0.07);
+}
+
 
 .xkit-control-button-container:is(.in-new-footer, .in-community) {
   margin-left: 0;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Because Tumblr's edit/delete buttons have hover effects, this tries out adding them to our buttons, too, to look more consistent.

At the moment I think this looks... bad.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

todo

