### PR TITLE
feat(Themed Posts): Adjust nearly-identical background/foreground colors

### DIFF
--- a/src/features/themed_posts/index.js
+++ b/src/features/themed_posts/index.js
@@ -34,6 +34,14 @@ const hexToRGBComponents = hex => {
 };
 const hexToRGB = hex => hexToRGBComponents(hex).join(', ');
 
+const colorsAreSimilar = (hexA, hexB) => {
+  const componentsA = hexToRGBComponents(hexA);
+  const componentsB = hexToRGBComponents(hexB);
+  return Object.keys(componentsA).every(
+    i => Math.abs(componentsA[i] - componentsB[i]) < 32
+  );
+};
+
 const createContrastingColor = hex => {
   const components = hexToRGBComponents(hex);
   const isLight = average(components) > 128;
@@ -69,8 +77,8 @@ const processPosts = async function (postElements) {
         } = theme;
 
         const backgroundColorRGB = hexToRGB(backgroundColor);
-        const titleColorRGB = titleColor === backgroundColor ? createContrastingColor(titleColor) : hexToRGB(titleColor);
-        const linkColorRGB = linkColor === backgroundColor ? createContrastingColor(linkColor) : hexToRGB(linkColor);
+        const titleColorRGB = colorsAreSimilar(titleColor, backgroundColor) ? createContrastingColor(titleColor) : hexToRGB(titleColor);
+        const linkColorRGB = colorsAreSimilar(linkColor, backgroundColor) ? createContrastingColor(linkColor) : hexToRGB(linkColor);
 
         styleElement.textContent += `
           [data-xkit-themed="${name}"] {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This makes the text/accent colors used by Themed Posts a bit lighter or darker if they're _close to_ matching the background color, expanding on #1917.

The threshold used here is of course pretty arbitrary. I'm generally inclined to be fairly conservative with it, because due to the fact that for browser support reasons we're not doing color manipulation anywhere close to correctly, the results of this intervention (and the consistency of the computation of the threshold, probably) are quite low quality. Readable is better than not, of course, but readable and bad looking is not necessarily better than marginally readable and good looking, in the case of this specific feature (there's a clear consensus that the jankiness is clearly part of the charm).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
- Enable Themed Posts and post theming in the blog view.
- Confirm that https://www.tumblr.com/markovchaingang has post text increased in contrast.
- Confirm that https://www.tumblr.com/targetedknowledge has post text increased in contrast.
- Confirm that https://www.tumblr.com/eregar does **not** have post text increased in contrast (should we bump the threshold to e.g. 48 so this one is affected? I'm torn.)
- Confirm that https://www.tumblr.com/robo-nonagon does **not** have post text increased in contrast.
