### PR TITLE
chore: thoroughly type-annotate `XKitFeatureElement` and `XKitFeature()`

### DIFF
--- a/src/action/components/xkit-feature/index.js
+++ b/src/action/components/xkit-feature/index.js
@@ -35,54 +35,49 @@ const adoptedStyleSheets = await fetchStyleSheets([
 ].map(import.meta.resolve));
 
 /**
- * @typedef CheckboxPreferenceObject
+ * @typedef BasePreference
+ * @property {string} label Label displayed to the user to describe the preference.
+ * @property {string} [inherit] The storage key to inherit the value of, if the preference has not been set.
+ */
+
+/**
+ * @typedef Checkbox
  * @property {"checkbox"} type Type of preference.
- * @property {string} label Label displayed to the user to describe the preference.
  * @property {boolean} default Default value of the preference to display to the user.
- * @property {string} [inherit] The storage key to inherit the value of, if the preference has not been set.
  */
 
 /**
- * @typedef TextPreferenceObject
+ * @typedef Text
  * @property {"text"} type Type of preference.
- * @property {string} label Label displayed to the user to describe the preference.
  * @property {string} default Default value of the preference to display to the user.
- * @property {string} [inherit] The storage key to inherit the value of, if the preference has not been set.
  */
 
 /**
- * @typedef TextAreaPreferenceObject
+ * @typedef TextArea
  * @property {"textarea"} type Type of preference.
- * @property {string} label Label displayed to the user to describe the preference.
  * @property {string} default Default value of the preference to display to the user.
- * @property {string} [inherit] The storage key to inherit the value of, if the preference has not been set.
  */
 
 /**
- * @typedef ColorPreferenceObject
+ * @typedef Color
  * @property {"color"} type Type of preference.
- * @property {string} label Label displayed to the user to describe the preference.
  * @property {string} default Default value of the preference to display to the user.
- * @property {string} [inherit] The storage key to inherit the value of, if the preference has not been set.
  */
 
 /**
- * @typedef SelectPreferenceObject
+ * @typedef Select
  * @property {"select"} type Type of preference.
- * @property {string} label Label displayed to the user to describe the preference.
  * @property {{ label: string, value: string }[]} options List of options for the user to choose between.
  * @property {string} default Default value of the preference to display to the user. Must match one of the `options` item's `value`.
- * @property {string} [inherit] The storage key to inherit the value of, if the preference has not been set.
  */
 
 /**
- * @typedef IframePreferenceObject
+ * @typedef Iframe
  * @property {"iframe"} type Type of preference.
- * @property {string} label Accessible label to describe the preference.
  * @property {string} src A URL, relative to `src/`, to be embedded in the feature's preference list.
  */
 
-/** @typedef {CheckboxPreferenceObject | TextPreferenceObject | TextAreaPreferenceObject | ColorPreferenceObject | SelectPreferenceObject | IframePreferenceObject} Preference */
+/** @typedef {BasePreference & (Checkbox | Text | TextArea | Color | Select | Iframe)} Preference */
 /** @typedef {Record<string, Preference>} Preferences */
 
 class XKitFeatureElement extends CustomElement {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
You know what? There's actually nothing wrong with our web components. Let's invest in them more.

This PR brings `XKitFeatureElement`'s typing up to standard with the as-of-yet unused `CheckboxPreferenceElement` component. This is a lot of JSdoc! But damn, it's pretty nice. VS Code even understands that these two destructured constants are both strings now:

https://github.com/AprilSylph/XKit-Rewritten/blob/31de8ce642580de584720a989ee593a5bcd9c08f/src/action/components/xkit-feature/index.js#L173-L174

Oh, and static members are now actually `static` now. I assume this saves some memory?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Open `src/action/components/xkit-feature/index.js` in VS Code
3. Hover over everything that's been type-annotated
    - **Expected result**: Nothing is... wrong? There's still a lot missing, but when VS Code has the opportunity to infer something, it should infer correctly, at least.
4. Load the modified addon in the browser
5. Open the control panel
    - **Expected result**: All features render without issue
    - **Expected result**: All features' preferences render without issue
    - **Expected result**: Features can be enabled/disabled without issue
    - **Expected result**: Instant-save preference types (e.g. checkbox, select) can be changed without issue
    - **Expected result**: Debounced-save preference types (e.g. text, textarea) can be changed without issue
