### PR TITLE
chore: Update control button colors to match new footer buttons

### DIFF
--- a/src/content_scripts/control_buttons.css
+++ b/src/content_scripts/control_buttons.css
@@ -26,6 +26,10 @@
   width: 24px;
   height: 24px;
 
+  fill: var(--content-fg-secondary);
+}
+
+.xkit-control-button-container.in-legacy-footer .xkit-control-button-inner svg {
   fill: rgba(var(--black), 0.65);
 }
 
@@ -34,6 +38,11 @@
 }
 
 .xkit-control-button:disabled svg {
+  opacity: 0.5;
+}
+
+.xkit-control-button-container.in-legacy-footer .xkit-control-button:disabled svg {
+  opacity: unset;
   fill: rgba(var(--black), 0.4);
 }
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

The new footer buttons are a slightly different color than the old ones. This updates our control buttons to match.

I left the old color in ~~in case someone doesn't have the new footer flag for some reason or manages to access the old footer, but this is of course pretty unnecessary since they're similar.~~ so that draft/queue posts still have matching button colors.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that Quick Tags/Trim Reblogs button colors match the Tumblr button colors on regular published posts.
- Confirm that Quick Tags/Trim Reblogs disabled button colors match the disabled Tumblr button colors on regular published posts.
- Confirm that Quick Tags/Trim Reblogs button colors match the Tumblr button colors on posts in the queue.
- Confirm that Quick Tags/Trim Reblogs button colors match the Tumblr button colors on posts in the drafts folder.
- If desired, confirm that Quick Tags/Trim Reblogs button colors match the Tumblr button colors on posts in communities with #1803.