### PR TITLE
chore(Panorama): Increase some CSS specificity for future compatibility

### DIFF
--- a/src/features/panorama/index.js
+++ b/src/features/panorama/index.js
@@ -74,7 +74,7 @@ ${keyToCss('cell')}, ${postSelector}
     article > header,
     article ${keyToCss('reblog')}
   ) {
-  max-width: unset;
+  max-width: unset !important;
 }
 
 /* Center non-expanded content */
@@ -107,7 +107,7 @@ ${keyToCss('cell')}, ${postSelector}
 /* Fix ad containers */
 ${keyToCss('adTimelineObject', 'instreamAd', 'nativeIponWebAd', 'takeoverBanner')},
 ${keyToCss('adTimelineObject', 'instreamAd', 'nativeIponWebAd', 'takeoverBanner')} header {
-  max-width: unset;
+  max-width: unset !important;
 }
 [data-is-resizable="true"][style="width: 540px;"],
 ${keyToCss('takeoverBanner')} {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This increases the specificity of a few of the Panorama selectors using !important so it's resilient against future Tumblr changes that could use an extra feature-flag-specific class.

There are lots of ways to do this (put one of the keyToCss selectors twice, `[class]`, `:not(.invalid-selector-for-specificity)`, etc). Not sure which is best. We could extract a variable `const extraSpecificity = 'whatever'` which I have done on some other dev branches; I feel like a short variable name would be more elegant there but I don't have one.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Perform the tests from #1291. (I didn't do endless-scrolling-off or patio, but like, close enough, right)

