### PR TITLE
feat: add `CheckboxPreference` component

### DIFF
--- a/src/action/components/checkbox-preference/index.css
+++ b/src/action/components/checkbox-preference/index.css
@@ -1,0 +1,6 @@
+li {
+  display: flex;
+  align-items: flex-start;
+  column-gap: 8px;
+  padding: 4px;
+}

--- a/src/action/components/checkbox-preference/index.js
+++ b/src/action/components/checkbox-preference/index.js
@@ -1,0 +1,61 @@
+import { CustomElement, fetchStyleSheets } from '../index.js';
+
+const localName = 'checkbox-preference';
+
+const templateDocument = new DOMParser().parseFromString(`
+  <template id="${localName}">
+    <li>
+      <input id="checkbox" type="checkbox">
+      <label for="checkbox"></label>
+    </li>
+  </template>
+`, 'text/html');
+
+const adoptedStyleSheets = await fetchStyleSheets([
+  '/lib/normalize.min.css',
+  './index.css'
+].map(import.meta.resolve));
+
+class CheckboxPreferenceElement extends CustomElement {
+  /** @type {string} */ featureName;
+  /** @type {string} */ preferenceName;
+
+  /** @type {HTMLInputElement} */ #inputElement;
+  /** @type {HTMLLabelElement} */ #labelElement;
+
+  constructor () {
+    super(templateDocument, adoptedStyleSheets);
+
+    this.#inputElement = this.shadowRoot.querySelector('input');
+    this.#labelElement = this.shadowRoot.querySelector('label');
+  }
+
+  /** @param {string} label Label displayed to the user to describe the preference. */
+  set label (label) { this.#labelElement.textContent = label; }
+  get label () { return this.#labelElement.textContent; }
+
+  /** @param {boolean} value Whether or not this preference is enabled. */
+  set value (value = false) { this.#inputElement.checked = value; }
+  get value () { return this.#inputElement.checked; }
+
+  #onChange = async ({ currentTarget }) => {
+    const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
+    browser.storage.local.set({ [storageKey]: currentTarget.checked });
+  };
+
+  connectedCallback () { this.#inputElement.addEventListener('change', this.#onChange); }
+  disconnectedCallback () { this.#inputElement.removeEventListener('change', this.#onChange); }
+}
+
+customElements.define(localName, CheckboxPreferenceElement);
+
+/**
+ * @typedef {object} CheckboxPreferenceProps
+ * @property {string} featureName The feature's internal name (e.g. `"quick_reblog"`).
+ * @property {string} preferenceName The preference's internal name (e.g. `"showTagSuggestions"`).
+ * @property {string} label The preference's label (e.g. `"Suggest tags from the post being reblogged"`).
+ * @property {boolean} value The preference's current value (as set by the user, or the preference's default).
+ */
+
+/** @type {(props: CheckboxPreferenceProps) => CheckboxPreferenceElement} */
+export const CheckboxPreference = (props = {}) => Object.assign(document.createElement(localName), props);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #1831

Creates a `CheckboxPreferenceElement` class and `CheckboxPreference` shorthand function, for rendering checkbox-type preferences.

This just creates the component and doesn't implement it anywhere. I would prefer for all preferences to be switched to using slotted components at the same time, since that will require not-insignificant lift to make the control panel's search/highlight functionality work on componentised preferences.

Having unused files is far less messy than having mid-migration spaghetti code, in my opinion.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Apply this patch to the branch: [diff.patch](https://github.com/user-attachments/files/24562094/diff.patch)
3. Load the addon from `src/`
4. Open a Tumblr tab
5. Open the XKit control panel via the browser toolbar action
6. Enable a feature that has checkbox-type preferences, e.g. Classic Footer
    - **Expected result**: Checkbox preferences render an `<input type="checkbox">` and a `<label>`
    - **Expected result**: Checkbox preferences render the correct checked state for their `<input>`
    - **Expected result**: Checkbox preferences render the correct text content for their `<label>`
7. Toggle a checkbox-type preference on
    - **Expected result**: The preference change takes effect on the Tumblr tab immediately
8. Toggle a checkbox-type preference off
    - **Expected result**: The preference change takes effect on the Tumblr tab immediately
9. Open the XKit control panel in a new tab
10. Inspect the accessibility properties of checkbox-type preferences
    - **Expected result**: Every `checkbox` element in the accessibility tree has a `name` matching the visible label
    - **Expected result**: Every `label` element in the accessibility tree has the correct `label for` relation
