### PR TITLE
feat(Classic Footer): Allow userstyles to customize note count

### DIFF
--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -84,7 +84,8 @@ const processPosts = (postElements) => filterPostElements(postElements).forEach(
 
   const { noteCount } = await timelineObject(postElement);
   const noteCountButton = dom('button', { class: noteCountClass }, { click: onNoteCountClick }, [
-    `${noteCountFormat.format(noteCount)} ${noteCount === 1 ? 'note' : 'notes'}`
+    dom('span', null, null, [noteCountFormat.format(noteCount)]),
+    ` ${noteCount === 1 ? 'note' : 'notes'}`
   ]);
 
   const engagementControls = postElement.querySelector(engagementControlsSelector);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adjusts the DOM structure of the Classic Footer note count element slightly so that user styles can adjust the number and word(s) separately.

Maybe they should both be separate spans so either can be hidden easily? (Replacing the word(s) with an `:after`, for example, is annoying this way.) In the extreme case, the number could be a css var and be displayed as `:before { content: var(--count) }` or something, but like, eh.

**edit:** Requested in https://github.com/AprilSylph/XKit-Rewritten/issues/1901#issuecomment-3392296634!

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that the Classic Footer note count element appears as expected.

