### PR TITLE
feat: add `TextAreaPreference` component

### DIFF
--- a/src/action/components/textarea-preference/index.css
+++ b/src/action/components/textarea-preference/index.css
@@ -1,0 +1,29 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  row-gap: 6px;
+  padding: 4px;
+}
+
+label {
+  align-self: flex-start;
+}
+
+textarea {
+  align-self: stretch;
+
+  box-sizing: border-box;
+  padding: 4px;
+  border: none;
+  border-radius: 3px;
+  resize: none;
+
+  background-color: rgb(var(--passive-grey));
+  color: rgb(var(--black));
+  scrollbar-color: rgba(var(--black), 0.5) rgb(var(--passive-grey));
+  scrollbar-width: thin;
+}
+
+textarea:focus {
+  background-color: rgb(var(--active-grey));
+}

--- a/src/action/components/textarea-preference/index.js
+++ b/src/action/components/textarea-preference/index.js
@@ -1,0 +1,69 @@
+import { CustomElement, fetchStyleSheets } from '../index.js';
+
+const localName = 'textarea-preference';
+
+const templateDocument = new DOMParser().parseFromString(`
+  <template id="${localName}">
+    <label for="textarea"></label>
+    <textarea id="textarea" rows="5" spellcheck="false"></textarea>
+  </template>
+`, 'text/html');
+
+const adoptedStyleSheets = await fetchStyleSheets([
+  '/lib/normalize.min.css',
+  './index.css',
+].map(import.meta.resolve));
+
+class TextAreaPreferenceElement extends CustomElement {
+  /** @type {string} */ featureName;
+  /** @type {string} */ preferenceName;
+
+  /** @type {HTMLTextAreaElement} */ #textAreaElement;
+  /** @type {HTMLLabelElement}    */ #labelElement;
+  /** @type {ReturnType<Window['setTimeout']>} */ #timeoutID;
+
+  constructor () {
+    super(templateDocument, adoptedStyleSheets);
+
+    this.#textAreaElement = this.shadowRoot.getElementById('textarea');
+    this.#labelElement = this.#textAreaElement.labels[0];
+  }
+
+  /** @param {string} label Label displayed to the user to describe the preference. */
+  set label (label) { this.#labelElement.textContent = label; }
+  get label () { return this.#labelElement.textContent; }
+
+  /** @param {string} value The saved or default value of this preference. */
+  set value (value = '') { this.#textAreaElement.value = value; }
+  get value () { return this.#textAreaElement.value; }
+
+  /** @type {(event: InputEvent) => void} */ #onInput = () => {
+    const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
+    const storageValue = this.#textAreaElement.value;
+
+    clearTimeout(this.#timeoutID);
+    this.#timeoutID = setTimeout(() => browser.storage.local.set({ [storageKey]: storageValue }), 500);
+  };
+
+  connectedCallback () {
+    this.role ??= 'listitem';
+    this.#textAreaElement.addEventListener('input', this.#onInput);
+  }
+
+  disconnectedCallback () {
+    this.#textAreaElement.removeEventListener('input', this.#onInput);
+  }
+}
+
+customElements.define(localName, TextAreaPreferenceElement);
+
+/**
+ * @typedef TextAreaPreferenceProps
+ * @property {string} featureName The feature's internal name (e.g. `"show_originals"`).
+ * @property {string} preferenceName The preference's internal name (e.g. `"whitelistedUsernames"`).
+ * @property {string} label The preference's label (e.g. `"Always show reblogs from these blogs (comma-separated)"`).
+ * @property {string} value The preference's current value (as set by the user, or the preference's default).
+ */
+
+/** @type {(props: TextAreaPreferenceProps) => TextAreaPreferenceElement} */
+export const TextAreaPreference = (props = {}) => Object.assign(document.createElement(localName), props);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #1831
- relates to #2055
- relates to #2075

Creates a `TextAreaPreferenceElement` class and `TextAreaPreference` shorthand function, for rendering textarea-type preferences.

Like previous preference components, this PR does not implement any usages of the component, just the component itself.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Download and apply this patch: [textarea-component.patch](https://github.com/user-attachments/files/25044360/textarea-component.patch)
3. Load the modified addon
4. Open a Tumblr tab, and keep it visible
5. Open the XKit control panel and enable CleanFeed
    - **Expected result**: The textarea-type preferences do not look broken
    - **Expected result**: The "Treat these tags as mature" preference is pre-filled with its default value of `"nsfw, nsft"`
6. Change your CleanFeed preferences to blur and unblur posts on your dashboard
    - **Expected result**: Changes to textarea preferences _are not_ reflected immediately after every keystroke
    - **Expected result**: Changes to textarea preferences _are_ reflected when keystrokes stop for a half-second

