### PR TITLE
feat(Classic Footer): Enable feature on trail items

### DIFF
--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -4,7 +4,7 @@ import { buildStyle, postSelector } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
 import { pageModifications } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
-import { timelineObject } from '../../utils/react_props.js';
+import { timelineObject, trailItem } from '../../utils/react_props.js';
 
 const activeAttribute = 'data-classic-footer';
 const noteCountClass = 'xkit-classic-footer-note-count';
@@ -232,31 +232,42 @@ const onNoteCountClick = (event) => {
   const postElement = event.currentTarget.closest(postOrRadarSelector);
   if (!postElement) { return; }
 
+  // todo: improve reliablity by targeting close button in modal notes (i.e. if user switched to reblogs tab).
   const closeNotesButton = postElement.querySelector(closeNotesButtonSelector);
+  const replyButton = event.currentTarget.parentElement.querySelector(replyButtonSelector);
 
   closeNotesButton
     ? closeNotesButton.click()
-    : [...postElement.querySelectorAll(`[${activeAttribute}] ${replyButtonSelector}`)].at(-1)?.click();
+    : replyButton.click();
 };
 
 const processPosts = (postElements) => postElements.forEach(async postElement => {
-  postElement.querySelector(`.${noteCountClass}`)?.remove();
-  postElement.querySelector(`.${reblogLinkClass}`)?.remove();
+  [...postElement.querySelectorAll(`.${noteCountClass}, .${reblogLinkClass}`)]
+    .forEach(element => element.remove());
 
-  const { noteCount } = await timelineObject(postElement);
-  const noteCountButton = button({
-    'aria-hidden': noteCount === 0 && noZeroNotes,
-    class: `${noteCountClass} ${modernButtonStyle ? modernStyleClass : ''}`,
-    click: onNoteCountClick,
-  }, getButtonChildren(noteCount));
+  const timelineObjectData = await timelineObject(postElement);
 
-  const engagementControls = [...postElement.querySelectorAll(engagementControlsSelector)].at(-1);
-  engagementControls?.closest('footer').setAttribute(activeAttribute, '');
-  engagementControls?.before(noteCountButton);
+  [...postElement.querySelectorAll(engagementControlsSelector)]
+    .forEach(async engagementControls => {
+      const trailItemData = await trailItem(engagementControls);
 
-  if (noReblogMenu) {
-    processReblogButton(engagementControls?.querySelector(reblogButtonSelector));
-  }
+      const noteCount = trailItemData
+        ? trailItemData.post.noteCount ?? 0
+        : timelineObjectData.noteCount;
+
+      const noteCountButton = button({
+        'aria-hidden': noteCount === 0 && noZeroNotes,
+        class: `${noteCountClass} ${modernButtonStyle ? modernStyleClass : ''}`,
+        click: onNoteCountClick,
+      }, getButtonChildren(noteCount));
+
+      engagementControls.closest('footer').setAttribute(activeAttribute, '');
+      engagementControls.before(noteCountButton);
+
+      if (noReblogMenu) {
+        processReblogButton(engagementControls.querySelector(reblogButtonSelector), timelineObjectData, trailItemData);
+      }
+    });
 });
 
 const getReblogMenuItem = async (reblogButton, href) => {
@@ -296,10 +307,15 @@ const onReblogLinkClick = (event) => {
   getReblogMenuItem(reblogButton, href).then(reblogMenuItem => reblogMenuItem.click());
 };
 
-const processReblogButton = async reblogButton => {
+const processReblogButton = (reblogButton, timelineObjectData, trailItemData) => {
   if (!reblogButton) return;
 
-  const { blogName, canReblog, idString, reblogKey } = await timelineObject(reblogButton);
+  const { blog: { name } } = trailItemData ?? timelineObjectData;
+  const { canReblog, id } = trailItemData?.post ?? timelineObjectData;
+
+  // trail items have the same reblog key as their parent post
+  const { reblogKey } = timelineObjectData;
+
   if (!canReblog) return;
 
   const styleContent = `${reblogMenuPortalSelector}:has([aria-labelledby="${reblogButton.id}"]) { display: none; }`;
@@ -308,7 +324,7 @@ const processReblogButton = async reblogButton => {
     'aria-label': reblogButton.getAttribute('aria-label'),
     class: reblogLinkClass,
     click: onReblogLinkClick,
-    href: `/reblog/${blogName}/${idString}/${reblogKey}`,
+    href: `/reblog/${name}/${id}/${reblogKey}`,
   }, [
     link({ rel: 'stylesheet', class: 'xkit', href: `data:text/css,${encodeURIComponent(styleContent)}` }),
     reblogButton.firstElementChild.cloneNode(true)],


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This allows Classic Footer to process the footers on trail items the same way it processes post footers.

Not currently implemented: opening the notes, changing the tab to e.g. likes, then clicking the Classic Footer notes count to close the notes 100% consistently. I can't remember why we determined this was inconsistent, but I don't think it's important enough to be a blocker.

Additional note: clicking the note count makes the notes popup appear over by the replycomment/reblog/like buttons rather than by the element you clicked; again, I don't think this is important enough to be a blocker, but we should file it as an improvable issue after merging this if it's merged as-is.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

On a blog with the new footers-on-trail-items feature:
- [x] Confirm that Classic Footer affects the trail item footers.
- [x] Confirm that the "turn the reblog buttons back into links" option opens the reblog form to the correct post on both the post footer and trail footers.
- [x] Confirm correct behavior on posts with reblogs disabled.
- [x] Confirm correct behavior on reblogs of posts with reblogs disabled.
- [x] Confirm correct behavior on broken blogs.