### PR TITLE
feat(No Recommended): Hide posts from non-joined communities in search results

### DIFF
--- a/src/features/no_recommended/feature.json
+++ b/src/features/no_recommended/feature.json
@@ -15,7 +15,7 @@
     },
     "hide_recommended_community_posts": {
       "type": "checkbox",
-      "label": "Hide posts from non-joined communities in For You",
+      "label": "Hide posts from non-joined communities in For You and search results",
       "default": false
     },
     "hide_answertime": {

--- a/src/features/no_recommended/hide_recommended_community_posts.js
+++ b/src/features/no_recommended/hide_recommended_community_posts.js
@@ -1,11 +1,11 @@
 import { buildStyle, filterPostElements, getTimelineItemWrapper } from '../../utils/interface.js';
 import { onNewPosts } from '../../utils/mutations.js';
 import { timelineObject } from '../../utils/react_props.js';
-import { forYouTimelineFilter } from '../../utils/timeline_id.js';
+import { forYouTimelineFilter, searchPostsTimelineFilter } from '../../utils/timeline_id.js';
 import { joinedCommunityUuids } from '../../utils/user.js';
 
 const hiddenAttribute = 'data-no-recommended-community-posts-hidden';
-const timeline = forYouTimelineFilter;
+const timeline = [forYouTimelineFilter, searchPostsTimelineFilter];
 const includeFiltered = true;
 
 export const styleElement = buildStyle(`[${hiddenAttribute}] {

--- a/src/utils/timeline_id.js
+++ b/src/utils/timeline_id.js
@@ -73,6 +73,11 @@ export const tagTimelineFilter = tag =>
     timelineId?.startsWith(`hubsTimeline-${tag}-recent-`) ||
     timelineId?.match(exactly(`tag-${uuidV4}-${tag}-recent`));
 
+export const searchPostsTimelineFilter = search =>
+  ({ dataset: { timeline, timelineId } }) =>
+    timelineId?.startsWith('searchTimeline-post-') ||
+    timelineId?.match(startsWith(`search-${uuidV4}-`));
+
 export const anyCommunityTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
   timelineId?.match(exactly(`communities-${anyBlogName}-recent`)) ||
   timelineId?.match(exactly(`community-${uuidV4}-${anyBlogName}`));


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As requested by a user in the tags, this adds search results to the list of places where No Recommended will hide community posts when the relevant option is enabled.

Closes #2067, a version of this with a separate preference.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Find a community post in a search result (https://www.tumblr.com/search/evil%20science/recent is usually pretty good). Enable the "Hide posts from non-joined communities in For You and search results" No Recommended feature and confirm that it is hidden.