### PR TITLE
Revert "fix(Themed Posts): Temporarily disable reblog trail theming with new Tumblr A/B Test"

### DIFF
--- a/src/features/themed_posts/index.js
+++ b/src/features/themed_posts/index.js
@@ -8,11 +8,7 @@ export const styleElement = buildStyle();
 
 const blogs = new Set();
 const groupsFromHex = /^#(?<red>[A-Fa-f0-9]{1,2})(?<green>[A-Fa-f0-9]{1,2})(?<blue>[A-Fa-f0-9]{1,2})$/;
-
-// Prevent unreadable text by not theming trail items if they'll change
-// background color on hover until we implement compatibility with
-// postChromeBodyNavigationEventsRedesign.
-const reblogSelector = `${keyToCss('reblog')}:not(${keyToCss('withTrailItemPermalink')})`;
+const reblogSelector = keyToCss('reblog');
 const timelineSelector = keyToCss('timeline');
 
 let enableOnPeepr;


### PR DESCRIPTION
### Description

- reverts #2026
- relates to #2100

### Testing steps

1. Load the modified addon
2. Enable Themed Posts &rarr; "Theme every reblog trail item individually"
    - **Expected result**: The option still works