### PR TITLE
feat: add `TextPreference` component

### DIFF
--- a/src/action/components/text-preference/index.css
+++ b/src/action/components/text-preference/index.css
@@ -1,0 +1,28 @@
+li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  column-gap: 8px;
+  padding: 4px;
+}
+
+label {
+  flex-shrink: 0;
+}
+
+input {
+  flex-shrink: 1;
+
+  box-sizing: border-box;
+  min-width: 0;
+  padding: 4px;
+  border: none;
+  border-radius: 3px;
+
+  background-color: rgb(var(--passive-grey));
+  color: rgb(var(--black));
+}
+
+input:focus {
+  background-color: rgb(var(--active-grey));
+}

--- a/src/action/components/text-preference/index.js
+++ b/src/action/components/text-preference/index.js
@@ -1,0 +1,66 @@
+import { CustomElement, fetchStyleSheets } from '../index.js';
+
+const localName = 'text-preference';
+
+const templateDocument = new DOMParser().parseFromString(`
+  <template id="${localName}">
+    <li>
+      <label for="text"></label>
+      <input id="text" type="text" size="28" spellcheck="false">
+    </li>
+  </template>
+`, 'text/html');
+
+const adoptedStyleSheets = await fetchStyleSheets([
+  '/lib/normalize.min.css',
+  './index.css'
+].map(import.meta.resolve));
+
+class TextPreferenceElement extends CustomElement {
+  /** @type {string} */ featureName;
+  /** @type {string} */ preferenceName;
+
+  /** @type {HTMLInputElement} */ #inputElement;
+  /** @type {HTMLLabelElement} */ #labelElement;
+  /** @type {ReturnType<Window['setTimeout']>} */ #timeoutID;
+
+  constructor () {
+    super(templateDocument, adoptedStyleSheets);
+
+    this.#inputElement = this.shadowRoot.querySelector('input');
+    this.#labelElement = this.shadowRoot.querySelector('label');
+  }
+
+  /** @param {string} label Label displayed to the user to describe the preference. */
+  set label (label) { this.#labelElement.textContent = label; }
+  get label () { return this.#labelElement.textContent; }
+
+  /** @param {string} value The saved or default value of this preference. */
+  set value (value = '') { this.#inputElement.value = value; }
+  get value () { return this.#inputElement.value; }
+
+  /** @type {(event: { currentTarget: HTMLInputElement }) => void} */
+  #onInput = ({ currentTarget }) => {
+    const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
+    const storageValue = currentTarget.value;
+
+    clearTimeout(this.#timeoutID);
+    this.#timeoutID = setTimeout(() => browser.storage.local.set({ [storageKey]: storageValue }), 500);
+  };
+
+  connectedCallback () { this.#inputElement.addEventListener('input', this.#onInput); }
+  disconnectedCallback () { this.#inputElement.removeEventListener('input', this.#onInput); }
+}
+
+customElements.define(localName, TextPreferenceElement);
+
+/**
+ * @typedef TextPreferenceProps
+ * @property {string} featureName The feature's internal name (e.g. `"quick_tags"`).
+ * @property {string} preferenceName The preference's internal name (e.g. `"originalPostTag"`).
+ * @property {string} label The preference's label (e.g. `"Original post tag"`).
+ * @property {string} value The preference's current value (as set by the user, or the preference's default).
+ */
+
+/** @type {(props: TextPreferenceProps) => TextPreferenceElement} */
+export const TextPreference = (props = {}) => Object.assign(document.createElement(localName), props);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #1831 
- relates to #2055 

Creates a `TextPreferenceElement` class and `TextPreference` shorthand function, for rendering text-type preferences.

Like `CheckboxPreference`, this doesn't implement any usages of the new component, just the component itself.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Download and apply this patch to enable rendering the component: [text-preference.patch](https://github.com/user-attachments/files/24801147/text-preference.patch)
3. Load the modified addon
4. Open a Tumblr tab, and keep it visible
5. Open the XKit control panel and enable TimeFormat
    - **Expected result**: The text-type "Format" preference don't look broken
    - **Expected result**: The text-type "Format" preference is pre-filled with its default value
6. Without copy-pasting, change the "Format" preference from `MMM D, YYYY - h:mm A` to `Do MMM, YYYY`
    - **Expected result**: Changes to the preference _are not_ reflected immediately after every keystroke
    - **Expected result**: Changes to the preference _are_ reflected when keystrokes stop for a half-second
7. Open the control panel in a new tab
8. Open the preferences for Quick Reblog and Quick Tags
9. Enable responsive design mode
    - **Expected result**: 🆕 When making the viewport smaller, the labels for text preferences stay on one line, and only the text box shrinks to fit
    - **Expected result**: 🆕 When making the viewport wider, the width of text preference inputs caps out at ~240px instead of growing infinitely

