### PR TITLE
feat(Classic Footer): add option to hide "0 notes"

### DIFF
--- a/src/features/classic_footer/feature.json
+++ b/src/features/classic_footer/feature.json
@@ -12,6 +12,11 @@
       "type": "checkbox",
       "label": "Turn reblog buttons back into links",
       "default": true
+    },
+    "noZeroNotes": {
+      "type": "checkbox",
+      "label": "Hide the note count on posts with no notes",
+      "default": false
     }
   }
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- resolves #1921

Adds an off-by-default option to Classic Footer: "Hide the note count on posts with no notes".

This adds the `aria-hidden` attribute to note count buttons created by Classic Footer. If this option is enabled and the post has zero notes, it is set to `true`; otherwise, it is `false` (which, for once, is actually synonymous with not having the attribute present at all).

Note count buttons with `aria-hidden="true"` have `visibility: hidden;` applied to them, keeping them in the flex layout (which keeps the interaction buttons right-aligned with no additional CSS) but otherwise removing them from sight.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Enable Classic Footer
3. Enable the "Hide the note count on posts with no notes" option
4. Find a post with at least one note
    - **Expected result**: The note count button is visible
    - **Expected result**: The note count button is exposed in the accessibility tree
5. Find a post with zero notes
    - **Expected result**: The note count button is not visible
    - **Expected result**: The note count button is not exposed in the accessibility tree
    - **Expected result**: The interaction buttons are still right-aligned, as in other posts
6. Disable the "Hide the note count on posts with no notes" option
    - **Expected result**: The post with zero notes now shows a "0 notes" button
    - **Expected result**: The "0 notes" button is exposed in the accessibility tree