### PR TITLE
chore: remove `any` type from all JSDoc

### DIFF
--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -6,7 +6,7 @@
  * @param {string} path Absolute path of script file to inject; will be fed to {@linkcode https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/getURL|browser.runtime.getURL()}
  * @param {Array} [args] Array of arguments to pass to the injected function
  * @param {Element} [target] Target element; will be accessible as the `this` value in the injected function
- * @returns {Promise<any>} The transmitted result of the function call
+ * @returns {Promise} The transmitted result of the function call
  */
 export const inject = (path, args = [], target = document.documentElement) =>
   new Promise((resolve, reject) => {

--- a/src/utils/text_format.js
+++ b/src/utils/text_format.js
@@ -36,9 +36,9 @@ export const dateTimeFormat = new Intl.DateTimeFormat(document.documentElement.l
 /**
  * Adds string elements between an array's items to format it as an English prose list.
  * The Oxford comma is included.
- * @param {any[]} array Input array of any number of items
+ * @param {(string | Node)[]} array Input array of any number of items
  * @param {string} andOr String 'and' or 'or', used before the last item
- * @returns {any[]} An array alternating between the input items and strings
+ * @returns {(string | Node)[]} An array alternating between the input items and strings
  */
 export const elementsAsList = (array, andOr) =>
   array.flatMap((item, i) => {

--- a/src/utils/tumblr_helpers.js
+++ b/src/utils/tumblr_helpers.js
@@ -1,9 +1,17 @@
 import { inject } from './inject.js';
 
 /**
- * @param {...any} args Arguments to pass to window.tumblr.apiFetch()
+ * @typedef {string | number | boolean | null | Json[] | { [key: string]: Json }} Json
+ * @see https://www.typescriptlang.org/play/3-7/types-and-code-flow/recursive-type-references.ts.html
+ */
+
+/** @typedef {Record<string, Json>} Dictionary */
+/** @typedef {Record<string, string>} QueryParams */
+
+/**
+ * @param {globalThis.RequestInit & { queryParams?: QueryParams, body?: (string | Dictionary) }} args Arguments to pass to `window.tumblr.apiFetch()`
  * @see {@link https://github.com/tumblr/docs/blob/master/web-platform.md#apifetch}
- * @returns {Promise<Response|Error>} Resolves or rejects with result of window.tumblr.apiFetch()
+ * @returns {Promise<Response | Error>} Resolves or rejects with result of `window.tumblr.apiFetch()`
  */
 export const apiFetch = async (...args) => inject('/main_world/api_fetch.js', args);
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- dependency of #2102

`jsdoc/reject-any-type` is now included in the recommended rules, and for good reason! `any` is not a real type. In all our usages, we can either use a more specific type, or stop explicitly using it when it can be inferred instead.

Intellisense seems unable to parse the recursive type for stringifiable JSON correctly, and treats it as equivalent to `any`, even though functions should really be disallowed by it... oh well. Still better than actually putting `any`.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Just code review will suffice. Expect zero new CI warnings.
