### PR TITLE
refactor: Create `withModalOnError` helper function

### DIFF
--- a/src/features/mass_privater/index.js
+++ b/src/features/mass_privater/index.js
@@ -1,6 +1,6 @@
 import { dom } from '../../utils/dom.js';
 import { megaEdit } from '../../utils/mega_editor.js';
-import { showModal, modalCancelButton, modalCompleteButton, hideModal, showErrorModal, createTagSpan, createBlogSpan, withErrorModal } from '../../utils/modals.js';
+import { showModal, modalCancelButton, modalCompleteButton, hideModal, showErrorModal, createTagSpan, createBlogSpan, withModalOnError } from '../../utils/modals.js';
 import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
 import { dateTimeFormat, elementsAsList } from '../../utils/text_format.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
@@ -26,7 +26,7 @@ const createNowString = () => {
 };
 
 const showInitialPrompt = async () => {
-  const initialForm = dom('form', { id: getPostsFormId }, { submit: withErrorModal(confirmInitialPrompt) }, [
+  const initialForm = dom('form', { id: getPostsFormId }, { submit: withModalOnError(confirmInitialPrompt) }, [
     dom('label', null, null, [
       'Posts on blog:',
       dom('select', { name: 'blog', required: true }, null, userBlogs.map(createBlogOption)),

--- a/src/features/tag_replacer/index.js
+++ b/src/features/tag_replacer/index.js
@@ -1,6 +1,6 @@
 import { dom } from '../../utils/dom.js';
 import { megaEdit } from '../../utils/mega_editor.js';
-import { showModal, modalCancelButton, modalCompleteButton, showErrorModal, createTagSpan, createBlogSpan, withErrorModal } from '../../utils/modals.js';
+import { showModal, modalCancelButton, modalCompleteButton, showErrorModal, createTagSpan, createBlogSpan, withModalOnError } from '../../utils/modals.js';
 import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
 import { userBlogs } from '../../utils/user.js';
@@ -11,7 +11,7 @@ const createBlogOption = ({ name, title, uuid }) => dom('option', { value: uuid,
 const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
 
 const showInitialPrompt = async () => {
-  const initialForm = dom('form', { id: getPostsFormId }, { submit: withErrorModal(confirmReplaceTag) }, [
+  const initialForm = dom('form', { id: getPostsFormId }, { submit: withModalOnError(confirmReplaceTag) }, [
     dom('label', null, null, [
       'Replace tags on:',
       dom('select', { name: 'blog', required: true }, null, userBlogs.map(createBlogOption)),

--- a/src/features/trim_reblogs/index.js
+++ b/src/features/trim_reblogs/index.js
@@ -2,7 +2,7 @@ import { createControlButtonTemplate, cloneControlButton, insertControlButton } 
 import { keyToCss } from '../../utils/css_map.js';
 import { dom } from '../../utils/dom.js';
 import { filterPostElements, postSelector } from '../../utils/interface.js';
-import { showModal, hideModal, modalCancelButton, showErrorModal, withErrorModal } from '../../utils/modals.js';
+import { showModal, hideModal, modalCancelButton, showErrorModal, withModalOnError } from '../../utils/modals.js';
 import { onNewPosts } from '../../utils/mutations.js';
 import { notify } from '../../utils/notifications.js';
 import { timelineObject } from '../../utils/react_props.js';
@@ -160,7 +160,7 @@ const processPosts = postElements => filterPostElements(postElements).forEach(as
   const items = trail.length + (content.length ? 1 : 0);
 
   if (canEdit && ['ask', 'submission'].includes(state) === false) {
-    const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: withErrorModal(onButtonClicked) }, items < 2);
+    const clonedControlButton = cloneControlButton(controlButtonTemplate, { click: withModalOnError(onButtonClicked) }, items < 2);
     insertControlButton(postElement, clonedControlButton, buttonClass);
   }
 });

--- a/src/utils/modals.js
+++ b/src/utils/modals.js
@@ -63,7 +63,7 @@ export const showErrorModal = exception => {
   });
 };
 
-export const withErrorModal = func =>
+export const withModalOnError = func =>
   async (...args) => {
     try {
       return await func(...args);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This creates a `withErrorModal` helper function that wraps a given function in `showErrorModal` to catch errors when it's executed. I find this more clear than writing e.g. `event => onButtonClicked(event).catch(showErrorModal)`. My guess is that this is probably uncontroversial?

Question is, would we want to write `withErrorModal(someCallback)` in the place where it's used, as I did here, or around someCallback where it's defined? The latter breaks jsdoc.

(cherry-picked from #2126)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that Mass Privater, Tag Replacer, and Trim Reblogs show error messages when attempting to use them with no network connection.