### PR TITLE
fix(Seen Posts): restore "only dim avatars" option functionality

### DIFF
--- a/src/features/seen_posts/index.css
+++ b/src/features/seen_posts/index.css
@@ -1,5 +1,6 @@
-body:not(.xkit-seen-posts-only-dim-avatar) [data-seen-posts-seen]:not(:hover),
-body.xkit-seen-posts-only-dim-avatar [data-seen-posts-seen]:not(:hover) article > :first-child figure:has(img[loading="eager"]) {
+body.xkit-seen-posts-only-dim-avatar [data-seen-posts-seen]:not(:hover) article header figure, /* Unmodified Tumblr DOM structure */
+body.xkit-seen-posts-only-dim-avatar [data-seen-posts-seen]:not(:hover) article .dbplus-stickyContainer figure, /* Dashboard+ floating avatars */
+body:not(.xkit-seen-posts-only-dim-avatar) [data-seen-posts-seen]:not(:hover) {
   opacity: 0.5;
 }
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- fixes #1951

Before | After
-|-
<img width="750" height="1334" alt="Screen Shot 2025-11-20 at 11 16 30" src="https://github.com/user-attachments/assets/2d924caa-eec7-4e18-9f95-2467dc9a5551" /> | <img width="750" height="1334" alt="Screen Shot 2025-11-20 at 11 16 38" src="https://github.com/user-attachments/assets/917c5366-782a-47f5-b12e-c47e39eef1b3" />

Dimming the entire `figure` also dims whatever badge is attached to the avatar, which I think looks quite good.

I've opted to continue using `article > :first-child` instead of `article header` so that anyone using Dashboard Plus to bring back sticky avatars can continue to use this option.

(Wasn't there a `<div>` wrapper between the `<article>` and its `<header>` added recently? It seems to have gone away now. Maybe someone realised that `<header>`'s ARIA role changes based on whether it's a child of an `<article>` or not...)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Open https://www.tumblr.com/dashboard and scroll until you find a post with a badge on the avatar in the header
3. Enable Seen Posts &rarr; "Only dim avatars on seen posts"
4. Refresh the feed
    - **Expected result**: The aforementioned post's avatar is now dimmed
    - **Expected result**: The avatar badge (or sub-avatar) is also dimmed to the same extent
    - **Expected result**: Original posts with dimmed avatars do not also have dimmed media

#### Compatibility testing (optional)
1. Install Dashboard Plus
2. Enable Dashboard Plus &rarr; posts &rarr; "floating avatars"
3. Reload your Tumblr tab
    - **Expected result**: The floating avatars of seen posts are dimmed
    - **Expected result**: The floating avatars of unseen posts are not dimmed
