### PR TITLE
perf: use element IDs and ARIA relations to initialise preference components

### DIFF
--- a/src/action/components/checkbox-preference/index.js
+++ b/src/action/components/checkbox-preference/index.js
@@ -38,8 +38,7 @@ class CheckboxPreferenceElement extends CustomElement {
   set value (value = false) { this.#inputElement.checked = value; }
   get value () { return this.#inputElement.checked; }
 
-  /** @type {(event: Event) => void} */
-  #onChange = () => {
+  /** @type {(event: Event) => void} */ #onChange = () => {
     const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
     const storageValue = this.#inputElement.checked;
 

--- a/src/action/components/text-preference/index.js
+++ b/src/action/components/text-preference/index.js
@@ -39,8 +39,7 @@ class TextPreferenceElement extends CustomElement {
   set value (value = '') { this.#inputElement.value = value; }
   get value () { return this.#inputElement.value; }
 
-  /** @type {(event: InputEvent) => void} */
-  #onInput = () => {
+  /** @type {(event: InputEvent) => void} */ #onInput = () => {
     const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
     const storageValue = this.#inputElement.value;
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #2055 
- relates to #2075 

Using `querySelector` unnecessarily makes me feel like I'm doing something wrong.

These components already take advantage of their DOM being sandboxed in terms of how they use `id` and `for` attributes. We might as well make further use of this and avoid interacting with the CSS engine when initialising the element references.

At least, I think `getElementById` is faster than `querySelector`. At the scale we're working at, this shouldn't be a perceptible change to anyone either way.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Apply this patch to enable rendering components for checkbox/text-type preferences: [preference-components.patch](https://github.com/user-attachments/files/24910313/preference-components.patch)
3. Open the XKit control panel and expand Quick Reblog's and TimeFormat's preferences
    - **Expected result**: Checkbox-type preferences render with correct labels and initial checked states
    - **Expected result**: Changes to checkbox-type preferences are reflected in the Backup tab
    - **Expected result**: Text-type preferences render with correct labels and initial values
    - **Expected result**: Changes to text-type preferences are reflected in the Backup tab
