### PR TITLE
fix(Vanilla Audio): Improve player appearance with rounded corners A/B

### DIFF
--- a/src/features/vanilla_audio/index.js
+++ b/src/features/vanilla_audio/index.js
@@ -1,12 +1,25 @@
 import { keyToCss } from '../../utils/css_map.js';
 import { getPreferences } from '../../utils/preferences.js';
 import { pageModifications } from '../../utils/mutations.js';
+import { buildStyle } from '../../utils/interface.js';
 
 const trackInfoSelector = keyToCss('trackInfo');
 
 let defaultVolume;
 
 const excludeClass = 'xkit-vanilla-audio-done';
+
+export const styleElement = buildStyle(`
+${keyToCss('hasRoundedCorners')} > .${excludeClass} {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+}
+
+${keyToCss('hasRoundedCorners')} > .${excludeClass} ~ audio[controls] {
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+}
+`);
 
 const addAudioControls = nativePlayers => nativePlayers.forEach(nativePlayer => {
   if (nativePlayer.classList.contains(excludeClass)) return;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

chat is this stupid? chat?

| before | after |
| - | - |
| <img width="570" src="https://github.com/user-attachments/assets/06831672-9a04-4064-b39f-278c44773223" /> | <img width="570" src="https://github.com/user-attachments/assets/84fcb5c2-d748-4d94-98f8-1a2bd81a543b" /> |

idk, is there a better way to do this?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

With the rounded corners A/B flag, confirm that... audio posts... look... better?
