### PR TITLE
feat(UI): move sponsor progress to Configuration tab

### DIFF
--- a/src/action/components/sponsor-progress/index.css
+++ b/src/action/components/sponsor-progress/index.css
@@ -1,12 +1,16 @@
 :host {
-  position: relative;
+  position: sticky;
+  bottom: 0;
 
   display: flex;
   flex-direction: row;
   justify-content: space-between;
   align-items: center;
   column-gap: 12px;
-  padding-block: 4px;
+  padding: 8px;
+  border-top: 1px solid rgb(var(--active-grey));
+
+  background-color: rgb(var(--white));
 }
 
 #caption {

--- a/src/action/components/xkit-feature/index.css
+++ b/src/action/components/xkit-feature/index.css
@@ -1,4 +1,4 @@
-details {
+:host(:not(:last-child)) details {
   border-bottom: 1px dotted rgb(var(--active-grey));
 }
 

--- a/src/action/popup.html
+++ b/src/action/popup.html
@@ -48,6 +48,7 @@
           <p>No results found.</p>
         </div>
         <div class="features"></div>
+        <sponsor-progress></sponsor-progress>
       </section>
       <section id="backup-panel" role="tabpanel" aria-labelledby="backup-tab" tabindex="0" hidden>
         <details id="export" open>
@@ -96,7 +97,6 @@
           <li><a href="https://github.com/AprilSylph/Outbox-for-Tumblr#readme" target="_blank">Outbox for Tumblr</a></li>
           <li><a href="https://github.com/AprilSylph/Filtering-Plus#readme" target="_blank">Filtering+ for Tumblr</a></li>
         </ul>
-        <sponsor-progress></sponsor-progress>
       </section>
     </main>
   </body>


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Moves the sponsor progress element from the Links tab to the Configuration tab, and makes it stick to the bottom of the viewport.

This was a lot less complicated than I thought it would be! This is the first time that `position: sticky; bottom: 0;` has done what I want it to do.

Before | Before | After | After
-|-|-|-
<img width="750" height="1334" alt="Screen Shot 2026-03-17 at 10 56 36" src="https://github.com/user-attachments/assets/57132e01-625d-4e90-bdae-d8d56443a08a" /> | <img width="750" height="1334" alt="Screen Shot 2026-03-17 at 10 56 48" src="https://github.com/user-attachments/assets/039d870c-21f0-47f6-bc60-301b16633828" /> | <img width="750" height="1334" alt="Screen Shot 2026-03-17 at 10 57 07" src="https://github.com/user-attachments/assets/43311aad-35c6-4c31-9f90-6c0311dae752" /> | <img width="750" height="1334" alt="Screen Shot 2026-03-17 at 10 57 13" src="https://github.com/user-attachments/assets/7838cda3-a53f-4075-8744-7e948f1b4ce2" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Open the XKit control panel
    - **Expected result**: The sponsor progress element is immediately visible, and loads my sponsor goal progress
3. Scroll the Configuration tabpanel
    - **Expected result**: The sponsor progress element keeps its position
    - **Expected result**: The sponsor progress element's presence does not prevent you from seeing the last feature in the list

The other half of validating this PR is your opinion on whether or not this is okay to add, or if you believe my own goal is unreasonable in the face of your (so far, unpaid) contributions. I will not make this change without your consent.