### PR TITLE
 chore(Classic Footer): Ensure reply button is in post footer

### DIFF
--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -230,11 +230,13 @@ const getButtonChildren = (noteCount) => {
 const onNoteCountClick = (event) => {
   event.stopPropagation();
   const postElement = event.currentTarget.closest(postOrRadarSelector);
-  const closeNotesButton = postElement?.querySelector(closeNotesButtonSelector);
+  if (!postElement) { return; }
+
+  const closeNotesButton = postElement.querySelector(closeNotesButtonSelector);
 
   closeNotesButton
     ? closeNotesButton.click()
-    : postElement?.querySelector(`[${activeAttribute}] ${replyButtonSelector}`)?.click();
+    : [...postElement.querySelectorAll(`[${activeAttribute}] ${replyButtonSelector}`)].at(-1)?.click();
 };
 
 const processPosts = (postElements) => postElements.forEach(async postElement => {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This adds extra logic to the Classic Footer reply button selection used to open the post notes when the user clicks the added note count, ensuring that it can only target buttons in the post footer at the end of a post.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable Classic Footer.
- Confirm that clicking on the note count opens and closes the notes on a normal post.
- Confirm that clicking on the note count opens and closes the notes popup on a narrow post, such as on https://www.tumblr.com/explore/trending with the masonry layout enabled.

