### PR TITLE
fix(Tweaks): Remove "(99+)" count from page title

### DIFF
--- a/src/features/tweaks/hide_following_notification_badge.js
+++ b/src/features/tweaks/hide_following_notification_badge.js
@@ -19,7 +19,7 @@ const onTitleChanged = () => {
   const titleElement = document.querySelector('head title:not([data-xkit])');
 
   const rawTitle = titleElement.textContent;
-  const newTitle = rawTitle.replace(/^\(\d{1,2}\) /, '');
+  const newTitle = rawTitle.replace(/^\(\d{1,2}\+?\) /, '');
   customTitleElement.textContent = newTitle;
 
   observer.observe(titleElement, { characterData: true, subtree: true });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As discussed in https://github.com/AprilSylph/XKit-Rewritten/pull/1584#discussion_r2489601542, the "Hide the Home/Following unread count" tweak removes the unread count from the page title, but the regular expression used does not match if there are 100 or more (99 or more? whatever) unread posts. This fixes this.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Conveniently, I had 99+ unread posts at time of writing, so I confirmed that toggling the tweak in question on and off removes/re-adds the "(99+) unread count in the page title.
