### PR TITLE
chore(UI): Standardise "colour" spelling in UI

### DIFF
--- a/src/features/accesskit/feature.json
+++ b/src/features/accesskit/feature.json
@@ -7,7 +7,7 @@
     "background_color": "#df46f6"
   },
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#accesskit",
-  "relatedTerms": [ "Disable GIFs" ],
+  "relatedTerms": [ "Disable GIFs", "colors" ],
   "preferences": {
     "disable_gifs": {
       "type": "checkbox",

--- a/src/features/painter/feature.json
+++ b/src/features/painter/feature.json
@@ -6,6 +6,7 @@
     "color": "white",
     "background_color": "#4bb51b"
   },
+  "relatedTerms": [ "color" ],
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#painter",
   "preferences": {
     "ownColour": {

--- a/src/features/themed_posts/feature.json
+++ b/src/features/themed_posts/feature.json
@@ -6,6 +6,7 @@
     "color": "white",
     "background_color": "peru"
   },
+  "relatedTerms": [ "colors" ],
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#themed-posts",
   "preferences": {
     "reblogTrailTheming": {

--- a/src/features/tweaks/feature.json
+++ b/src/features/tweaks/feature.json
@@ -9,7 +9,8 @@
   "help": "https://github.com/AprilSylph/XKit-Rewritten/wiki/Features#tweaks",
   "relatedTerms": [
     "Blacklist",
-    "Separator"
+    "Separator",
+    "colored"
   ],
   "preferences": {
     "restore_attribution_links": {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This uses "colour" as the spelling in visible UI, and makes sure that "color" can also be used as a search keyword.

This doesn't fix preference highlighting, which could be done by adding a relatedTerms field to individual options (I did not do this because you are refactoring them) or by building a dictionary of alternative search strings into the search function itself (a lot of code for not a lot of value).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that "color" and "colour" searches cause the same features to be shown in the configuration UI.