### PR TITLE
fix(Vanilla Audio): hide play button on Tumblr audio player again

### DIFF
--- a/src/features/vanilla_audio/index.css
+++ b/src/features/vanilla_audio/index.css
@@ -1,9 +1,15 @@
+.xkit-vanilla-audio-done {
+  cursor: auto;
+}
+
 .xkit-vanilla-audio-done :is(button, [role="slider"]) {
   display: none;
 }
 
 .xkit-vanilla-audio-done .trackInfo {
   padding-left: 20px;
+  pointer-events: auto;
+  user-select: auto;
 }
 
 .xkit-vanilla-audio-done ~ audio[controls] {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- fixes #1817

Before | After
-|-
<img width="1080" height="1172" alt="Screenshot 2025-12-16 at 10-55-19 Eat shit and die – @april on Tumblr" src="https://github.com/user-attachments/assets/90c1a878-40cf-4c33-b74d-25e7fb7507b6" /> | <img width="1080" height="1172" alt="Screenshot 2025-12-16 at 10-55-40 Eat shit and die – @april on Tumblr" src="https://github.com/user-attachments/assets/39dd2411-8328-431d-b3be-3e3cde199322" />

This also adds the necessary CSS to enable text selection in the modified Tumblr player's audio metadata display, allowing you to select and copy the track title/artist/album freely. This is only three additional style declarations and barely adds any effort to testing, so I'm opting not to split it out into its own PR (although I would do that if I cared deeply about having one squashed commit per public changelog item, which I don't).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Enable Vanilla Audio
3. Find an audio post
    - **Expected result**: The vanilla audio player is inserted below the custom Tumblr player
    - **Expected result**: The Tumblr player's play button is hidden
    - **Expected result**: The Tumblr player's audio metadata display has symmetrical padding
4. Click around in the modified Tumblr audio player
    - **Expected result**: Scrubbing through the Tumblr audio player is not possible
    - **Expected result**: The track title can be selected as text
    - **Expected result**: The track artist can be selected as text
    - **Expected result**: The track album can be selected as text
