### PR TITLE
refactor(UI): remove non-component smells from feature toggle code

### DIFF
--- a/src/action/components/xkit-feature/index.js
+++ b/src/action/components/xkit-feature/index.js
@@ -43,10 +43,10 @@ class XKitFeatureElement extends CustomElement {
   /** @type {HTMLDetailsElement}  */ #detailsElement;
   /** @type {HTMLInputElement}    */ #enabledToggle;
 
-  /** @type {boolean}     */ #disabled = false;
-  /** @type {boolean}     */ deprecated = false;
-  /** @type {string}      */ featureName = '';
-  /** @type {string[]}    */ relatedTerms = [];
+  /** @type {boolean}   */ #disabled = false;
+  /** @type {boolean}   */ deprecated = false;
+  /** @type {string}    */ featureName = '';
+  /** @type {string[]}  */ relatedTerms = [];
 
   constructor () {
     super(templateDocument, adoptedStyleSheets);
@@ -55,32 +55,33 @@ class XKitFeatureElement extends CustomElement {
     this.#enabledToggle = this.shadowRoot.querySelector('input[type="checkbox"]');
   }
 
-  /** @param {InputEvent} event `input` event for the feature's "Enable this feature" toggle. */
+  /** @param {InputEvent & { currentTarget: HTMLInputElement }} event `input` event for the feature's "Enable this feature" toggle. */
   #handleEnabledToggleInput = async ({ currentTarget: { checked } }) => {
-    let {
+    const {
       [XKitFeatureElement.#enabledFeaturesKey]: enabledFeatures = [],
       [XKitFeatureElement.#specialAccessKey]: specialAccess = [],
     } = await browser.storage.local.get();
 
-    const hasPreferences = this.querySelector('[slot="preferences"]') !== null;
-    if (hasPreferences) this.#detailsElement.open = checked;
+    /** @type {Set<string>} */ const enabledFeaturesSet = new Set(enabledFeatures);
+    /** @type {Set<string>} */ const specialAccessSet = new Set(specialAccess);
 
-    if (checked) {
-      enabledFeatures.push(this.featureName);
-    } else {
-      enabledFeatures = enabledFeatures.filter(x => x !== this.featureName);
+    checked
+      ? enabledFeaturesSet.add(this.featureName)
+      : enabledFeaturesSet.delete(this.featureName);
 
-      if (this.deprecated && !specialAccess.includes(this.featureName)) {
-        specialAccess.push(this.featureName);
-      }
-    }
+    this.deprecated
+      ? specialAccessSet.add(this.featureName)
+      : specialAccessSet.delete(this.featureName);
+
+    await browser.storage.local.set({
+      [XKitFeatureElement.#enabledFeaturesKey]: Array.from(enabledFeaturesSet),
+      [XKitFeatureElement.#specialAccessKey]: Array.from(specialAccessSet),
+    });
 
     this.disabled = !checked;
 
-    browser.storage.local.set({
-      [XKitFeatureElement.#enabledFeaturesKey]: enabledFeatures,
-      [XKitFeatureElement.#specialAccessKey]: specialAccess,
-    });
+    const hasPreferences = this.querySelector('[slot="preferences"]') !== null;
+    if (hasPreferences) this.#detailsElement.open = checked;
   };
 
   connectedCallback () {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Refactors the feature toggle callback to stop relying on the `input` element's `id`, instead using `this.featureName` directly; stops setting `id` on the feature toggle element; uses `Set` objects to handle adding/removing of feature names from `enabledFeatures` and `specialAccess`.

There are two very niche behavioural changes expected from this:
1. If you modify your config to add features to `specialAccess` which are not currently deprecated, toggling those features will now remove them from `specialAccess`.
    - If we ever deprecate, then de-deprecate, then re-deprecate the same feature, this would mean that each deprecation would be treated as separate for the purpose of grandfathering access—a user who had the feature enabled at the time of the first deprecation and then disabled it before the second deprecation would lose access to it upon the second deprecation. This will, realistically, never happen, but now the code aligns with how I think this scenario should be handled theoretically.
2. If writing `enabledFeatures` or `specialAccess` fails somehow, the UI will no longer add/remove "(disabled)" from the feature's title, or toggle the visibility of its preferences.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Open the control panel
    - **Expected result**: Enabling a feature works
    - **Expected result**: Disabling a feature works