### PR TITLE
feat(UI): modernise feature summary styling

### DIFF
--- a/src/action/components/xkit-feature/index.css
+++ b/src/action/components/xkit-feature/index.css
@@ -7,8 +7,8 @@ summary {
   flex-direction: row;
   justify-content: flex-start;
   align-items: flex-start;
-  column-gap: 1ch;
-  padding: 1ch;
+  column-gap: 8px;
+  padding: 8px;
 
   cursor: pointer;
 }
@@ -54,7 +54,7 @@ summary:focus {
   display: flex;
   flex-direction: row;
   align-items: center;
-  column-gap: 1ch;
+  column-gap: 8px;
   height: 36px;
   margin-left: auto;
 }
@@ -97,8 +97,8 @@ summary:focus {
 }
 
 ul.preferences {
-  padding: 0 0.5ch;
-  margin: 1ch 0;
+  padding: 0 4px;
+  margin: 8px 0;
 
   list-style-type: none;
 }
@@ -116,7 +116,7 @@ ul.preferences:empty::before {
 li {
   display: flex;
   align-items: center;
-  padding: 0.5ch;
+  padding: 4px;
 }
 
 li.search-highlighted {
@@ -125,7 +125,7 @@ li.search-highlighted {
 
 label:not(:first-child),
 input:not(:first-child) {
-  margin-left: 1ch;
+  margin-left: 8px;
 }
 
 input[type="text"] {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #1641 

The way that feature icons are aligned when feature descriptions become multi-line is bugging me. I think they should always be visually anchored to the feature name, rather than centred in the feature row. I think the same should apply to the help button and feature toggle, too.

And as soon as I started touching these styles... more things started to bug me. The line height of feature titles/descriptions is just a little bit over half the height of feature icons, by .1px, but the whole thing looks too cramped if that .1px is shaved off. We're using `margin` where flexbox `column-gap` would work identically. We're using `ch` units for a bunch of measurements instead of whole pixel values.

So, I took some pointers from Tumblr's design system and made feature summaries into a weird variant of the "user row" component, which resolves all my gripes and, in my opinion, looks slightly better overall:

Before | After
-|-
<img width="750" height="1334" alt="Screen Shot 2026-01-09 at 10 54 57" src="https://github.com/user-attachments/assets/ad46e8fb-bec7-4168-aec4-a725445262ba" /> | <img width="750" height="1334" alt="Screen Shot 2026-01-09 at 10 55 26" src="https://github.com/user-attachments/assets/eb4b34bc-0125-4d22-a5b3-e4fc1c53433d" />

This does mean that I'll need to redo the product screenshots again... oh well.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Open the control panel via the browser toolbar
    - **Expected result**: All features have bigger, slightly more rounded icons
    - **Expected result**: Features with long descriptions still have their description text wrap onto new lines
    - **Expected result**: All feature icons and buttons are aligned to the top of the summary, regardless of description wrapping
