### PR TITLE
style: alphabetise all imports

### DIFF
--- a/src/action/components/color-preference/index.js
+++ b/src/action/components/color-preference/index.js
@@ -1,5 +1,5 @@
-import { CustomElement, fetchStyleSheets } from '../index.js';
 import Coloris from '../../../lib/coloris.js';
+import { CustomElement, fetchStyleSheets } from '../index.js';
 
 const localName = 'color-preference';
 

--- a/src/action/components/xkit-feature/index.js
+++ b/src/action/components/xkit-feature/index.js
@@ -1,5 +1,5 @@
-import { CustomElement, fetchStyleSheets } from '../index.js';
 import Coloris from '../../../lib/coloris.js';
+import { CustomElement, fetchStyleSheets } from '../index.js';
 
 const localName = 'xkit-feature';
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -1,9 +1,9 @@
-import { pageModifications } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
 import { canvas, div } from '../../utils/dom.js';
 import { buildStyle, postSelector } from '../../utils/interface.js';
-import { getPreferences } from '../../utils/preferences.js';
 import { memoize } from '../../utils/memoize.js';
+import { pageModifications } from '../../utils/mutations.js';
+import { getPreferences } from '../../utils/preferences.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
 const pausedPosterAttribute = 'data-paused-gif-use-poster';

--- a/src/features/classic_search/index.js
+++ b/src/features/classic_search/index.js
@@ -1,5 +1,5 @@
-import { getPreferences } from '../../utils/preferences.js';
 import { pageModifications } from '../../utils/mutations.js';
+import { getPreferences } from '../../utils/preferences.js';
 import { navigate } from '../../utils/tumblr_helpers.js';
 
 let newTab;

--- a/src/features/cleanfeed/index.js
+++ b/src/features/cleanfeed/index.js
@@ -1,9 +1,9 @@
-import { onNewPosts } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle, filterPostElements } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
-import { timelineObject } from '../../utils/react_props.js';
+import { onNewPosts } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
+import { timelineObject } from '../../utils/react_props.js';
 
 export const styleElement = buildStyle();
 

--- a/src/features/collapsed_queue/index.js
+++ b/src/features/collapsed_queue/index.js
@@ -1,9 +1,9 @@
-import { filterPostElements } from '../../utils/interface.js';
-import { getPreferences } from '../../utils/preferences.js';
-import { onNewPosts } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
-import { anyQueueTimelineFilter, anyDraftsTimelineFilter } from '../../utils/timeline_id.js';
 import { div } from '../../utils/dom.js';
+import { filterPostElements } from '../../utils/interface.js';
+import { onNewPosts } from '../../utils/mutations.js';
+import { getPreferences } from '../../utils/preferences.js';
+import { anyQueueTimelineFilter, anyDraftsTimelineFilter } from '../../utils/timeline_id.js';
 
 const wrapperClass = 'xkit-collapsed-queue-wrapper';
 const containerClass = 'xkit-collapsed-queue-container';

--- a/src/features/hide_avatars/index.js
+++ b/src/features/hide_avatars/index.js
@@ -1,6 +1,6 @@
-import { getPreferences } from '../../utils/preferences.js';
-import { translate } from '../../utils/language_data.js';
 import { buildStyle } from '../../utils/interface.js';
+import { translate } from '../../utils/language_data.js';
+import { getPreferences } from '../../utils/preferences.js';
 
 export const styleElement = buildStyle();
 

--- a/src/features/limit_checker/index.js
+++ b/src/features/limit_checker/index.js
@@ -1,7 +1,7 @@
-import { apiFetch } from '../../utils/tumblr_helpers.js';
-import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
-import { modalCompleteButton, showErrorModal, showModal } from '../../utils/modals.js';
 import { dom } from '../../utils/dom.js';
+import { modalCompleteButton, showErrorModal, showModal } from '../../utils/modals.js';
+import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
+import { apiFetch } from '../../utils/tumblr_helpers.js';
 
 const dateTimeFormat = new Intl.DateTimeFormat(document.documentElement.lang, { dateStyle: 'short', timeStyle: 'short' });
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));

--- a/src/features/mass_unliker/index.js
+++ b/src/features/mass_unliker/index.js
@@ -1,7 +1,7 @@
-import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
-import { showModal, modalCancelButton, modalCompleteButton, showErrorModal } from '../../utils/modals.js';
-import { apiFetch } from '../../utils/tumblr_helpers.js';
 import { dom } from '../../utils/dom.js';
+import { showModal, modalCancelButton, modalCompleteButton, showErrorModal } from '../../utils/modals.js';
+import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
+import { apiFetch } from '../../utils/tumblr_helpers.js';
 
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 

--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -1,13 +1,13 @@
+import { keyToCss } from '../../utils/css_map.js';
+import { dom } from '../../utils/dom.js';
 import { buildStyle, getTimelineItemWrapper, filterPostElements, getPopoverWrapper, notificationSelector } from '../../utils/interface.js';
+import { translate } from '../../utils/language_data.js';
+import { onNewPosts, onNewNotifications, pageModifications } from '../../utils/mutations.js';
+import { getPreferences } from '../../utils/preferences.js';
 import { blogData, notificationObject, timelineObject } from '../../utils/react_props.js';
+import { followingTimelineSelector } from '../../utils/timeline_id.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
 import { primaryBlogName } from '../../utils/user.js';
-import { keyToCss } from '../../utils/css_map.js';
-import { onNewPosts, onNewNotifications, pageModifications } from '../../utils/mutations.js';
-import { dom } from '../../utils/dom.js';
-import { getPreferences } from '../../utils/preferences.js';
-import { translate } from '../../utils/language_data.js';
-import { followingTimelineSelector } from '../../utils/timeline_id.js';
 
 const mutualIconClass = 'xkit-mutual-icon';
 const hiddenAttribute = 'data-mutual-checker-hidden';

--- a/src/features/no_recommended/hide_radar.js
+++ b/src/features/no_recommended/hide_radar.js
@@ -1,6 +1,6 @@
-import { pageModifications } from '../../utils/mutations.js';
-import { translate } from '../../utils/language_data.js';
 import { buildStyle } from '../../utils/interface.js';
+import { translate } from '../../utils/language_data.js';
+import { pageModifications } from '../../utils/mutations.js';
 
 const hiddenAttribute = 'data-no-recommended-radar-hidden';
 

--- a/src/features/no_recommended/hide_recommended_blogs.js
+++ b/src/features/no_recommended/hide_recommended_blogs.js
@@ -1,7 +1,7 @@
 import { keyToCss } from '../../utils/css_map.js';
-import { pageModifications } from '../../utils/mutations.js';
-import { translate } from '../../utils/language_data.js';
 import { blogViewSelector, buildStyle } from '../../utils/interface.js';
+import { translate } from '../../utils/language_data.js';
+import { pageModifications } from '../../utils/mutations.js';
 
 const hiddenAttribute = 'data-no-recommended-blogs-hidden';
 

--- a/src/features/no_recommended/hide_recommended_blogs_modal.js
+++ b/src/features/no_recommended/hide_recommended_blogs_modal.js
@@ -1,6 +1,6 @@
 import { keyToCss } from '../../utils/css_map.js';
-import { pageModifications } from '../../utils/mutations.js';
 import { blogViewSelector, buildStyle } from '../../utils/interface.js';
+import { pageModifications } from '../../utils/mutations.js';
 
 const hiddenAttribute = 'data-no-recommended-blogs-modal-hidden';
 

--- a/src/features/notificationblock/index.js
+++ b/src/features/notificationblock/index.js
@@ -1,11 +1,11 @@
+import { dom } from '../../utils/dom.js';
 import { buildStyle } from '../../utils/interface.js';
 import { registerMeatballItem, unregisterMeatballItem } from '../../utils/meatballs.js';
-import { onNewNotifications } from '../../utils/mutations.js';
 import { showModal, hideModal, modalCancelButton } from '../../utils/modals.js';
-import { dom } from '../../utils/dom.js';
-import { userBlogNames } from '../../utils/user.js';
-import { apiFetch } from '../../utils/tumblr_helpers.js';
+import { onNewNotifications } from '../../utils/mutations.js';
 import { notificationObject } from '../../utils/react_props.js';
+import { apiFetch } from '../../utils/tumblr_helpers.js';
+import { userBlogNames } from '../../utils/user.js';
 
 const storageKey = 'notificationblock.blockedPostTargetIDs';
 const meatballButtonBlockId = 'notificationblock-block';

--- a/src/features/painter/index.js
+++ b/src/features/painter/index.js
@@ -1,8 +1,8 @@
 import { filterPostElements } from '../../utils/interface.js';
+import { onNewPosts } from '../../utils/mutations.js';
+import { getPreferences } from '../../utils/preferences.js';
 import { timelineObject } from '../../utils/react_props.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
-import { getPreferences } from '../../utils/preferences.js';
-import { onNewPosts } from '../../utils/mutations.js';
 
 let ownColour;
 let originalColour;

--- a/src/features/postblock/index.js
+++ b/src/features/postblock/index.js
@@ -1,9 +1,9 @@
+import { dom } from '../../utils/dom.js';
 import { getTimelineItemWrapper, filterPostElements } from '../../utils/interface.js';
 import { registerMeatballItem, unregisterMeatballItem } from '../../utils/meatballs.js';
 import { showModal, hideModal, modalCancelButton } from '../../utils/modals.js';
-import { timelineObject } from '../../utils/react_props.js';
 import { onNewPosts, pageModifications } from '../../utils/mutations.js';
-import { dom } from '../../utils/dom.js';
+import { timelineObject } from '../../utils/react_props.js';
 
 const meatballButtonId = 'postblock';
 const meatballButtonLabel = 'Block this post';

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -1,15 +1,15 @@
 import { sha256 } from '../../utils/crypto.js';
-import { timelineObject } from '../../utils/react_props.js';
-import { apiFetch } from '../../utils/tumblr_helpers.js';
+import { keyToCss } from '../../utils/css_map.js';
+import { div, select, input, fieldset, button, option, hr, span } from '../../utils/dom.js';
 import { postSelector, filterPostElements, postType, appendWithoutOverflow, buildStyle } from '../../utils/interface.js';
-import { joinedCommunities, joinedCommunityUuids, primaryBlog, userBlogs } from '../../utils/user.js';
-import { getPreferences } from '../../utils/preferences.js';
+import { showErrorModal } from '../../utils/modals.js';
 import { onNewPosts } from '../../utils/mutations.js';
 import { notify } from '../../utils/notifications.js';
-import { div, select, input, fieldset, button, option, hr, span } from '../../utils/dom.js';
-import { showErrorModal } from '../../utils/modals.js';
-import { keyToCss } from '../../utils/css_map.js';
 import { popoverStackingContextFix } from '../../utils/post_popovers.js';
+import { getPreferences } from '../../utils/preferences.js';
+import { timelineObject } from '../../utils/react_props.js';
+import { apiFetch } from '../../utils/tumblr_helpers.js';
+import { joinedCommunities, joinedCommunityUuids, primaryBlog, userBlogs } from '../../utils/user.js';
 
 // Clean up previous instance after addon reload
 document.getElementById('quick-reblog')?.remove();

--- a/src/features/quote_replies/index.js
+++ b/src/features/quote_replies/index.js
@@ -1,8 +1,8 @@
 import { keyToCss } from '../../utils/css_map.js';
 import { dom } from '../../utils/dom.js';
 import { inject } from '../../utils/inject.js';
-import { showErrorModal } from '../../utils/modals.js';
 import { buildStyle, displayInlineFlexUnlessDisabledAttr, notificationSelector } from '../../utils/interface.js';
+import { showErrorModal } from '../../utils/modals.js';
 import { pageModifications } from '../../utils/mutations.js';
 import { notify } from '../../utils/notifications.js';
 import { getPreferences } from '../../utils/preferences.js';

--- a/src/features/scroll_to_bottom/index.js
+++ b/src/features/scroll_to_bottom/index.js
@@ -1,7 +1,7 @@
 import { keyToClasses, keyToCss } from '../../utils/css_map.js';
+import { buildStyle, displayBlockUnlessDisabledAttr } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
 import { pageModifications } from '../../utils/mutations.js';
-import { buildStyle, displayBlockUnlessDisabledAttr } from '../../utils/interface.js';
 
 const scrollToBottomButtonId = 'xkit-scroll-to-bottom-button';
 $(`[id="${scrollToBottomButtonId}"]`).remove();

--- a/src/features/seen_posts/index.js
+++ b/src/features/seen_posts/index.js
@@ -1,7 +1,7 @@
-import { filterPostElements, getTimelineItemWrapper, postSelector } from '../../utils/interface.js';
-import { getPreferences } from '../../utils/preferences.js';
-import { onNewPosts, pageModifications } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
+import { filterPostElements, getTimelineItemWrapper, postSelector } from '../../utils/interface.js';
+import { onNewPosts, pageModifications } from '../../utils/mutations.js';
+import { getPreferences } from '../../utils/preferences.js';
 import { followingTimelineFilter, followingTimelineSelector, timelineSelector } from '../../utils/timeline_id.js';
 
 const excludeAttribute = 'data-seen-posts-done';

--- a/src/features/shorten_posts/index.js
+++ b/src/features/shorten_posts/index.js
@@ -1,8 +1,8 @@
+import { keyToCss } from '../../utils/css_map.js';
+import { dom } from '../../utils/dom.js';
 import { buildStyle, filterPostElements, postSelector } from '../../utils/interface.js';
 import { onNewPosts } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
-import { keyToCss } from '../../utils/css_map.js';
-import { dom } from '../../utils/dom.js';
 
 let showTags;
 let maxHeight;

--- a/src/features/show_originals/index.js
+++ b/src/features/show_originals/index.js
@@ -1,10 +1,10 @@
-import { filterPostElements, getTimelineItemWrapper } from '../../utils/interface.js';
-import { isMyPost, timelineObject } from '../../utils/react_props.js';
-import { getPreferences } from '../../utils/preferences.js';
-import { onNewPosts } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
+import { a, div } from '../../utils/dom.js';
+import { filterPostElements, getTimelineItemWrapper } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
-import { userBlogs } from '../../utils/user.js';
+import { onNewPosts } from '../../utils/mutations.js';
+import { getPreferences } from '../../utils/preferences.js';
+import { isMyPost, timelineObject } from '../../utils/react_props.js';
 import {
   followingTimelineFilter,
   anyBlogPostsTimelineFilter,
@@ -14,7 +14,7 @@ import {
   anyCommunityTimelineFilter,
   communitiesTimelineFilter,
 } from '../../utils/timeline_id.js';
-import { a, div } from '../../utils/dom.js';
+import { userBlogs } from '../../utils/user.js';
 
 const hiddenAttribute = 'data-show-originals-hidden';
 const lengthenedClass = 'xkit-show-originals-lengthened';

--- a/src/features/tag_tracking_plus/index.js
+++ b/src/features/tag_tracking_plus/index.js
@@ -1,10 +1,10 @@
-import { apiFetch, onClickNavigate } from '../../utils/tumblr_helpers.js';
 import { filterPostElements } from '../../utils/interface.js';
-import { timelineObject } from '../../utils/react_props.js';
 import { onNewPosts } from '../../utils/mutations.js';
-import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
 import { getPreferences } from '../../utils/preferences.js';
+import { timelineObject } from '../../utils/react_props.js';
+import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
 import { tagTimelineFilter } from '../../utils/timeline_id.js';
+import { apiFetch, onClickNavigate } from '../../utils/tumblr_helpers.js';
 
 const storageKey = 'tag_tracking_plus.trackedTagTimestamps';
 let timestamps;

--- a/src/features/themed_posts/index.js
+++ b/src/features/themed_posts/index.js
@@ -1,8 +1,8 @@
-import { buildStyle, filterPostElements, blogViewSelector, postSelector } from '../../utils/interface.js';
-import { getPreferences } from '../../utils/preferences.js';
-import { onNewPosts } from '../../utils/mutations.js';
-import { timelineObject } from '../../utils/react_props.js';
 import { keyToCss } from '../../utils/css_map.js';
+import { buildStyle, filterPostElements, blogViewSelector, postSelector } from '../../utils/interface.js';
+import { onNewPosts } from '../../utils/mutations.js';
+import { getPreferences } from '../../utils/preferences.js';
+import { timelineObject } from '../../utils/react_props.js';
 
 export const styleElement = buildStyle();
 

--- a/src/features/timestamps/index.js
+++ b/src/features/timestamps/index.js
@@ -1,9 +1,9 @@
+import { keyToCss } from '../../utils/css_map.js';
 import { getPostElements } from '../../utils/interface.js';
-import { timelineObject } from '../../utils/react_props.js';
-import { apiFetch } from '../../utils/tumblr_helpers.js';
 import { onNewPosts } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
-import { keyToCss } from '../../utils/css_map.js';
+import { timelineObject } from '../../utils/react_props.js';
+import { apiFetch } from '../../utils/tumblr_helpers.js';
 
 const noteCountSelector = keyToCss('noteCount');
 const reblogHeaderSelector = keyToCss('reblogHeader');

--- a/src/features/tweaks/create_button_no_bubbles.js
+++ b/src/features/tweaks/create_button_no_bubbles.js
@@ -1,6 +1,6 @@
 import { keyToCss } from '../../utils/css_map.js';
-import { onClickNavigate } from '../../utils/tumblr_helpers.js';
 import { pageModifications } from '../../utils/mutations.js';
+import { onClickNavigate } from '../../utils/tumblr_helpers.js';
 
 const modifiedAttribute = 'data-xkit-tweaks-create-button-no-bubbles';
 

--- a/src/features/tweaks/hide_blocked_blogs.js
+++ b/src/features/tweaks/hide_blocked_blogs.js
@@ -1,7 +1,7 @@
-import { blogTimelineFilter, timelineSelector } from '../../utils/timeline_id.js';
 import { buildStyle, getTimelineItemWrapper, filterPostElements } from '../../utils/interface.js';
-import { isMyPost, timelineObject } from '../../utils/react_props.js';
 import { onNewPosts } from '../../utils/mutations.js';
+import { isMyPost, timelineObject } from '../../utils/react_props.js';
+import { blogTimelineFilter, timelineSelector } from '../../utils/timeline_id.js';
 
 const hiddenAttribute = 'data-xkit-tweaks-hide-blocked-blogs-hidden';
 export const styleElement = buildStyle(`

--- a/src/features/tweaks/hide_filtered_posts.js
+++ b/src/features/tweaks/hide_filtered_posts.js
@@ -1,6 +1,6 @@
-import { pageModifications } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle, getTimelineItemWrapper } from '../../utils/interface.js';
+import { pageModifications } from '../../utils/mutations.js';
 
 const hiddenAttribute = 'data-tweaks-hide-filtered-posts-hidden';
 export const styleElement = buildStyle(`

--- a/src/features/tweaks/hide_liked_posts.js
+++ b/src/features/tweaks/hide_liked_posts.js
@@ -1,5 +1,5 @@
-import { onNewPosts } from '../../utils/mutations.js';
 import { buildStyle, getTimelineItemWrapper, filterPostElements } from '../../utils/interface.js';
+import { onNewPosts } from '../../utils/mutations.js';
 import { isMyPost, timelineObject } from '../../utils/react_props.js';
 import { followingTimelineFilter } from '../../utils/timeline_id.js';
 

--- a/src/features/tweaks/hide_my_posts.js
+++ b/src/features/tweaks/hide_my_posts.js
@@ -1,5 +1,5 @@
-import { onNewPosts } from '../../utils/mutations.js';
 import { buildStyle, getTimelineItemWrapper, filterPostElements } from '../../utils/interface.js';
+import { onNewPosts } from '../../utils/mutations.js';
 import { isMyPost } from '../../utils/react_props.js';
 import { followingTimelineFilter } from '../../utils/timeline_id.js';
 

--- a/src/features/tweaks/restore_attribution_links.js
+++ b/src/features/tweaks/restore_attribution_links.js
@@ -1,8 +1,8 @@
-import { onNewPosts } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
+import { buildStyle, postSelector, trailItemSelector } from '../../utils/interface.js';
+import { onNewPosts } from '../../utils/mutations.js';
 import { timelineObject, trailItem } from '../../utils/react_props.js';
 import { navigate } from '../../utils/tumblr_helpers.js';
-import { buildStyle, postSelector, trailItemSelector } from '../../utils/interface.js';
 
 const headerSelector = `${postSelector} header`;
 const subheaderSelector = `${headerSelector} ${keyToCss('subheader')}`;

--- a/src/features/tweaks/subtle_activity_mutuals.js
+++ b/src/features/tweaks/subtle_activity_mutuals.js
@@ -1,7 +1,7 @@
-import { pageModifications } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
-import { buildStyle } from '../../utils/interface.js';
 import { dom } from '../../utils/dom.js';
+import { buildStyle } from '../../utils/interface.js';
+import { pageModifications } from '../../utils/mutations.js';
 
 const labelSelector = `${keyToCss('activity', 'activityItem')} ${keyToCss('followingBadgeContainer', 'mutualsBadgeContainer')}`;
 

--- a/src/features/vanilla_audio/index.js
+++ b/src/features/vanilla_audio/index.js
@@ -1,6 +1,6 @@
 import { keyToCss } from '../../utils/css_map.js';
-import { getPreferences } from '../../utils/preferences.js';
 import { pageModifications } from '../../utils/mutations.js';
+import { getPreferences } from '../../utils/preferences.js';
 
 const trackInfoSelector = keyToCss('trackInfo');
 

--- a/src/features/vanilla_video/index.js
+++ b/src/features/vanilla_video/index.js
@@ -1,6 +1,6 @@
-import { getPreferences } from '../../utils/preferences.js';
-import { pageModifications } from '../../utils/mutations.js';
 import { keyToCss } from '../../utils/css_map.js';
+import { pageModifications } from '../../utils/mutations.js';
+import { getPreferences } from '../../utils/preferences.js';
 
 const vanillaVideoClass = 'xkit-vanilla-video-player';
 

--- a/src/utils/post_actions.js
+++ b/src/utils/post_actions.js
@@ -1,8 +1,8 @@
-import { buildSvg } from './remixicon.js';
-import { pageModifications } from './mutations.js';
 import { keyToCss } from './css_map.js';
 import { dom } from './dom.js';
 import { displayBlockUnlessDisabledAttr } from './interface.js';
+import { pageModifications } from './mutations.js';
+import { buildSvg } from './remixicon.js';
 
 // Remove outdated post options when loading module
 $('.xkit-post-option').remove();


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
This is the result of setting `'import-x/order': ['warn', { alphabetize: { order: 'asc', caseInsensitive: true } }]` and running our autofix package script.

This does not actually commit any rule changes; figuring out if we should actually enforce this is a different matter to actually doing the formatting, which is already a lot of lines changed!

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
CI passing and this being a net-neutral change is probably good enough as validation.
I've smoke-tested the addon and nothing jumps out to me as broken.
