### PR TITLE
feat(Vanilla Audio): update styles; achieve browser parity

### DIFF
--- a/src/features/vanilla_audio/index.css
+++ b/src/features/vanilla_audio/index.css
@@ -1,4 +1,7 @@
 .xkit-vanilla-audio-done {
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+
   cursor: auto;
 }
 
@@ -8,12 +11,28 @@
 
 .xkit-vanilla-audio-done .trackInfo {
   padding-left: 20px;
+
   pointer-events: auto;
   user-select: auto;
 }
 
 .xkit-vanilla-audio-done ~ audio[controls] {
   width: 100%;
+  border-bottom-left-radius: 8px;
+  border-bottom-right-radius: 8px;
+  overflow: clip;
+
+  color-scheme: dark;
+}
+
+@supports (selector(audio::-webkit-media-controls-panel)) {
+  .xkit-vanilla-audio-done ~ audio[controls] {
+    height: 40px;
+    background-color: #484848;
+  }
+  .xkit-vanilla-audio-done ~ audio::-webkit-media-controls-panel {
+    background-color: #484848;
+  }
 }
 
 /* XKit 7 override */


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Updates Vanilla Audio's styles to better fit with the new "rounded corners" look of the Tumblr audio player, and adds Chrome-specific styles that makes its audio elements look more like Firefox's.

Before | After
-|-
<img width="1112" height="416" alt="Screen Shot 2026-02-11 at 12 13 45" src="https://github.com/user-attachments/assets/7f8e8fb0-2052-4980-8645-38320ef032a7" /> | <img width="1112" height="416" alt="Screen Shot 2026-02-11 at 12 14 06" src="https://github.com/user-attachments/assets/01b6e351-2195-4d22-9bd8-2c1b7193adae" />
<img width="556" height="208" alt="Screenshot 2026-02-11 at 12 15 25 pm" src="https://github.com/user-attachments/assets/3c86368c-53fd-46af-a3c9-bde254b35942" /> | <img width="556" height="208" alt="Screenshot 2026-02-11 at 12 15 36 pm" src="https://github.com/user-attachments/assets/1a7f60f4-22eb-4ab0-96dc-64c9c3068b48" />

Not tested in Safari.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

#### Firefox

1. Load the modified addon
2. Enable Vanilla Audio
3. Find a post with uploaded audio
    - **Expected result**: Tumblr's audio player is now missing its rounded bottom corners
    - **Expected result**: The vanilla audio player has now gained rounded bottom corners 
    - **Expected result**: Nothing else about the vanilla audio player has changed

#### Chrome

1. Load the modified addon
2. Enable Vanilla Audio
3. View the same post as in Firefox
    - **Expected result**: The vanilla audio player looks like part of the Tumblr audio player, as it does in Firefox
    - **Expected result**: The vanilla audio player is the same colour as it is in Firefox
    - **Expected result**: The vanilla audio player is the same height as it is in Firefox

#### Safari

Detailed steps omitted for brevity; hopefully it's not completely broken by this?