### PR TITLE
feat: add `ColorPreference` component

### DIFF
--- a/src/action/components/color-preference/index.css
+++ b/src/action/components/color-preference/index.css
@@ -1,0 +1,34 @@
+:host {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  column-gap: 8px;
+  padding: 4px;
+}
+
+span {
+  display: contents;
+}
+
+label,
+.clr-field {
+  flex-shrink: 0;
+}
+
+button {
+  border-top-right-radius: 3px;
+  border-bottom-right-radius: 3px;
+}
+
+input {
+  padding: 4px;
+  border: none;
+  border-radius: 3px;
+
+  background-color: rgb(var(--passive-grey));
+  color: rgb(var(--black));
+}
+
+input:focus {
+  background-color: rgb(var(--active-grey));
+}

--- a/src/action/components/color-preference/index.js
+++ b/src/action/components/color-preference/index.js
@@ -1,0 +1,82 @@
+import { CustomElement, fetchStyleSheets } from '../index.js';
+import Coloris from '../../../lib/coloris.js';
+
+const localName = 'color-preference';
+
+const templateDocument = new DOMParser().parseFromString(`
+  <template id="${localName}">
+    <span>
+      <input id="color" type="text" size="10" spellcheck="false">
+    </span>
+    <label for="color"></label>
+  </template>
+`, 'text/html');
+
+const adoptedStyleSheets = await fetchStyleSheets([
+  '/lib/coloris.css',
+  '/lib/normalize.min.css',
+  './index.css',
+].map(import.meta.resolve));
+
+class ColorPreferenceElement extends CustomElement {
+  /** @type {string} */ featureName;
+  /** @type {string} */ preferenceName;
+
+  /** @type {HTMLInputElement} */ #inputElement;
+  /** @type {HTMLLabelElement} */ #labelElement;
+
+  constructor () {
+    super(templateDocument, adoptedStyleSheets);
+
+    this.#inputElement = this.shadowRoot.getElementById('color');
+    this.#labelElement = this.#inputElement.labels[0];
+
+    Coloris.init(); // eslint-disable-line import-x/no-named-as-default-member
+  }
+
+  /** @param {string} label Label displayed to the user to describe the preference. */
+  set label (label) { this.#labelElement.textContent = label; }
+  get label () { return this.#labelElement.textContent; }
+
+  /** @param {string} value The saved or default value of this preference. */
+  set value (value = '') { this.#inputElement.value = value; }
+  get value () { return this.#inputElement.value; }
+
+  /** @type {(event: Event) => void} */ #onChange = () => {
+    const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
+    const storageValue = this.#inputElement.value;
+
+    browser.storage.local.set({ [storageKey]: storageValue });
+  };
+
+  connectedCallback () {
+    this.role ??= 'listitem';
+    this.#inputElement.addEventListener('change', this.#onChange);
+
+    Coloris({
+      alpha: false,
+      clearButton: true,
+      closeButton: true,
+      el: this.#inputElement,
+      swatches: ['#ff4930', '#ff8a00', '#00cf35', '#00b8ff', '#7c5cff', '#ff62ce'],
+      themeMode: 'auto',
+    });
+  }
+
+  disconnectedCallback () {
+    this.#inputElement.removeEventListener('change', this.#onChange);
+  }
+}
+
+customElements.define(localName, ColorPreferenceElement);
+
+/**
+ * @typedef {object} ColorPreferenceProps
+ * @property {string} featureName The feature's internal name (e.g. `"painter"`).
+ * @property {string} preferenceName The preference's internal name (e.g. `"reblogColour"`).
+ * @property {string} label The preference's label (e.g. `"Reblogged post colour"`).
+ * @property {boolean} value The preference's current value (as set by the user, or the preference's default).
+ */
+
+/** @type {(props: ColorPreferenceProps) => ColorPreferenceElement} */
+export const ColorPreference = (props = {}) => Object.assign(document.createElement(localName), props);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #1831
- relates to #2055
- relates to #2075
- relates to #2086

Creates a `ColorPreferenceElement` class and `ColorPreference` shorthand function, for rendering colour-type preferences.

Like previous preference components, this PR does not implement any usages of the component, just the component itself.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Apply this patch: [color-preference.patch](https://github.com/user-attachments/files/25070867/color-preference.patch)
3. Load the modified addon
4. Open a Tumblr tab and keep it visible
5. Open the XKit control panel and enable Painter
    - **Expected result**: Colour-type preferences render without issue
6. Change Painter's colour-type preferences
    - **Expected result**: Colour-type preference changes are finalised only upon closing the Coloris colour picker
    - **Expected result**: Colour-type preference changes are reflected immediately upon being finalised
