### PR TITLE
fix(UI): increase Coloris picker width

### DIFF
--- a/src/action/popup.css
+++ b/src/action/popup.css
@@ -163,3 +163,7 @@ textarea {
   scrollbar-color: rgba(var(--black), 0.5) rgb(var(--passive-grey));
   scrollbar-width: thin;
 }
+
+.clr-picker {
+  width: 210px;
+}


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Before | After
-|-
<img width="750" height="1334" alt="Screen Shot 2026-03-19 at 10 51 04" src="https://github.com/user-attachments/assets/a654a052-effb-4b6a-b967-369e6c3977bb" /> | <img width="750" height="1334" alt="Screen Shot 2026-03-19 at 10 53 35" src="https://github.com/user-attachments/assets/577380f7-804d-432f-8783-34d76f3e5763" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Open the XKit control panel &rarr; Painter
3. Open the Coloris colour picker
    - **Expected result**: The "Clear" and "Close" buttons are on the same line once again
