### PR TITLE
feat(UI): Acorn styling for control panel tab buttons

### DIFF
--- a/src/action/popup.css
+++ b/src/action/popup.css
@@ -130,6 +130,8 @@ main {
 [role="tablist"] [role="tab"] {
   min-height: 32px;
   min-width: 79px;
+  flex-grow: 1;
+  flex-shrink: 0;
   padding: 3.75px 15px;
   border: 1px solid transparent;
   border-radius: 8px;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- Storybook: [UI Widgets &rarr; Named Deck &rarr; Tabs](https://firefoxux.github.io/firefox-desktop-components/?path=/story/ui-widgets-named-deck--tabs)
- Storybook: [UI Widgets &rarr; Button &rarr; README § Ghost](https://firefoxux.github.io/firefox-desktop-components/?path=/docs/ui-widgets-button-readme--docs#ghost)

Before | After | Before | After
-|-|-|-
<img width="750" height="1334" alt="Screen Shot 2026-03-24 at 15 14 35" src="https://github.com/user-attachments/assets/ddd13953-2077-4872-b0d0-116dbbb9df42" /> | <img width="750" height="1334" alt="Screen Shot 2026-03-25 at 13 47 43" src="https://github.com/user-attachments/assets/c96c3b79-a581-4bad-b78c-7e87219bbbca" /> | <img width="750" height="1334" alt="Screen Shot 2026-03-24 at 15 14 40" src="https://github.com/user-attachments/assets/7bfcc49e-a385-4f8f-a1c4-ab6d54280c2f" /> | <img width="750" height="1334" alt="Screen Shot 2026-03-25 at 13 47 46" src="https://github.com/user-attachments/assets/a4628451-4f28-4aa6-be2b-ade209ff679c" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
On both light and dark colour schemes, the tablist buttons should have sufficient readable contrast...
- When not selected and not hovered
- When not selected and hovered
- When not selected and hovered and pressed
- When selected

Their focus outline colour should match other accented parts of the UI, such as enabled feature toggle switches.
