### PR TITLE
style: enforce `import-x/order` (`alphabetize`, `asc`)

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,11 +27,18 @@ export default [
   { rules: { '@stylistic/comma-dangle': ['warn', 'always-multiline'] } },
 
   /**
-   * Use recommended `import-x` lint rules. Additionally, prevent cyclical imports.
+   * Use recommended `import-x` lint rules; prevent cyclical imports; enforce alphabetical imports.
    * @see https://github.com/un-ts/eslint-plugin-import-x/blob/master/src/config/flat/recommended.ts
    * @see https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/no-cycle.md
+   * @see https://github.com/un-ts/eslint-plugin-import-x/blob/master/docs/rules/order.md
    */
-  { rules: { ...plugins['import-x'].flatConfigs.recommended.rules, 'import-x/no-cycle': 'error' } },
+  {
+    rules: {
+      ...plugins['import-x'].flatConfigs.recommended.rules,
+      'import-x/no-cycle': 'error',
+      'import-x/order': ['warn', { alphabetize: { order: 'asc', caseInsensitive: true } }],
+    },
+  },
 
   /**
    * Import `eslint-plugin-jsdoc` and use its recommended config.


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- preceded by #2092 

Enforces alphabetic-by-filename imports in `src/` via our ESLint config.

Combined with #2093, this makes for automatic import sorting in VS Code! Wow!

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally and open it in VS Code
2. Find some poor feature `.js` file to muck up
3. Un-alphabetise its imports
    - **Expected result**: The ESLint extension is not happy, and reports warnings for out-of-order imports
4. Try to save the file
    - **Expected result**: Your vandalism is undone before it even hits the working directory!
