### PR TITLE
fix(Collapsed Queue): Infinite loop that freezes page

### DIFF
--- a/src/features/collapsed_queue/index.js
+++ b/src/features/collapsed_queue/index.js
@@ -21,9 +21,9 @@ const processPosts = async function (postElements) {
     const container = Object.assign(document.createElement('div'), { className: containerClass });
     wrapper.append(container);
 
-    headerElement.after(wrapper);
-    while (wrapper.nextElementSibling && wrapper.nextElementSibling !== footerElement) {
-      container.append(wrapper.nextElementSibling);
+    footerElement.before(wrapper);
+    while (wrapper.previousElementSibling && wrapper.previousElementSibling !== headerElement) {
+      container.prepend(wrapper.previousElementSibling);
     }
   });
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Yikes.

This updates Collapsed Queue for the extra `div` that was added to the post DOM structure a few days ago. I thought I had tested this, but I misremembered; I tested Collapsed Queue with the new split-notes footer, but not the extra `div`.

Resolves #1933.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that Collapsed Queue works on both the draft and queue pages.

