### PR TITLE
feat(Quick Reblog): add keyboard navigation support

### DIFF
--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -19,8 +19,6 @@ const quickTagsPanelId = 'xkit-quick-reblog-quick-tags-panel';
 const suggestedTagsTabId = 'xkit-quick-reblog-suggested-tags-tab';
 const suggestedTagsPanelId = 'xkit-quick-reblog-suggested-tags-panel';
 
-const stopEventPropagation = event => event.stopPropagation();
-
 const blogSelector = select({ change: onBlogSelectorChange });
 const blogAvatar = div({ class: 'avatar' });
 const blogSelectorContainer = div({ class: 'select-container' }, [blogAvatar, blogSelector]);
@@ -53,7 +51,7 @@ const actionButtons = fieldset({ class: 'action-buttons' }, [
   button({ 'data-state': 'queue', click: reblogPost }, ['Queue']),
   button({ 'data-state': 'draft', click: reblogPost }, ['Draft']),
 ]);
-const popupElement = div({ id: 'quick-reblog', click: stopEventPropagation }, [
+const popupElement = div({ id: 'quick-reblog', click: event => event.stopPropagation() }, [
   blogSelectorContainer,
   commentInput,
   tagsTabList,


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- resolves #899
- integrates #917 

While the Quick Reblog popup's comment input or tag input are focused, <kbd>CTRL</kbd>+<kbd>Enter</kbd> (or <kbd>command</kbd>+<kbd>⏎</kbd>) acts as a shortcut for clicking "Reblog", while <kbd>ESC</kbd> acts as a shortcut for closing the popup.

Credit to @alleycatboy for requesting this feature, and for its basic implementation. My work here just addresses the review comments on the original PR, and updates the code for the present day.

It's a shame the GitHub API doesn't expose coauthor usernames, or at least not in a good format, or I would make sure that coauthors always got contributor credit on releases. I guess this scenario is rare enough that it's not too much effort to add manually, though.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
For brevity, I will only refer to the Windows/Linux versions of the keyboard shortcuts here; please use the macOS versions if that's the platform you're testing on.

1. Load the modified addon
2. Enable Quick Reblog
3. Enable Quick Reblog &rarr; "Show the comment field"
4. Find a rebloggable post, and open the Quick Reblog popup
    - **Expected result**: Using <kbd>ESC</kbd> in the comments field closes the popup instantly
    - **Expected result**: Using <kbd>ESC</kbd> in the tags field closes the popup instantly
    - **Expected result**: Using <kbd>CTRL</kbd>+<kbd>Enter</kbd> in the comments field reblogs the post, with the popup only closing after the reblog is successful
    - **Expected result**: Using <kbd>CTRL</kbd>+<kbd>Enter</kbd> in the tags field reblog the post, with the popup only closing after the reblog is successful