### PR TITLE
feat(UI): Acorn Box Item style for feature summaries

### DIFF
--- a/src/action/components/xkit-feature/index.css
+++ b/src/action/components/xkit-feature/index.css
@@ -25,24 +25,20 @@ summary:focus {
   background-color: rgb(var(--active-grey));
 }
 
-.disabled summary {
-  color: rgba(var(--black), .8);
-}
-
 .icon {
   display: flex;
   justify-content: center;
   align-items: center;
   flex-shrink: 0;
-  width: 36px;
-  height: 36px;
+  width: 32px;
+  height: 32px;
   border-radius: 8px;
   overflow: hidden;
 }
 
 .icon ::slotted(i) {
-  font-size: 30px;
-  line-height: 36px;
+  font-size: 26px;
+  line-height: 32px;
 }
 
 .icon,
@@ -55,7 +51,7 @@ summary:focus {
   flex-direction: row;
   align-items: center;
   column-gap: 8px;
-  height: 36px;
+  height: 32px;
   margin-left: auto;
 }
 
@@ -81,9 +77,21 @@ summary:focus {
 .title,
 .description {
   margin: 0;
+}
 
-  font-size: 14px;
-  line-height: 18px;
+.title {
+  font-size: 15px;
+  line-height: 18.5px;
+}
+
+.description {
+  font-size: 13px;
+  line-height: 16px;
+  opacity: 70%;
+}
+
+.disabled:not([open], :focus-within, :hover) :is(.icon, .meta) {
+  opacity: 60%;
 }
 
 .disabled .title::after {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #2054

I lied. I actually want to follow the Acorn design system, not Tumblr's. We're building a Firefox add-on here, after all.

I want to do a lot more, but refreshing the look of the entire control panel in one PR is not happening.

`v1.1.7` | 36c97eaa3cf40598ec2ae9d690cf217c4a6c9ebf | dfe69b2b4588a78bf2812b38ba5e2fcd8fcb933c
-|-|-
<img width="750" height="1334" alt="Screen Shot 2026-01-13 at 15 56 58" src="https://github.com/user-attachments/assets/d41a6e6e-677a-4b3a-a303-5f2b93dfacc1" /> | <img width="750" height="1334" alt="Screen Shot 2026-01-13 at 15 57 19" src="https://github.com/user-attachments/assets/4ce1ce64-2dcc-41a8-bd7b-9a69e72f6544" /> | <img width="750" height="1334" alt="Screen Shot 2026-01-13 at 15 57 37" src="https://github.com/user-attachments/assets/6d558203-37c7-40b1-9b18-714b30448cef" />

Further work of this general theme should probably come after rebuilding our web components in Lit, but before actually using those implementations.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Open the XKit Rewritten control panel
3. Compare feature summaries to [Storybook for Firefox &rarr; UI Widgets &rarr; Box Item &rarr; Large Icon Layout](https://firefoxux.github.io/firefox-desktop-components/?path=/story/ui-widgets-box-item--large-icon-layout&args=slottedActions:!true)
    - **Expected result**: They look similar enough. It's not perfect, but it's at least evocative.
