### PR TITLE
fix(Tweaks): add cleanup logic to attribution links option

### DIFF
--- a/src/features/tweaks/create_button_no_bubbles.js
+++ b/src/features/tweaks/create_button_no_bubbles.js
@@ -10,10 +10,10 @@ const processCreateButtons = (createButtons) => {
   }
 
   createButtons.forEach(createButton => {
-    createButton.dataset.href ??= createButton.getAttribute('href');
+    createButton.dataset.originalHref ??= createButton.getAttribute('href');
 
     createButton.setAttribute(modifiedAttribute, '');
-    createButton.setAttribute('href', createButton.dataset.href.replace(/\/new$/, '/new/text'));
+    createButton.setAttribute('href', createButton.dataset.originalHref.replace(/\/new$/, '/new/text'));
     createButton.addEventListener('click', onClickNavigate);
   });
 };
@@ -27,7 +27,8 @@ export const clean = async function () {
 
   [...document.querySelectorAll(`[${modifiedAttribute}]`)].forEach(modifiedButton => {
     modifiedButton.removeAttribute(modifiedAttribute);
-    modifiedButton.setAttribute('href', modifiedButton.dataset.href);
+    modifiedButton.setAttribute('href', modifiedButton.dataset.originalHref);
     modifiedButton.removeEventListener('click', onClickNavigate);
+    delete modifiedButton.dataset.originalHref;
   });
 };

--- a/src/features/tweaks/restore_attribution_links.js
+++ b/src/features/tweaks/restore_attribution_links.js
@@ -36,7 +36,7 @@ const processPosts = async function (postElements) {
     const reblogAttributionLink = postElement.querySelector(reblogAttributionLinkSelector);
 
     if (postAttributionLink && postAttributionLink.textContent === blogName) {
-      postAttributionLink.dataset.href ??= postAttributionLink.getAttribute('href');
+      postAttributionLink.dataset.originalHref ??= postAttributionLink.getAttribute('href');
       postAttributionLink.href = postUrl;
       postAttributionLink.dataset.blogName = blogName;
       postAttributionLink.dataset.postId = id;
@@ -44,7 +44,7 @@ const processPosts = async function (postElements) {
     }
 
     if (reblogAttributionLink && reblogAttributionLink.textContent === rebloggedFromName) {
-      reblogAttributionLink.dataset.href ??= reblogAttributionLink.getAttribute('href');
+      reblogAttributionLink.dataset.originalHref ??= reblogAttributionLink.getAttribute('href');
       reblogAttributionLink.href = rebloggedFromUrl;
       reblogAttributionLink.dataset.blogName = rebloggedFromName;
       reblogAttributionLink.dataset.postId = rebloggedFromId;
@@ -61,10 +61,10 @@ export const clean = async function () {
   onNewPosts.removeListener(processPosts);
 
   [...document.querySelectorAll(
-    `[data-href]:is(${postAttributionLinkSelector}, ${reblogAttributionLinkSelector})`
+    `[data-original-href]:is(${postAttributionLinkSelector}, ${reblogAttributionLinkSelector})`
   )].forEach(anchorElement => {
-    anchorElement.setAttribute('href', anchorElement.dataset.href);
+    anchorElement.setAttribute('href', anchorElement.dataset.originalHref);
     anchorElement.removeEventListener('click', onLinkClick, listenerOptions);
-    delete anchorElement.dataset.href;
+    delete anchorElement.dataset.originalHref;
   });
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- fixes #1087

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon in Firefox via `about:debugging#/runtime/this-firefox`
2. Open a Tumblr tab, and find a reblogged post on your dashboard (not Peepr)
3. Enable Tweaks &rarr; "Restore links to individual posts in the post header"
    - **Expected result**: Post attribution blogname links become permalinks to the current post
    - **Expected result**: Reblog attribution blogname links become permalinks to the reblog parent post
4. Disable the option
    - **Expected result**: Links that were previously modified are restored to their default state, linking only to blogs
5. Enable the option again
6. Reload the addon via `about:debugging` to simulate an update or restart
7. Go back to the Tumblr tab
    - **Expected result**: Attribution links still have modified link targets, pointing to the post or parent as appropriate
    - **Expected result**: Clicking an attribution link still opens the post/parent in Peepr
8. Disable the option again
    - **Expected result**: Attribution links are once again restored to their original state—including those that were on the page at the time of the addon restart