### PR TITLE
fix(Themed Posts): Temporarily disable reblog trail theming with new Tumblr A/B Test

### DIFF
--- a/src/features/themed_posts/index.js
+++ b/src/features/themed_posts/index.js
@@ -8,7 +8,11 @@ export const styleElement = buildStyle();
 
 const blogs = new Set();
 const groupsFromHex = /^#(?<red>[A-Fa-f0-9]{1,2})(?<green>[A-Fa-f0-9]{1,2})(?<blue>[A-Fa-f0-9]{1,2})$/;
-const reblogSelector = keyToCss('reblog');
+
+// Prevent unreadable text by not theming trail items if they'll change
+// background color on hover until we implement compatibility with
+// postChromeBodyNavigationEventsRedesign.
+const reblogSelector = `${keyToCss('reblog')}:not(${keyToCss('withTrailItemPermalink')})`;
 const timelineSelector = keyToCss('timeline');
 
 let enableOnPeepr;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in #2001, on accounts with the new Tumblr A/B test, hovered reblog trail items change background color. This overwrites the Themed Posts reblog trail theming background color, but not the foreground, often making text unreadable.

Options to fix this properly are discussed in that PR. If we want to do a release without fixing that, I think it makes sense to do one in which the subfeature is nonfunctional if it would be buggy, which is quite easy. This will also mean #2024 will not cause the same bug (it only affects `withTrailItemPermalink`) until we revert this and do it all properly.

Naturally, if you intend to look into resolving #2001 with full functionality, April, close this instead of reviewing it.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Open https://www.tumblr.com/april/801912410171719680 on an account with `postChromeBodyNavigationEventsRedesign`.
- Enable Themed Posts.
- Enable the "Theme every reblog trail item individually" option and confirm that... nothing happens.
- Hover over the text at the bottom of the reblog trail item and confirm that the text is still readable, as there is a normal/subtle hover effect.
- Open https://www.tumblr.com/april/801912410171719680 on an account without `postChromeBodyNavigationEventsRedesign`.
- Enable Themed Posts.
- Enable the "Theme every reblog trail item individually" option and confirm that the reblog trail item is themed blue as normal.