### PR TITLE
fix(Quote Replies, Sidebar Blogs): Broken elements on extension reload

### DIFF
--- a/src/features/quote_replies/index.js
+++ b/src/features/quote_replies/index.js
@@ -14,6 +14,9 @@ const storageKey = 'quote_replies.draftLocation';
 const buttonClass = 'xkit-quote-replies';
 const dropdownButtonClass = 'xkit-quote-replies-dropdown';
 
+// Remove outdated elements when loading module
+$(`.${buttonClass}`).remove();
+
 export const styleElement = buildStyle(`
 button.xkit-quote-replies {
   position: relative;

--- a/src/features/sidebar_blogs/index.js
+++ b/src/features/sidebar_blogs/index.js
@@ -5,6 +5,9 @@ import { pageModifications } from '../../utils/mutations.js';
 import { onClickNavigate } from '../../utils/tumblr_helpers.js';
 import { userBlogs } from '../../utils/user.js';
 
+// Remove outdated elements when loading module
+$('#narrow-sidebar-avatars').remove();
+
 export const styleElement = buildStyle(`
 :root {
   --sidebar-blogs-padding: 10px;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This fixes more features that will add multiple sets of elements to the page, one set of which will not function correctly, when XKit Rewritten is disabled and re-enabled (or, presumably, automatically updated) in Firefox.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable Quote Replies in Firefox and find one of its action buttons on the activity page.
- In another tab, open `about:addons` and disable XKit Rewitten. Wait a few moments, then enable XKit Rewritten.
- Confirm that there is only one Quote Replies action button on an activity item and that it functions correctly.
- Enable Sidebar Blogs in Firefox and resize the browser window until it creates blog icons in the sidebar.
- In another tab, open `about:addons` and disable XKit Rewitten. Wait a few moments, then enable XKit Rewritten.
- Confirm that there is only one Sidebar Blogs icon for each of your blogs and that clicking one soft navigates to it.