### PR TITLE
refactor(Classic Footer): Combine noReblogMenu link addition with main code

### DIFF
--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -140,7 +140,7 @@ const processPosts = (postElements) => postElements.forEach(async postElement =>
   engagementControls?.before(noteCountButton);
 
   if (noReblogMenu) {
-    processReblogButton(engagementControls.querySelector(reblogButtonSelector));
+    processReblogButton(engagementControls?.querySelector(reblogButtonSelector));
   }
 });
 


### PR DESCRIPTION
It's a surprise tool that can help us later.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Rather than registering a separate pageModifications function to implement the "Turn reblog buttons back into links" option in Classic Footer, this does the necessary changes in the same function. This will be useful if we have to modify the Classic Footer lifecycle for future compatibility.

Preference changes are implemented by triggering the same function again, with cleanup added to the function.

Also resolves #1944 (I think? I copied the `onStorageChanged` code from Vanilla Video).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Expect no functional changes. _todo: write this section._
