### PR TITLE
fix(Themed Posts): remove extra space between items in the reblog trail

### DIFF
--- a/src/features/themed_posts/index.js
+++ b/src/features/themed_posts/index.js
@@ -1,5 +1,5 @@
 import { keyToCss } from '../../utils/css_map.js';
-import { buildStyle, filterPostElements, blogViewSelector, postSelector } from '../../utils/interface.js';
+import { buildStyle, filterPostElements, blogViewSelector } from '../../utils/interface.js';
 import { onNewPosts } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
 import { timelineObject } from '../../utils/react_props.js';
@@ -118,16 +118,6 @@ export const main = async function () {
   blacklist = blacklistedUsernames.split(',').map(username => username.trim());
 
   if (reblogTrailTheming) {
-    styleElement.textContent += `
-      ${postSelector} ${reblogSelector} {
-        display: flow-root;
-        margin-top: 0;
-      }
-
-      ${postSelector} ${reblogSelector}:not(:last-child) > :last-child {
-        margin-bottom: 15px;
-      }
-    `;
     if (missingPostMode === 'palette') {
       styleElement.textContent += `
         ${timelineSelector} {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
The extra CSS that Themed Posts adds for reblog trail theming is redundant with the new UI update—all it does now is add extra blank space to the bottom of non-final reblog trail items.

Reference | Before | After
-|-|-
<img width="294" height="252" alt="Screen Shot 2026-02-12 at 12 37 10" src="https://github.com/user-attachments/assets/ccd8bdc2-240f-49e2-917d-678a6136e750" /> | <img width="294" height="259" alt="Screen Shot 2026-02-12 at 12 37 30" src="https://github.com/user-attachments/assets/65fb527c-c8b3-48f1-845c-987141acb57e" /> | <img width="294" height="252" alt="Screen Shot 2026-02-12 at 12 37 54" src="https://github.com/user-attachments/assets/6909024b-2021-4258-b002-0a9809fc3a38" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Find a post with more than one reblog trail item on it, and keep it visible
3. Enable Themed Posts &rarr; "Theme every reblog trail item individually"
    - **Expected result**: No gaps of post colour leak through between the reblog trail items
    - **Expected result**: The spacing between the reblog trail items has not changed