### PR TITLE
fix(Tweaks): update reblog trail item targeting

### DIFF
--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -3,7 +3,7 @@ import { dom } from './dom.js';
 import { timelineSelector } from './timeline_id.js';
 
 export const postSelector = '[tabindex="-1"][data-id]';
-export const trailItemSelector = `${keyToCss('reblogTrailWrapper')} > ${keyToCss('reblog')}`;
+export const trailItemSelector = `${postSelector} ${keyToCss('reblog')}`;
 export const blogViewSelector = '[style*="--blog-title-color"] *';
 export const notificationSelector = `:is(${keyToCss('notification')}[role="listitem"], ${keyToCss('activityItem')})`;
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- fixes #2060

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Open a Tumblr tab
3. Enable Tweaks &rarr; "Move post permalinks back to attributed blognames"
    - **Expected result**: The option takes effect in the reblog trail
    - **Expected result**: Nothing bad happens when opening the meatball menu for a reblog note with added content
    - **Expected result**: Nothing bad happens when clicking the "Reblog" meatball menu item
