### PR TITLE
feat: add VS Code extension recommendations

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,10 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint",
+        "editorconfig.editorconfig",
+        "github.github-vscode-theme",
+        "github.vscode-github-actions",
+        "github.vscode-pull-request-github",
+        "mhutchie.git-graph"
+    ]
+}


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Another little thing in my "hey let's make the repository more friendly to new contributors" crusade.

These are all the VS Code extensions I use when developing addons. Yes, all six of them.

I think being able to trivially configure your workspace to match that of the author-maintainer is useful, no?

This is committed via `git add --force` rather than modifying our gitignore file, so other changes to files in the `.vscode/` directory remain untracked by default. This allows individuals to customise their workspace for this repository without their `settings.json` getting picked up by git and unintentionally pushed as part of a PR.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Open this branch in VS Code
2. Go to Extensions &rarr; "Search Extensions in Marketplace"
3. Search for `@recommended`
    - **Expected result**: Six items appear under "Workspace Recommendations": ESLint, EditorConfig for VS Code, GitHub Theme, GitHub Actions, Git Graph, GitHub Pull Requests

(I assume that a fresh VS Code install would, upon starting up with this file committed, prompt to install these if they're not already installed; I can make no assumptions about your install, so I don't know if you'll be prompted!)