### PR TITLE
refactor: Post actions util

### DIFF
--- a/src/features/quick_tags/index.js
+++ b/src/features/quick_tags/index.js
@@ -260,7 +260,7 @@ export const main = async function () {
   controlButtonTemplate = createControlButtonTemplate(symbolId, buttonClass, 'Quick Tags');
 
   onNewPosts.addListener(processPosts);
-  registerPostOption('quick-tags', { symbolId, onclick: togglePostOptionPopupDisplay });
+  registerPostOption({ id: 'quick-tags', symbolId, onclick: togglePostOptionPopupDisplay });
 
   populatePopups();
 

--- a/src/utils/post_actions.js
+++ b/src/utils/post_actions.js
@@ -1,5 +1,5 @@
 import { keyToCss } from './css_map.js';
-import { dom } from './dom.js';
+import { button, label } from './dom.js';
 import { displayBlockUnlessDisabledAttr } from './interface.js';
 import { pageModifications } from './mutations.js';
 import { buildSvg } from './remixicon.js';
@@ -26,14 +26,14 @@ pageModifications.register(keyToCss('postFormButton'), addPostOptions);
 
 /**
  * Create and register a button to add to the new post form
- * @param {string} id Unique identifier for this post option
- * @param {object} options Construction options for this post option
+ * @param {object} options Destructured
+ * @param {string} options.id Identifier for this post option (must be unique)
  * @param {string} options.symbolId RemixIcon symbol to use
  * @param {(event: PointerEvent) => void} options.onclick Click handler function for this button
  */
-export const registerPostOption = async function (id, { symbolId, onclick }) {
-  postOptions[id] = dom('label', { class: 'xkit-post-option', [displayBlockUnlessDisabledAttr]: '' }, null, [
-    dom('button', null, { click: onclick }, [buildSvg(symbolId)]),
+export const registerPostOption = async function ({ id, symbolId, onclick }) {
+  postOptions[id] = label({ class: 'xkit-post-option', [displayBlockUnlessDisabledAttr]: '' }, [
+    button({ click: onclick }, [buildSvg(symbolId)]),
   ]);
 
   pageModifications.trigger(addPostOptions);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This refactors the post actions util slightly, making `registerPostOption` mirror `registerMeatballItem` and making use of the new dom utils.

Note to self: this was from investigating #1720.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that Quick Tags adds a post action button to the post form and that it functions correctly.