### PR TITLE
chore: configure VS Code auto imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "javascript.preferences.autoImportFileExcludePatterns": ["node_modules/**/*"],
+  "javascript.preferences.importModuleSpecifier": "relative",
+  "javascript.preferences.importModuleSpecifierEnding": "js",
+  "javascript.suggest.paths": true
+}

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,4 @@
+{
+  "include": ["src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #2064

> I don't really want to add a dependency to the package.json that isn't actually used—if anything, I would consider it a hindrance to have in the project since then the node_modules versions of its exports get picked up by code autocomplete tools, which would not actually work.

Importing directly from `node_modules` doesn't work anyway, stupid.

Stop allowing VS Code to suggest unusable exports.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Open any feature's `index.js` file in VS Code
3. Start typing "Sortable" somewhere in the file
    - **Expected result**: `../../lib/sortable.esm.js` is suggested
    - **Expected result**: 🆕 The bare `sortablejs` package is _not_ suggested
    - **Expected result**: 🆕 `SortablePlugin` is _not_ suggested
