### PR TITLE
chore(Quick Tags): Improve footer targeting

### DIFF
--- a/src/features/quick_tags/index.js
+++ b/src/features/quick_tags/index.js
@@ -175,7 +175,7 @@ const addFakeTagsToFooter = (postElement, tags) => {
   );
   const tagsElement = dom('div', { class: tagsClass }, null, [dom('div', null, null, fakeTags)]);
 
-  postElement.querySelector('footer').parentNode.prepend(tagsElement);
+  [...postElement.querySelectorAll('footer')].at(-1)?.parentNode.prepend(tagsElement);
 };
 
 const processFormSubmit = function ({ currentTarget }) {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This tweaks Quick Tags' fake tags insertion to ensure that it can't target the wrong footer element.

Related: #1969

Obsoleted by merging https://github.com/AprilSylph/XKit-Rewritten/compare/master...marcustyphoon/quick-tags-really-refresh, which I didn't make a PR for, but could; would we rather do this?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that Quick Tags functions normally on posts with and without tags.
