### PR TITLE
feat: add `IframePreference` component

### DIFF
--- a/src/action/components/iframe-preference/index.css
+++ b/src/action/components/iframe-preference/index.css
@@ -1,0 +1,9 @@
+:host {
+  display: flex;
+  flex-direction: column;
+  padding: 4px;
+}
+
+iframe {
+  border: none;
+}

--- a/src/action/components/iframe-preference/index.js
+++ b/src/action/components/iframe-preference/index.js
@@ -1,0 +1,44 @@
+import { CustomElement, fetchStyleSheets } from '../index.js';
+
+const localName = 'iframe-preference';
+
+const templateDocument = new DOMParser().parseFromString(`
+  <template id="${localName}">
+    <iframe id="iframe"></iframe>
+  </template>
+`, 'text/html');
+
+const adoptedStyleSheets = await fetchStyleSheets([
+  '/lib/normalize.min.css',
+  './index.css',
+].map(import.meta.resolve));
+
+class IframePreferenceElement extends CustomElement {
+  /** @type {HTMLIFrameElement} */ #iframeElement;
+
+  constructor () {
+    super(templateDocument, adoptedStyleSheets);
+    this.#iframeElement = this.shadowRoot.getElementById('iframe');
+  }
+
+  /** @param {string} label Accessible description for this preference box. */
+  set label (label = '') { this.#iframeElement.title = label; }
+  get label () { return this.#iframeElement.title; }
+
+  /** @param {string} src A page URL, relative to `src/`, to be embedded in the feature's preference list. */
+  set src (src = '') { this.#iframeElement.src = src; }
+  get src () { return this.#iframeElement.src; }
+
+  connectedCallback () { this.role ??= 'listitem'; }
+}
+
+customElements.define(localName, IframePreferenceElement);
+
+/**
+ * @typedef IframePreferenceProps
+ * @property {string} label The preference's label (e.g. `"Manage tag bundles"`).
+ * @property {string} src The preference's URL, relative to `src/` (e.g. `"/features/quick_tags/options/index.html"`).
+ */
+
+/** @type {(props: IframePreferenceProps) => IframePreferenceElement} */
+export const IframePreference = (props = {}) => Object.assign(document.createElement(localName), props);

--- a/src/action/components/xkit-feature/index.js
+++ b/src/action/components/xkit-feature/index.js
@@ -74,7 +74,7 @@ const adoptedStyleSheets = await fetchStyleSheets([
 /**
  * @typedef Iframe
  * @property {"iframe"} type Type of preference.
- * @property {string} src A URL, relative to `src/`, to be embedded in the feature's preference list.
+ * @property {string} src A page URL, relative to `src/`, to be embedded in the feature's preference list.
  */
 
 /** @typedef {BasePreference & (Checkbox | Text | TextArea | Color | Select | Iframe)} Preference */


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- relates to #1831
- relates to #2055
- relates to #2075
- relates to #2086
- relates to #2089
- relates to #2091

Finally, the last in the series! This is the easiest component to implement, since it's just an iframe in a list item wrapper.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Apply this patch: [iframe-preference.patch](https://github.com/user-attachments/files/25180676/iframe-preference.patch)
3. Load the locally modified addon
4. Enable Quick Tags and PostBlock
    - **Expected result**: The "Manage tag bundles" iframe is rendered without issue
    - **Expected result**: The "Manage blocked posts" iframe is rendered without issue
5. Change Quick Tags and/or PostBlock's data to make the iframe render more things
    - **Expected result**: The iframe resizes with added items, never forcing you to scroll the framed contents

