### PR TITLE
feat(UI): use dark theme checkboxes when appropriate

### DIFF
--- a/src/action/popup.html
+++ b/src/action/popup.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="color-scheme" content="light dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>XKit Control Panel</title>
     <link rel="icon" href="../icons/128.png" type="image/png">

--- a/src/features/postblock/options/index.html
+++ b/src/features/postblock/options/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="color-scheme" content="light dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>XKit: Manage blocked posts</title>
     <link rel="icon" href="/icons/128.png" type="image/png">

--- a/src/features/quick_tags/options/index.html
+++ b/src/features/quick_tags/options/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="color-scheme" content="light dark">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>XKit: Manage tag bundles</title>
     <link rel="stylesheet" href="/lib/modern-normalize.css">


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Adds [`<meta name="color-scheme">`](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/meta/name/color-scheme) to the UI's HTML.

Currently, this has the sole effect of making checkboxes match the dark theme, if enabled:

Before | After
-|-
<img width="375" height="667" alt="Screen Shot 2026-02-25 at 09 55 16" src="https://github.com/user-attachments/assets/dbca4e78-a83f-4a00-96ab-7d237962ced0" /> | <img width="375" height="667" alt="Screen Shot 2026-02-25 at 09 55 43" src="https://github.com/user-attachments/assets/2899061a-444d-4bd0-b815-e2ce27e782fd" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon onto a browser that uses a light theme
2. Open the XKit control panel
    - **Expected result**: No visual changes can be observed
3. Load the modified addon onto a browser that uses a dark theme
4. Open the XKit control panel
    - **Expected result**: Checkboxes are dark now!
    - **Expected result**: No deleterious visual changes can be observed
