### PR TITLE
fix: Allow number attribute values in new dom util

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -36,7 +36,7 @@ export function element (tagName, properties = {}, children = []) {
     ? document.createElementNS(properties.xmlns, tagName)
     : document.createElement(tagName);
 
-  const attributes = Object.entries(properties).filter(([key, value]) => typeof value === 'string');
+  const attributes = Object.entries(properties).filter(([key, value]) => typeof value !== 'function');
   const events = Object.entries(properties).filter(([key, value]) => typeof value === 'function');
 
   element.replaceChildren(...children);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This tweaks the new dom utils so they can take numerical attribute values.

Of course, attribute values are actually implicitly typecast to strings at some point in this process; html attributes can't be numbers. It feels kind of silly to have to explicit string cast the value for a range element (#698), though.

Naturally, we could specifically check for only strings and numbers here. This would mean that accidentally setting an attribute to any object value during development would cause it to be silently ignored. My guess is that allowing them (resulting in their toString values being set as the attribute) makes this easier to debug if this case occurs, though I bet it's pretty unlikely this happens and makes a difference.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

n/a