### PR TITLE
chore: Add additional shorthand dom helpers

### DIFF
--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -50,10 +50,10 @@ export function element (tagName, properties = {}, children = []) {
 }
 
 /** @typedef {(props?: Properties, children?: Children) => HTMLElement} HTMLShorthand */
+/** @typedef {(props?: Properties) => HTMLElement} VoidHTMLShorthand */
 /** @typedef {(props?: Properties, children?: Children) => SVGElement} SVGShorthand */
 
 /** @type {HTMLShorthand} */ export const a = (props = {}, children = []) => element('a', props, children);
-/** @type {HTMLShorthand} */ export const br = (props = {}, children = []) => element('br', props, children);
 /** @type {HTMLShorthand} */ export const button = (props = {}, children = []) => element('button', props, children);
 /** @type {HTMLShorthand} */ export const canvas = (props = {}, children = []) => element('canvas', props, children);
 /** @type {HTMLShorthand} */ export const datalist = (props = {}, children = []) => element('datalist', props, children);
@@ -63,9 +63,6 @@ export function element (tagName, properties = {}, children = []) {
 /** @type {HTMLShorthand} */ export const form = (props = {}, children = []) => element('form', props, children);
 /** @type {HTMLShorthand} */ export const h1 = (props = {}, children = []) => element('h1', props, children);
 /** @type {HTMLShorthand} */ export const h3 = (props = {}, children = []) => element('h3', props, children);
-/** @type {HTMLShorthand} */ export const hr = (props = {}, children = []) => element('hr', props, children);
-/** @type {HTMLShorthand} */ export const img = (props = {}, children = []) => element('img', props, children);
-/** @type {HTMLShorthand} */ export const input = (props = {}, children = []) => element('input', props, children);
 /** @type {HTMLShorthand} */ export const label = (props = {}, children = []) => element('label', props, children);
 /** @type {HTMLShorthand} */ export const li = (props = {}, children = []) => element('li', props, children);
 /** @type {HTMLShorthand} */ export const option = (props = {}, children = []) => element('option', props, children);
@@ -80,6 +77,11 @@ export function element (tagName, properties = {}, children = []) {
 /** @type {HTMLShorthand} */ export const th = (props = {}, children = []) => element('th', props, children);
 /** @type {HTMLShorthand} */ export const tr = (props = {}, children = []) => element('tr', props, children);
 /** @type {HTMLShorthand} */ export const ul = (props = {}, children = []) => element('ul', props, children);
+
+/** @type {VoidHTMLShorthand} */ export const br = (props = {}) => element('br', props);
+/** @type {VoidHTMLShorthand} */ export const hr = (props = {}) => element('hr', props);
+/** @type {VoidHTMLShorthand} */ export const img = (props = {}) => element('img', props);
+/** @type {VoidHTMLShorthand} */ export const input = (props = {}) => element('input', props);
 
 /** @type {SVGShorthand} */ export const path = (props = {}, children = []) => element('path', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);
 /** @type {SVGShorthand} */ export const svg = (props = {}, children = []) => element('svg', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds `br`, `canvas`, and `figcaption` dom helpers, which we either could use in the current codebase or might use in PRs.

It also removes the children prop in helpers for element types that can't have any children.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

n/a, review only

