### PR TITLE
fix: Incorrect safari <26 detection in popover stacking util

### DIFF
--- a/src/utils/post_popovers.js
+++ b/src/utils/post_popovers.js
@@ -3,6 +3,9 @@ import { postSelector } from './interface.js';
 
 /**
  * Detects Chromium <130, Firefox <140, Safari <26, or another old or non-compliant browser.
+ * @see https://caniuse.com/css-text-wrap-balance
+ * @see https://caniuse.com/cookie-store-api
+ * @see https://caniuse.com/mdn-api_audiodecoder
  */
 const browserIsOld =
   CSS.supports('text-wrap-style', 'balance') === false ||


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes a minor mistake I made in `browserIsOld` calculation that causes the popover stacking fix we made to be applied to Safari 26 when it doesn't need to be. 

Specifically, I interpreted https://caniuse.com/webcodecs having "video-only support" listed for Safari ≤18.6, but full support listed for 26, as meaning that version 26 would have `ImageDecoder`, and at the time I didn't have a Safari 26 installation to test. https://caniuse.com/mdn-api_imagedecoder and https://caniuse.com/mdn-api_imagedecoder show that the feature that was in fact added, and thus the correct query, is `typeof AudioDecoder`; Safari still doesn't have `ImageDecoder` (doesn't really seem like "full support" to me, but I digress). I checked Safari 18.5 and 26 to confirm (yay, VMs) (boo, web development on Safari is fucking impossible).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

I confirmed that the `container-type: unset` post footer stacking context fix is still applied in Firefox 128 and isn't applied in Firefox 144.

