### PR TITLE
fix(Quick Reblog): apply AlreadyReblogged colour to whole button

### DIFF
--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -187,16 +187,20 @@
 
 /* === AlreadyReblogged === */
 
-footer.published :is(button:not([role]), a[href^="/reblog/"]) use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--green)); }
-footer.queue :is(button:not([role]), a[href^="/reblog/"]) use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--purple)); }
-footer.draft :is(button:not([role]), a[href^="/reblog/"]) use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]) { --icon-color-primary: rgb(var(--red)); }
+footer.published :is(a, button):has(svg use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"])) { color: rgb(var(--green)); }
+footer.queue :is(a, button):has(svg use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"])) { color: rgb(var(--purple)); }
+footer.draft :is(a, button):has(svg use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"])) { color: rgb(var(--red)); }
 
-footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"])) {
-  position: relative;
+footer:is(.published, .queue, .draft) :is(a, button) svg use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"]) {
+  --icon-color-primary: currentColor; /* Ensure that colouration is applied to icon */
+}
+
+footer:is(.published, .queue, .draft) :is(a, button):has(svg use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"])) {
+  position: relative; /* For absolute positioning of tick pseudo-element */
 }
 
 /* Cut-out for tick in 2025 post footer */
-footer:is(.published, .queue, .draft) :is(a[href^="/reblog/"], button) svg:has(use[href="#managed-icon__ds-reblog-24"]) {
+footer:is(.published, .queue, .draft) :is(a, button) svg:has(use[href="#managed-icon__ds-reblog-24"]) {
   -webkit-mask-image: radial-gradient(
     calc(14.7px / 2) calc(18px / 2) at bottom 4px left 21px,
     transparent 99%,
@@ -210,7 +214,7 @@ footer:is(.published, .queue, .draft) :is(a[href^="/reblog/"], button) svg:has(u
 }
 
 /* Styles for tick pseudo-element */
-footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after {
+footer:is(.published, .queue, .draft) :is(a, button):has(use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"]))::after {
   position: absolute;
 
   display: inline-block;
@@ -226,21 +230,17 @@ footer:is(.published, .queue, .draft) :is(button:not([role]), a[href^="/reblog/"
 }
 
 /* Pre-2025 post footer */
-footer:is(.published, .queue, .draft) a[href^="/reblog/"]:has(use[href="#managed-icon__reblog"])::after {
+footer:is(.published, .queue, .draft) a:has(use[href="#managed-icon__reblog"])::after {
   background-color: var(--content-panel);
   bottom: -5px;
   right: -5px;
 }
 
 /* 2025 post footer */
-footer:is(.published, .queue, .draft) :is(a[href^="/reblog/"], button):has(use[href="#managed-icon__ds-reblog-24"])::after {
+footer:is(.published, .queue, .draft) :is(a, button):has(use[href="#managed-icon__ds-reblog-24"])::after {
   bottom: 4px;
   left: 21px;
 }
-
-footer.published :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after { color: rgb(var(--green)); }
-footer.queue :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after { color: rgb(var(--purple)); }
-footer.draft :is(button:not([role]), a[href^="/reblog/"]):has(use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__reblog"]))::after { color: rgb(var(--red)); }
 
 /* === XKit 7 override === */
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- fixes #1923

Before | After
-|-
<img width="750" height="1334" alt="Screen Shot 2025-11-10 at 16 46 01" src="https://github.com/user-attachments/assets/006f6886-7ef7-4fbc-971a-d3ae74ee91d9" /> | <img width="750" height="1334" alt="Screen Shot 2025-11-10 at 16 46 17" src="https://github.com/user-attachments/assets/25fab806-112c-48a3-aabf-a151c2909491" />

This PR is also a refactor of the AlreadyReblogged CSS:
- Targeting of reblog buttons has been simplified, dropping the attribute checks on the `a`/`button` in favour of relying on just the AlreadyReblogged classname on the `footer` and the presence of a reblog icon
- The green/purple/red `color` override is now applied to the entire button, making the extra CSS for colouring the tick pseudo-element redundant

Setting `--icon-color-primary` is not necessary to recolour icons in the new iconset, but I've kept a rule for setting that on the icons anyway, for compatibility's sake.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon with a blank config
2. Enable Quick Reblog
3. Use Quick Reblog to reblog a post
    - **Expected result**: The post's reblog icon turns green
    - **Expected result**: The post's reblog icon gains a green tick
    - **Expected result**: The reblog button's reblog count turns green
4. Use Quick Reblog to queue a post
    - **Expected result**: The post's reblog icon turns purple
    - **Expected result**: The post's reblog icon gains a purple tick
    - **Expected result**: The reblog button's reblog count turns purple
5. Use Quick Reblog to draft a post
    - **Expected result**: The post's reblog icon turns red
    - **Expected result**: The post's reblog icon gains a red tick
    - **Expected result**: The reblog button's reblog count count turns red
6. Enable Classic Footer
    - **Expected result**: The reblogged post(s) keep their coloured reblog icons
    - **Expected result**: The reblogged post(s) keep their coloured ticks
7. Disable Classic Footer's "Turn reblog buttons back into links" option
    - **Expected result**: No visual changes occur

#### Compatibility

1. Disable the `postFooterSplitNotesCountSingleAction` feature, and reload the page
2. Find the post(s) you reblogged with Quick Reblog previously
    - **Expected result**: Those posts have green reblog buttons, and green ticks
3. Use Quick Reblog to queue a post
    - **Expected result**: The reblog button turns purple, and gains a purple tick
4. Use Quick Reblog to draft a post
    - **Expected result**: The reblog button turns red, and gains a red tick