### PR TITLE
fix(Scroll to Bottom): Feature corrupting visible queue contents

### DIFF
--- a/src/features/scroll_to_bottom/index.js
+++ b/src/features/scroll_to_bottom/index.js
@@ -32,7 +32,6 @@ const onLoadersAdded = () => {
 
 const scrollToBottom = () => {
   clearTimeout(timeoutID);
-  // window.scrollTo({ top: document.documentElement.scrollHeight });
   requestAnimationFrame(() => window.scrollTo({ top: document.documentElement.scrollHeight }));
 
   timeoutID = setTimeout(() => {
@@ -43,10 +42,7 @@ const scrollToBottom = () => {
 };
 const observer = new ResizeObserver(scrollToBottom);
 
-let timer;
-
 const startScrolling = () => {
-  timer = Date.now();
   observer.observe(document.documentElement);
   active = true;
   scrollToBottomButton.classList.add(activeClass);
@@ -54,7 +50,6 @@ const startScrolling = () => {
 };
 
 const stopScrolling = () => {
-  timer && console.log('scrolled to bottom in', Date.now() - timer, 'ms');
   clearTimeout(timeoutID);
   observer.disconnect();
   active = false;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes an issue where using Scroll to Bottom on the queue page made a bunch of clones of my queued posts appear. This is, obviously, pretty bad. I didn't test what happens if you e.g. delete one, thinking you have it queued twice, but yeah. My guess is this is caused by sortablejs (as I only observe it on queue), likely a race condition when the load-more-posts code gets called at an unexpected time.

Quick test: ```Object.groupBy([...document.querySelectorAll('[data-id]')].map(element => element.dataset.id), id => id)```

Putting our programmatic scroll in an rAF seems to fix this. Fortunately, two doesn't seem to be needed; that would result in an extra render occurring each time we scroll, which would be slower (likely making #1793 worse). One, I would guess, just shifts the scroll and resulting observer callbacks to later in the same synchronous event loop iteration, potentially changing the amount of js code that's run but not really affecting the render loop.

I was going to make this predicated on `${keyToCss('timeline')} > .sortableContainer`, but it doesn't seem to really slow down or have ill effects on the feature in general, so perhaps better safe than sorry?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that Scroll to Bottom functions normally on a normal timeline and on following/followers and stops when reaching the end of a timeline. (I should probably list more here. I dunno, I couldn't think of a specific thing to test.)
- Scroll to the bottom of a queue page with multiple pages and use the above snippet to confirm that each post only appears once.
- If desired, unrevert the test commits, open tabs with this code and with the original code substituted, scroll to the bottom of a moderate-length timeline, and confirm that about the same amount of time elapses.

I think this one's honestly more of a "can you think of an error-state-causing race condition that could occur with this based on looking at it." I _think_ I can't?