### PR TITLE
fix(Tweaks): Footer tooltip tweak not applying to edit/delete buttons

### DIFF
--- a/src/features/tweaks/hide_footer_tooltips.js
+++ b/src/features/tweaks/hide_footer_tooltips.js
@@ -2,7 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle } from '../../utils/interface.js';
 
 export const styleElement = buildStyle(`
-article footer ${keyToCss('footerRow', 'footerContent')} :is(${keyToCss('tooltip')}, ${keyToCss('tooltip')} ~ *) {
+article footer ${keyToCss('footerRow', 'footerContent', 'postOwnerControls')} :is(${keyToCss('tooltip')}, ${keyToCss('tooltip')} ~ *) {
   display: none;
 }
 `);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

See title.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that the "hide control button tooltips in the post footer" tweak affects the new post footer edit and delete buttons.
