### PR TITLE
chore: Update github api version in dev script

### DIFF
--- a/dev/release-notes.js
+++ b/dev/release-notes.js
@@ -14,7 +14,7 @@ try {
 
   const response = await fetch(
     `${GITHUB_API_URL}/repos/${GITHUB_REPOSITORY}/commits?per_page=100`,
-    { headers: { Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2022-11-28', ...GITHUB_TOKEN && { Authorization: `Bearer ${GITHUB_TOKEN}` } } },
+    { headers: { Accept: 'application/vnd.github+json', 'X-GitHub-Api-Version': '2026-03-10', ...GITHUB_TOKEN && { Authorization: `Bearer ${GITHUB_TOKEN}` } } },
   );
   if (!response.ok) { throw new Error(`🛑 HTTP ${response.status} (${response.statusText})`); }
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in the [github changelog](https://github.blog/changelog/2026-03-12-rest-api-version-2026-03-10-is-now-available/), there's a new version of the github api. On a quick skim of the changes, I don't see anything that would affect our dev script.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that the dev/release-notes.js script still functions correctly.