### PR TITLE
chore: Remove old follow button selector

### DIFF
--- a/src/features/tweaks/hide_mini_follow.js
+++ b/src/features/tweaks/hide_mini_follow.js
@@ -5,9 +5,7 @@ import { pageModifications } from '../../utils/mutations.js';
 
 const hiddenAttribute = 'data-tweaks-hide-mini-follow-hidden';
 
-export const styleElement = buildStyle(`
-article ${keyToCss('followButton')}:not(${keyToCss('postMeatballsContainer')} *), [${hiddenAttribute}] { display: none; }
-`);
+export const styleElement = buildStyle(`[${hiddenAttribute}] { display: none; }`);
 
 const processButtons = buttons => buttons.forEach(button => {
   if (button.textContent === translate('Follow')) {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

The "Hide follow buttons on posts" tweak originally hid elements using the mapped selector key `followButton`. This is also used for various other follow buttons around the site (11 classes), as came up in https://github.com/AprilSylph/XKit-Rewritten/issues/1697, and we then added entirely different code in https://github.com/AprilSylph/XKit-Rewritten/pull/1733 to handle the new header, which does not use this.

This removes the now-unused (that I know of) code, assuming that the old version of the header is long-gone (and that there aren't any tools in the tumblr-modification ecosystem to bring it back; I don't personally know of any).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that the "Hide follow buttons on posts" tweak works as expected.
- Check my logic—is there any other kind of follow button this tweak is supposed to hide? (Community posts have a different header; this didn't work on blazed posts before anyway.)