### PR TITLE
refactor(Tweaks): "Restore links to individual posts in the post header"

### DIFF
--- a/src/features/tweaks/feature.json
+++ b/src/features/tweaks/feature.json
@@ -15,7 +15,7 @@
   "preferences": {
     "restore_attribution_links": {
       "type": "checkbox",
-      "label": "Move post permalinks back to attributed blognames",
+      "label": "Restore links to individual posts in the post header",
       "default": false
     },
     "create_button_no_bubbles": {

--- a/src/features/tweaks/restore_attribution_links.js
+++ b/src/features/tweaks/restore_attribution_links.js
@@ -12,44 +12,10 @@ const postAttributionLinkSelector = `${headerSelector} a[rel="author"]`;
 const reblogAttributionLinkSelector = `${subheaderSelector} a${keyToCss('blogLink')}`;
 const trailAttributionLinkSelector = `${trailHeaderSelector} a[rel="author"]`;
 
-const postContentEventPermalinkSelector = `${keyToCss('postContent')}${keyToCss('hasPermalink')}`;
-const trailItemEventPermalinkSelector = `${keyToCss('reblog')}${keyToCss('withTrailItemPermalink')}`;
-const footerEventPermalinkSelector = `${keyToCss('footerWrapper')}${keyToCss('isReblogWithAddedContent')}`;
-const anyElementEventPermalinkSelector = `:is(
-  ${postContentEventPermalinkSelector},
-  ${trailItemEventPermalinkSelector},
-  ${footerEventPermalinkSelector}
-)`;
-const hasHoverColorSelector = keyToCss(
-  'heightRestrictorExpandButtonWrapper',
-  'contentWarningCover',
-  'expandTagsButtonWrapper',
-);
-
-// This takes advantage of tumblr's special-case code for audio players
-const preventPostClickAttributeName = 'data-audio-player';
-const preventPostClickAttributeValue = 'xkit-restore-attribution-links';
-
 export const styleElement = buildStyle(`
-/**
- * Hides the cover-style permalinks on processed headers, as they are redundant.
- */
 ${headerSelector}:has([data-router-url]:is(${postAttributionLinkSelector})) [rel="bookmark"],
 ${trailHeaderSelector}:has([data-router-url]:is(${trailAttributionLinkSelector})) [rel="bookmark"] {
   display: none !important;
-}
-
-/**
- * Removes the different background colour when hovering a post body pseudo-permalink.
- * This doesn't have :hover because, on reblogs with contributed content not viewed
- * alone, Tumblr syncs the last reblog and footer's hover state using :has().
- */
-${anyElementEventPermalinkSelector}[${preventPostClickAttributeName}] {
-  background-color: unset !important;
-  cursor: unset !important;
-}
-${anyElementEventPermalinkSelector}[${preventPostClickAttributeName}] ${hasHoverColorSelector} {
-  background-color: unset !important;
 }
 `);
 
@@ -97,8 +63,6 @@ const processPosts = async function (postElements) {
       postAttributionLink.dataset.routerUrl = postRouterUrl;
       postAttributionLink.href = postUrl;
       postAttributionLink.addEventListener('click', onLinkClick, listenerOptions);
-
-      postElement.querySelector(postContentEventPermalinkSelector)?.setAttribute(preventPostClickAttributeName, preventPostClickAttributeValue);
     }
 
     if (reblogAttributionLink && reblogAttributionLink.textContent === rebloggedFromName) {
@@ -118,7 +82,6 @@ const processPosts = async function (postElements) {
         if (isContributedContent) {
           trailAttributionLink.dataset.routerUrl = postRouterUrl;
           trailAttributionLink.href = postUrl;
-          postElement.querySelector(footerEventPermalinkSelector)?.setAttribute(preventPostClickAttributeName, preventPostClickAttributeValue);
         } else {
           const hasCustomTheme = new URL(blog.url).hostname !== 'www.tumblr.com';
           trailAttributionLink.dataset.routerUrl = `${blog.blogViewUrl.replace(/\/$/, '')}/${post.id}`;
@@ -126,7 +89,6 @@ const processPosts = async function (postElements) {
         }
 
         trailAttributionLink.addEventListener('click', onLinkClick, listenerOptions);
-        trailAttributionLink.closest(trailItemEventPermalinkSelector)?.setAttribute(preventPostClickAttributeName, preventPostClickAttributeValue);
       }
     });
   });
@@ -147,8 +109,4 @@ export const clean = async function () {
     delete anchorElement.dataset.originalHref;
     delete anchorElement.dataset.routerUrl;
   });
-
-  [...document.querySelectorAll(
-    `[${preventPostClickAttributeName}="${preventPostClickAttributeValue}"]`,
-  )].forEach(bodyPermalinkElement => bodyPermalinkElement.removeAttribute(preventPostClickAttributeName));
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- reverts #2024

Since the whole-post permalinks code has now been removed from Redpop completely, we don't need "Move post permalinks back to attributed blognames" anymore. Let's change it back to its old name, and clean up the now-dead code it contains.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

1. Load the modified addon
2. Enable Tweaks &rarr; "Restore links to individual posts in the post header"
    - **Expected result**: Cover-style post header permalinks are hidden
    - **Expected result**: Cover-style reblog trail header permalinks are hidden
    - **Expected result**: The attributed blog name in the post header links to the post's permalink
    - **Expected result**: The attributed reblog parent blog name in the post header links to the post's previous reblog
    - **Expected result**: Attributed blog names in the reblog trail all link to their content's permalink
    - **Expected result**: All the modified links open the modal blog view on a normal click, even when the link points to the blog network