### PR TITLE
feat: add `SelectPreference` component

### DIFF
--- a/src/action/components/select-preference/index.css
+++ b/src/action/components/select-preference/index.css
@@ -1,0 +1,29 @@
+:host {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  column-gap: 8px;
+  padding: 4px;
+}
+
+label {
+  flex-shrink: 0;
+}
+
+select {
+  flex-shrink: 1;
+
+  box-sizing: border-box;
+  padding: 4px;
+  border: none;
+  border-radius: 3px;
+  overflow: hidden;
+
+  background-color: rgb(var(--passive-grey));
+  color: rgb(var(--black));
+  text-overflow: ellipsis;
+}
+
+select:focus {
+  background-color: rgb(var(--active-grey));
+}

--- a/src/action/components/select-preference/index.js
+++ b/src/action/components/select-preference/index.js
@@ -1,0 +1,80 @@
+import { CustomElement, fetchStyleSheets } from '../index.js';
+
+const localName = 'select-preference';
+
+const templateDocument = new DOMParser().parseFromString(`
+  <template id="${localName}">
+    <label for="select"></label>
+    <select id="select"></select>
+  </template>
+`, 'text/html');
+
+const adoptedStyleSheets = await fetchStyleSheets([
+  '/lib/normalize.min.css',
+  './index.css',
+].map(import.meta.resolve));
+
+/** @typedef {{ label: string, value: string }} Option */
+
+/** @type {(option: Option) => HTMLOptionElement} */
+const createOptionElement = ({ label, value }) => Object.assign(document.createElement('option'), { textContent: label, value });
+
+/** @type {(optionElement: HTMLOptionElement) => Option} */
+const getOptionObject = ({ textContent, value }) => ({ label: textContent, value });
+
+class SelectPreferenceElement extends CustomElement {
+  /** @type {string} */ featureName;
+  /** @type {string} */ preferenceName;
+
+  /** @type {HTMLSelectElement} */ #selectElement;
+  /** @type {HTMLLabelElement}  */ #labelElement;
+
+  constructor () {
+    super(templateDocument, adoptedStyleSheets);
+
+    this.#selectElement = this.shadowRoot.getElementById('select');
+    this.#labelElement = this.#selectElement.labels[0];
+  }
+
+  /** @param {string} label Label displayed to the user to describe the preference. */
+  set label (label) { this.#labelElement.textContent = label; }
+  get label () { return this.#labelElement.textContent; }
+
+  /** @param {Option[]} options List of options for the user to choose between. */
+  set options (options = []) { this.#selectElement.replaceChildren(...options.map(createOptionElement)); }
+  get options () { return [...this.#selectElement.options].map(getOptionObject); }
+
+  /** @param {string} value The saved or default value of this preference. Must match one of the `options` item's `value`. */
+  set value (value = '') { this.#selectElement.value = value; }
+  get value () { return this.#selectElement.value; }
+
+  /** @type {(event: Event) => void} */ #onChange = () => {
+    const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
+    const storageValue = this.#selectElement.value;
+
+    browser.storage.local.set({ [storageKey]: storageValue });
+  };
+
+  connectedCallback () {
+    this.role ??= 'listitem';
+    this.#selectElement.addEventListener('change', this.#onChange);
+  }
+
+  disconnectedCallback () {
+    this.#selectElement.removeEventListener('change', this.#onChange);
+  }
+}
+
+customElements.define(localName, SelectPreferenceElement);
+
+/**
+ * @typedef SelectPreferenceProps
+ * @property {string} featureName The feature's internal name (e.g. `"vanilla_audio"`).
+ * @property {string} preferenceName The preference's internal name (e.g. `"defaultVolume"`).
+ * @property {string} label The preference's label (e.g. `"Default Volume"`).
+ * @property {Option[]} options List of options for the user to choose between.
+ * @property {string} value The preference's current value (as set by the user, or the preference's default). Must match one of the `options` item's `value`.
+ */
+
+/** @type {(props: SelectPreferenceProps) => SelectPreferenceElement} */
+export const SelectPreference = (props = {}) => Object.assign(document.createElement(localName), props);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #1831
- relates to #2055
- relates to #2075
- relates to #2086
- relates to #2089

Creates a `SelectPreferenceElement` class and `SelectPreference` shorthand function, for rendering colour-type preferences.

Like previous preference components, this PR does not implement any usages of the component, just the component itself.

This one was fun, because I found out that setting `HTMLSelectElement.value` does actually work, provided it matches the `value` of one of the `<option>` elements. I've opted to keep the code simple by leveraging this, which does come at the cost of component instances needing to set `options` before setting its own `value`, but I think that's fine—the JSdoc already says that `value` must match one of the `options`.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Apply this patch: [select-preference.patch](https://github.com/user-attachments/files/25094323/select-preference.patch)
3. Load the modified addon
4. Open the XKit control panel and enable Vanilla Audio
    - **Expected result**: The "Default Volume" preference renders without issue
    - **Expected result**: The "Default Volume" preference renders showing **100%** selected, which is notably not the first option in the list
5. Change a select-type preference in any feature
    - **Expected result**: The changed preference value is reflected in the Backup tab
6. Close and reopen the XKit control panel
    - **Expected result**: Any changed select-type preferences render showing their saved value selected, instead of their default
