### PR TITLE
chore: Run CI on PRs targeting any branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ on:
       - package*.json
       - .eslintrc.json
   pull_request:
-    branches:
-      - master
 
 jobs:
   test:


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Right now, the CI workflow only runs on PRs targeting the master branch. That I can think of, we probably want it to run on any PR targeting any branch.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

n/a