### PR TITLE
fix(Classic Footer): hide CSS from Firefox context menus

### DIFF
--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -1,5 +1,5 @@
 import { keyToCss } from '../../utils/css_map.js';
-import { a, button, span } from '../../utils/dom.js';
+import { a, button, span, link } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
 import { pageModifications } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
@@ -183,13 +183,15 @@ const processReblogButtons = (reblogButtons) => reblogButtons.forEach(async rebl
 
   if (!canReblog) return;
 
+  const styleContent = `${reblogMenuPortalSelector}:has([aria-labelledby="${reblogButton.id}"]) { display: none; }`;
+
   const reblogLink = a({
     'aria-label': reblogButton.getAttribute('aria-label'),
     class: reblogLinkClass,
     click: onReblogLinkClick,
     href: `/reblog/${blogName}/${idString}/${reblogKey}`
   }, [
-    buildStyle(`${reblogMenuPortalSelector}:has([aria-labelledby="${reblogButton.id}"]) { display: none; }`),
+    link({ rel: 'stylesheet', class: 'xkit', href: `data:text/css,${encodeURIComponent(styleContent)}` }),
     reblogButton.firstElementChild.cloneNode(true)]
   );
 

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -82,6 +82,7 @@ export function element (tagName, properties = {}, children = []) {
 /** @type {VoidHTMLShorthand} */ export const hr = (props = {}) => element('hr', props);
 /** @type {VoidHTMLShorthand} */ export const img = (props = {}) => element('img', props);
 /** @type {VoidHTMLShorthand} */ export const input = (props = {}) => element('input', props);
+/** @type {VoidHTMLShorthand} */ export const link = (props = {}) => element('link', props);
 
 /** @type {SVGShorthand} */ export const path = (props = {}, children = []) => element('path', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);
 /** @type {SVGShorthand} */ export const svg = (props = {}, children = []) => element('svg', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to https://github.com/AprilSylph/XKit-Rewritten/pull/1931#issuecomment-3440323018

  > Interesting oddity: things like right clicking a link in Firefox and selecting the option to search the web for the text contents or dragging a link in safari and observing the tooltip will use the contents of the contained style element as the link text. This is probably minor enough to make it not worth bothering moving the style element one level up and making cleanup more annoying, but we could.

Alternate solution: use a `<link rel="stylesheet">` with a `data:` URI.

`link` elements are void, so rightfully ignored by Firefox's context menu.

This reduces the searchable text of the anchor element down to... the linked URL itself.

(I can't believe Chrome doesn't throw a fit about CSP for this???)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
#### Fix testing – Firefox
1. Load the modified addon in Firefox
2. Open a new Tumblr tab
3. Open a post's reblog menu
4. Enable Classic Footer
5. Right-click a reblog link
    - **Expected result**: The "Search for" text contains none of our menu-hiding CSS

#### Fix testing – Safari
1. Load the modified addon in Firefox
2. Open a new Tumblr tab
3. Open a post's reblog menu
4. Enable Classic Footer
5. Drag-click a reblog link
    - **Expected result**: The tooltip text contains none of our menu-hiding CSS

#### Regression testing – Chrome
1. Load the modified addon in Chrome
2. Open a new Tumblr tab
3. Open a post's reblog menu
4. Enable Classic Footer
    - **Expected result**: The reblog menu is hidden
5. Disable the "Turn reblog buttons back into links" option
    - **Expected result**: The reblog menu is unhidden