### PR TITLE
feat(Classic Footer): add translations for note count

### DIFF
--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -29,7 +29,6 @@ const pluralTranslation = new Map([
   ['de-DE', '%2$s Anmerkungen'],
   ['fr-FR', '%2$s notes'],
   ['it-IT', '%2$s note'],
-  ['ja-JP', 'リアクション%2$s件'],
   ['tr-TR', '%2$s not'],
   ['es-ES', '%2$s notas'],
   ['ru-RU', '%2$s заметок'],
@@ -37,13 +36,7 @@ const pluralTranslation = new Map([
   ['pt-PT', '%2$s notas'],
   ['pt-BR', '%2$s notas'],
   ['nl-NL', '%2$s notities'],
-  ['ko-KR', '반응 %2$s개'],
-  ['zh-CN', '%2$s 热度'],
-  ['zh-TW', '%2$s 則迴響'],
-  ['zh-HK', '%2$s 個迴響'],
-  ['id-ID', '%2$s nota'],
-  ['hi-IN', '%2$s नोट'],
-]).get(lang) ?? '%2$s notes';
+]).get(lang) ?? singularTranslation;
 
 let noReblogMenu;
 let modernButtonStyle;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- resolves #1930

Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2025-11-14 at 13 00 21" src="https://github.com/user-attachments/assets/3460ea0b-e29a-44b1-a91b-a9f0be66f3dc" /> | <img width="3840" height="2400" alt="Screen Shot 2025-11-14 at 13 00 33" src="https://github.com/user-attachments/assets/f6594f39-1744-4f62-b445-3cdcd86f76e6" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Enable Classic Footer
3. Verify that the Classic Footer note count uses the same string as Tumblr's own on every language for posts with more than one note:
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=en_US
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=de_DE
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=fr_FR
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=it_IT
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=ja_JP
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=tr_TR
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=es_ES
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=ru_RU
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=pl_PL
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=pt_PT
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=pt_BR
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=nl_NL
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=ko_KR
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=zh_CN
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=zh_TW
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=zh_HK
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=id_ID
    - https://www.tumblr.com/posthumanwanderings/136671808107?language=hi_IN
4. Verify that the Classic Footer note count uses the same string as Tumblr's own on every language for posts with exactly one note:
    - https://www.tumblr.com/ttafs/168787601254/notice?language=en_US
    - https://www.tumblr.com/ttafs/168787601254/notice?language=de_DE
    - https://www.tumblr.com/ttafs/168787601254/notice?language=fr_FR
    - https://www.tumblr.com/ttafs/168787601254/notice?language=it_IT
    - https://www.tumblr.com/ttafs/168787601254/notice?language=ja_JP
    - https://www.tumblr.com/ttafs/168787601254/notice?language=tr_TR
    - https://www.tumblr.com/ttafs/168787601254/notice?language=es_ES
    - https://www.tumblr.com/ttafs/168787601254/notice?language=ru_RU
    - https://www.tumblr.com/ttafs/168787601254/notice?language=pl_PL
    - https://www.tumblr.com/ttafs/168787601254/notice?language=pt_PT
    - https://www.tumblr.com/ttafs/168787601254/notice?language=pt_BR
    - https://www.tumblr.com/ttafs/168787601254/notice?language=nl_NL
    - https://www.tumblr.com/ttafs/168787601254/notice?language=ko_KR
    - https://www.tumblr.com/ttafs/168787601254/notice?language=zh_CN
    - https://www.tumblr.com/ttafs/168787601254/notice?language=zh_TW
    - https://www.tumblr.com/ttafs/168787601254/notice?language=zh_HK
    - https://www.tumblr.com/ttafs/168787601254/notice?language=id_ID
    - https://www.tumblr.com/ttafs/168787601254/notice?language=hi_IN