### PR TITLE
 feat(AccessKit Disable GIFs): Pause gifs in direct messages; animated sidebar ad

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -48,6 +48,8 @@ export const styleElement = buildStyle(`
 .${canvasClass} {
   position: absolute;
   visibility: visible;
+  top: 0;
+  left: 0;
 
   background-color: rgb(var(--white));
 }
@@ -55,7 +57,7 @@ export const styleElement = buildStyle(`
 .${canvasClass}${parentHovered},
 [${labelAttribute}]${hovered}::after,
 [${pausedPosterAttribute}]:not(${hovered}) > div > ${keyToCss('knightRiderLoader')} {
-  display: none;
+  display: none !important;
 }
 ${keyToCss('background')}[${labelAttribute}]::after {
   /* prevent double labels in recommended post cards */
@@ -203,10 +205,13 @@ export const main = async function () {
       },
       ${keyToCss(
         'linkCard', // post link element
+        'messageImage', // direct message attached image
+        'messagePost', // direct message linked post
         'typeaheadRow', // modal search dropdown entry
         'tagImage', // search page sidebar related tags, recommended tag carousel entry: https://www.tumblr.com/search/gif, https://www.tumblr.com/explore/recommended-for-you
         'topPost', // activity page top post
-        'takeoverBanner' // advertisement
+        'takeoverBanner', // advertisement
+        'mrecContainer' // advertisement
       )}
     ) img:is([srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]):not(${keyToCss('poster')})
   `;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This enables AccessKit Disable GIFs in three more places: GIFs sent in direct messages, GIFs that are part of post link cards sent in direct messages, and the house ad for Tumblr Premium that Tumblr puts in the sidebar when it can't show a different ad (seemingly primarily based on currently visible post content).

Seems like all that was needed to un-break these was setting the canvas element top and left css properties to 0 (in posts, they copy a class off the paused image that does this). I don't think this should have any negative consequences, though let me know if you can think of one.

To my knowledge this will not affect third-party sidebar ads because they're in iframes. (In a perfect world it would be neat to also pause those, but I probably wouldn't attempt it even if I could, as the code for those could be anything, so who knows how our modifications could interact with them.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable AccessKit Disable GIFs and confirm that GIFs sent in direct messages, GIFs that are part of post link cards sent in direct messages, and the animated sidebar house ad for Tumblr Premium (scroll a blog or community and it should pop up reasonably quickly) are paused, have labels, and unpause on hover.
- Comment the `if (posterElement) {` block, simulating all gifs being webps, and confirm that everything else referenced in the feature's `gifImage` selector code comments still functions. I mean, don't do this, probably, but I did. (Twice, because I forgot I had to comment that block in order to actually test the canvas element css. Good times.)

