### PR TITLE
chore: Remove unused `reblog_info` query parameter in util

### DIFF
--- a/src/utils/react_props.js
+++ b/src/utils/react_props.js
@@ -76,7 +76,7 @@ export const editPostFormTags = async ({ add = [], remove = [] }) =>
  */
 export const updatePostOnPage = async (postElement, keys) => {
   const currentTimelineObject = await timelineObject(postElement);
-  const { response: newTimelineObject } = await apiFetch(`/v2/blog/${currentTimelineObject.blog.uuid}/posts/${currentTimelineObject.id}?reblog_info=true`);
+  const { response: newTimelineObject } = await apiFetch(`/v2/blog/${currentTimelineObject.blog.uuid}/posts/${currentTimelineObject.id}`);
 
   const changeEntries = Object.entries(newTimelineObject).filter(([key]) => keys.includes(key));
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

I gave the the `updatePostOnPage` util the `reblog_info=true` query parameter. This query parameter, however, does nothing on the `/v2/blog/{blog-identifier}/posts/{post-id}` [API endpoint](https://github.com/tumblr/docs/blob/master/api.md#postspost-id---fetching-a-post-neue-post-format). This removes it, as discussed in #2140.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Smoke test Quick Tags.
