### PR TITLE
fix: Trim Reblogs: Update/clarify warning about trimming reblogs

### DIFF
--- a/src/features/trim_reblogs/index.js
+++ b/src/features/trim_reblogs/index.js
@@ -59,9 +59,9 @@ const onButtonClicked = async function ({ currentTarget: controlButton }) {
       showModal({
         title: '⚠️ This thread contains an ask!',
         message: [
-          `Trimming an ask from a thread will result in it appearing broken on custom themes (i.e. ${blog?.name}.tumblr.com).`,
+          `Trimming an ask from a thread has resulted in it appearing broken on custom themes (i.e. ${blog?.name}.tumblr.com) in the past.`,
           '\n\n',
-          'To avoid issues with custom themes, leave the ask intact when trimming.',
+          'To completely avoid issues with custom themes, leave the ask intact when trimming.',
         ],
         buttons: [
           modalCancelButton,


### PR DESCRIPTION
Fixes #2048

Updates the ask warning modal in `onButtonClicked` (`src/features/trim_reblogs/index.js`) to use past tense, reflecting that trimming asks no longer consistently causes broken appearances on custom themes. The original warning overstated the certainty of breakage with "will result in", which was inaccurate given changes to how Tumblr handles asks. Changes the phrasing to "has resulted in... in the past" and adds "completely" to the second sentence to clarify that leaving the ask intact remains the safest option without implying trimming is guaranteed to break. Verified by reviewing the modal message strings in `index.js` against the issue report.