### PR TITLE
refactor: Remove strict null check of react fibers

### DIFF
--- a/src/main_world/control_tags_input.js
+++ b/src/main_world/control_tags_input.js
@@ -7,7 +7,7 @@ export default function controlTagsInput ({ add, remove }) {
   const reactKey = Object.keys(selectedTagsElement).find(key => key.startsWith('__reactFiber'));
   let fiber = selectedTagsElement[reactKey];
 
-  while (fiber !== null) {
+  while (fiber) {
     let tags = fiber.stateNode?.state?.tags;
     if (Array.isArray(tags)) {
       tags.push(...add.filter(tag => tags.includes(tag) === false));

--- a/src/main_world/get_notification_props.js
+++ b/src/main_world/get_notification_props.js
@@ -3,7 +3,7 @@ export default function getNotificationProps () {
   const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
   let fiber = notificationElement[reactKey];
 
-  while (fiber !== null) {
+  while (fiber) {
     const props = fiber.memoizedProps || {};
     if (props?.notification !== undefined) {
       return props.notification;

--- a/src/main_world/get_tumblelogname_prop.js
+++ b/src/main_world/get_tumblelogname_prop.js
@@ -3,7 +3,7 @@ export default function getTumblelogNameProp () {
   const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
   let fiber = notificationElement[reactKey];
 
-  while (fiber !== null) {
+  while (fiber) {
     const props = fiber.memoizedProps || {};
     if (props?.tumblelogName !== undefined) {
       return props.tumblelogName;

--- a/src/main_world/test_header_element.js
+++ b/src/main_world/test_header_element.js
@@ -3,7 +3,7 @@ export default function testHeaderElement (selector) {
   const reactKey = Object.keys(menuElement).find(key => key.startsWith('__reactFiber'));
   let fiber = menuElement[reactKey];
 
-  while (fiber !== null) {
+  while (fiber) {
     if (fiber.elementType === 'header') {
       return fiber.stateNode.matches(selector);
     } else {

--- a/src/main_world/unbury_blog.js
+++ b/src/main_world/unbury_blog.js
@@ -3,7 +3,7 @@ export default function unburyBlog () {
   const reactKey = Object.keys(element).find(key => key.startsWith('__reactFiber'));
   let fiber = element[reactKey];
 
-  while (fiber !== null) {
+  while (fiber) {
     const { blog, blogSettings } = fiber.memoizedProps || {};
     if (blog ?? blogSettings) {
       return blog ?? blogSettings;

--- a/src/main_world/unbury_notification.js
+++ b/src/main_world/unbury_notification.js
@@ -3,7 +3,7 @@ export default function unburyNotification () {
   const reactKey = Object.keys(notificationElement).find(key => key.startsWith('__reactFiber'));
   let fiber = notificationElement[reactKey];
 
-  while (fiber !== null) {
+  while (fiber) {
     const { notification } = fiber.memoizedProps || {};
     if (notification !== undefined) {
       return notification;

--- a/src/main_world/unbury_timeline_object.js
+++ b/src/main_world/unbury_timeline_object.js
@@ -3,7 +3,7 @@ export default function unburyTimelineObject () {
   const reactKey = Object.keys(postElement).find(key => key.startsWith('__reactFiber'));
   let fiber = postElement[reactKey];
 
-  while (fiber !== null) {
+  while (fiber) {
     const { timelineObject } = fiber.memoizedProps || {};
     if (timelineObject !== undefined) {
       return timelineObject;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As described in the linked issue, this expands the fiber prop values that will end the while loops in our injected functions that read react internals to include undefined, providing a stronger guarantee that the loops will end properly if our assumptions about react internals no longer hold.

This notably does precisely nothing, as we immediately read `fiber.something` on the next line, which will throw if `fiber` is not truthy. There will thus be no infinite loop in the case where react changes the default value of fiber.return.

In fact, `TypeError: can't access property "memoizedProps", fiber is undefined` is more informative than this promise just not resolving; this brings up the fact that we should probably manually throw something informative after these while loops.

Resolves #1906.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Smoke test.

