### PR TITLE
fix: assign default ARIA roles to preference components

### DIFF
--- a/src/action/components/checkbox-preference/index.css
+++ b/src/action/components/checkbox-preference/index.css
@@ -1,4 +1,4 @@
-li {
+:host {
   display: flex;
   align-items: flex-start;
   column-gap: 8px;

--- a/src/action/components/checkbox-preference/index.js
+++ b/src/action/components/checkbox-preference/index.js
@@ -4,10 +4,8 @@ const localName = 'checkbox-preference';
 
 const templateDocument = new DOMParser().parseFromString(`
   <template id="${localName}">
-    <li>
-      <input id="checkbox" type="checkbox">
-      <label for="checkbox"></label>
-    </li>
+    <input id="checkbox" type="checkbox">
+    <label for="checkbox"></label>
   </template>
 `, 'text/html');
 

--- a/src/action/components/text-preference/index.css
+++ b/src/action/components/text-preference/index.css
@@ -1,4 +1,4 @@
-li {
+:host {
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/action/components/text-preference/index.js
+++ b/src/action/components/text-preference/index.js
@@ -4,10 +4,8 @@ const localName = 'text-preference';
 
 const templateDocument = new DOMParser().parseFromString(`
   <template id="${localName}">
-    <li>
-      <label for="text"></label>
-      <input id="text" type="text" size="28" spellcheck="false">
-    </li>
+    <label for="text"></label>
+    <input id="text" type="text" size="28" spellcheck="false">
   </template>
 `, 'text/html');
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #2055 
- relates to #2075

Something I didn't realise until yesterday: custom elements containers do actually exist in the accessibility tree! They just don't have any inherent semantic meaning, so it kinda just looks like they are their children... except, in our case, they're a barrier between the preference list `<ul>` elements and the shadowRoot-hosted `<li>` elements, which breaks the semantic meaning of `<li>`.

If the custom element is trying to render a list item, it actually needs to try to _be_ a list item.

Before | After
-|-
<img width="413" height="165" alt="Screenshot 2026-01-29 at 10 06 54 am" src="https://github.com/user-attachments/assets/7e7a56ed-3045-4efe-82cd-9c0dff2ede5e" /> | <img width="413" height="124" alt="Screenshot 2026-01-29 at 10 07 21 am" src="https://github.com/user-attachments/assets/38d45b84-7dd9-44e4-9aff-dba96a2d92cd" />

This also lets us remove the `<li>` elements from preference components entirely, since we can style the container via `:host` instead.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Enable rendering preference components: [preference-components.patch](https://github.com/user-attachments/files/24933470/preference-components.patch)
3. Load the modified addon in Firefox (does Chrome have A11Y tree devtools yet?)
4. Open the XKit control panel in a new tab
5. Browse the accessibility tree for features with checkbox/text-type preferences
    - **Expected result**: Every checkbox-type preference is detected as a list item
    - **Expected result**: Every text-type preference is detected as a list item
