### PR TITLE
fix(Tweaks): Consistently hide "See all" tags button when showing all tags

### DIFF
--- a/src/features/tweaks/show_all_tags.js
+++ b/src/features/tweaks/show_all_tags.js
@@ -5,7 +5,7 @@ export const styleElement = buildStyle(`
 ${keyToCss('tags')}${keyToCss('collapsed')} {
   max-height: none !important;
 }
-${keyToCss('seeAll')} {
+${keyToCss('seeAll', 'seeAllWrapper')} {
   display: none;
 }
 `);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This ensures that the "Show every line of tags by default" tweak will continue to hide the "See all..." button when it's active and said button does not function no matter what variant of the element in question a user's account has.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

On an account where the tweak was not functioning properly/using hacks to simulate this, find a post with multiple lines of tags (with the "show every line of tags by default" tweak disabled). Enable the tweak and confirm that the "See all..." button disappears.
