### PR TITLE
fix(Quick Tags): Exclude Quick Tags control from ask form

### DIFF
--- a/src/utils/post_actions.js
+++ b/src/utils/post_actions.js
@@ -13,12 +13,15 @@ const addPostOptions = ([postFormButton]) => {
   if (!postFormButton) { return; }
 
   const postActions = postFormButton.parentElement;
+  const inAskForm = postActions.closest(keyToCss('form'))?.querySelector(keyToCss('anonToggle'));
 
   postFormButton.before(
     ...Object.keys(postOptions)
       .sort()
       .map(id => postOptions[id])
-      .filter(postOption => !postActions.contains(postOption)),
+      .filter(({ showInAskForm }) => showInAskForm ? true : !inAskForm)
+      .map(({ element }) => element)
+      .filter(element => !postActions.contains(element)),
   );
 };
 
@@ -30,11 +33,15 @@ pageModifications.register(keyToCss('postFormButton'), addPostOptions);
  * @param {string} options.id Identifier for this post option (must be unique)
  * @param {string} options.symbolId RemixIcon symbol to use
  * @param {(event: PointerEvent) => void} options.onclick Click handler function for this button
+ * @param {boolean} [options.showInAskForm] Whether to show the button in the ask form
  */
-export const registerPostOption = async function ({ id, symbolId, onclick }) {
-  postOptions[id] = label({ class: 'xkit-post-option', [displayBlockUnlessDisabledAttr]: '' }, [
-    button({ click: onclick }, [buildSvg(symbolId)]),
-  ]);
+export const registerPostOption = async function ({ id, symbolId, onclick, showInAskForm = false }) {
+  postOptions[id] = {
+    element: label({ class: 'xkit-post-option', [displayBlockUnlessDisabledAttr]: '' }, [
+      button({ click: onclick }, [buildSvg(symbolId)]),
+    ]),
+    showInAskForm,
+  };
 
   pageModifications.trigger(addPostOptions);
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Removes the Quick Tags action button from the ask form which is accessible from tumblr.com/blogname, because it can't add any tags to the form because asks can't have tags.

Resolves #1720.

This bothers to add an option to the post actions util to opt out of this even though Quick Tags is our only feature that adds a post action and so this is unused; we could of course just hardcode it until and unless that were ever needed.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable Quick Tags.
- Open the ask form from a tumblr.com/blogname page. Confirm that there is no Quick Tags post action button.
- Open the post form. Confirm that there is still a Quick Tags post action button.