### PR TITLE
 fix(Themed Posts): Adjust identical background/foreground colors

### DIFF
--- a/src/features/themed_posts/index.js
+++ b/src/features/themed_posts/index.js
@@ -58,15 +58,11 @@ const processPosts = async function (postElements) {
       if (!blogs.has(name)) {
         blogs.add(name);
 
-        // const {
-        //   backgroundColor,
-        //   titleColor,
-        //   linkColor
-        // } = theme;
-
-        const backgroundColor = theme.backgroundColor;
-        const titleColor = theme.backgroundColor;
-        const linkColor = theme.backgroundColor;
+        const {
+          backgroundColor,
+          titleColor,
+          linkColor
+        } = theme;
 
         const backgroundColorRGB = hexToRGB(backgroundColor);
         const titleColorRGB = titleColor === backgroundColor ? createContrastingColor(titleColor) : hexToRGB(titleColor);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This makes the text/accent colors used by Themed Posts a bit lighter or darker if they exactly match the background color (typically if a user doesn't have a blog description and thus has no reason to select a text color). This is a rare case, but one that makes Themed Posts quite problematic.

I put a lot of work (#1735) into using advanced color CSS for this, but it's pretty messy and prone to browser version bugs. This is what happens if you instead say, eh, doing arithmetic on rgb values is more than good enough.

Colors are lightened if they are dark and darkened if they're light, using a semi-arbitrary (color theory wise, incorrect, I believe) threshold of "do the rgb values average to 128" and an arbitrary reasonable-looking adjustment of "add/subtract 100."

Resolves #1636.

Closes #1735.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Make a blog with a black-on-black theme or view https://www.tumblr.com/transienttest (if I haven't done something else with it at the time).
- Enable Themed Posts and confirm that post text and UI elements are readable.
- Un-revert the test commit, which will make all blogs everywhere behave like they have title and link colors identical to the background color. Sample a selection of blogs with different background colors and confirm that post text and UI elements are readable.
