### PR TITLE
refactor: Alternative double-inject prevention method (key in query param)

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -94,18 +94,6 @@
     return installedFeatures;
   };
 
-  const initMainWorld = () => new Promise(resolve => {
-    document.documentElement.addEventListener('xkit-injection-ready', resolve, { once: true });
-
-    const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
-    const script = Object.assign(document.createElement('script'), {
-      type: 'module',
-      nonce,
-      src: browser.runtime.getURL(`/main_world/index.js?t=${timestamp}`),
-    });
-    document.documentElement.append(script);
-  });
-
   const init = async function () {
     $('style.xkit, link.xkit').remove();
 
@@ -117,13 +105,13 @@
     ] = await Promise.all([
       getInstalledFeatures(),
       browser.storage.local.get(enabledFeaturesKey),
-      initMainWorld(),
     ]);
 
     /**
      * fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await
      * @see https://github.com/sveltejs/kit/issues/7805#issuecomment-1330078207
      */
+    await Promise.all(['inject'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
     await Promise.all(['css_map', 'language_data', 'user'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
 
     installedFeatures

--- a/src/main_world/index.js
+++ b/src/main_world/index.js
@@ -1,11 +1,8 @@
 const moduleCache = {};
 
-window.removeXKitListener?.();
+const key = new URL(import.meta.url).searchParams.get('key');
 
-const controller = new AbortController();
-window.removeXKitListener = () => controller.abort();
-
-document.documentElement.addEventListener('xkit-injection-request', async event => {
+document.documentElement.addEventListener(`xkit-injection-request-${key}`, async event => {
   const { detail, target } = event;
   const { id, path, args } = JSON.parse(detail);
 
@@ -19,16 +16,16 @@ document.documentElement.addEventListener('xkit-injection-request', async event 
 
     if (result instanceof Element) {
       result.dispatchEvent(
-        new CustomEvent('xkit-injection-element-response', { detail: JSON.stringify({ id }), bubbles: true }),
+        new CustomEvent(`xkit-injection-element-response-${key}`, { detail: JSON.stringify({ id }), bubbles: true }),
       );
     } else {
       document.documentElement.dispatchEvent(
-        new CustomEvent('xkit-injection-response', { detail: JSON.stringify({ id, result }) }),
+        new CustomEvent(`xkit-injection-response-${key}`, { detail: JSON.stringify({ id, result }) }),
       );
     }
   } catch (exception) {
     target.dispatchEvent(
-      new CustomEvent('xkit-injection-response', {
+      new CustomEvent(`xkit-injection-response-${key}`, {
         detail: JSON.stringify({
           id,
           exception: {
@@ -41,6 +38,6 @@ document.documentElement.addEventListener('xkit-injection-request', async event 
       }),
     );
   }
-}, { signal: controller.signal });
+});
 
-document.documentElement.dispatchEvent(new CustomEvent('xkit-injection-ready'));
+document.documentElement.dispatchEvent(new CustomEvent(`xkit-injection-ready-${key}`));

--- a/src/utils/inject.js
+++ b/src/utils/inject.js
@@ -1,3 +1,17 @@
+const key = Date.now();
+
+await new Promise(resolve => {
+  document.documentElement.addEventListener(`xkit-injection-ready-${key}`, resolve, { once: true });
+
+  const { nonce } = [...document.scripts].find(script => script.getAttributeNames().includes('nonce'));
+  const script = Object.assign(document.createElement('script'), {
+    type: 'module',
+    nonce,
+    src: browser.runtime.getURL(`/main_world/index.js?key=${key}`),
+  });
+  document.documentElement.append(script);
+});
+
 /**
  * Runs a function in the page's "main" execution environment and returns
  * its result. This permits access to variables exposed by the Tumblr web
@@ -17,8 +31,8 @@ export const inject = (path, args = [], target = document.documentElement) =>
       const { id, result, exception } = JSON.parse(detail);
       if (id !== requestId) return;
 
-      document.documentElement.removeEventListener('xkit-injection-response', responseHandler);
-      document.documentElement.removeEventListener('xkit-injection-element-response', responseHandler);
+      document.documentElement.removeEventListener(`xkit-injection-response-${key}`, responseHandler);
+      document.documentElement.removeEventListener(`xkit-injection-element-response-${key}`, responseHandler);
 
       if (exception) {
         reject(exception);
@@ -28,10 +42,10 @@ export const inject = (path, args = [], target = document.documentElement) =>
         resolve(result);
       }
     };
-    document.documentElement.addEventListener('xkit-injection-response', responseHandler);
-    document.documentElement.addEventListener('xkit-injection-element-response', responseHandler);
+    document.documentElement.addEventListener(`xkit-injection-response-${key}`, responseHandler);
+    document.documentElement.addEventListener(`xkit-injection-element-response-${key}`, responseHandler);
 
     target.dispatchEvent(
-      new CustomEvent('xkit-injection-request', { detail: JSON.stringify(data), bubbles: true }),
+      new CustomEvent(`xkit-injection-request-${key}`, { detail: JSON.stringify(data), bubbles: true }),
     );
   });


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

A year and a half ago, as noted in #1597, we had to prevent XKit Rewritten being initialized multiple times in Firefox from causing the inject function to trigger multiple times each time it's called, causing effects like double reblogs. I PR'd 4 methods to do this and we merged option 4. While looking through some old posts I thought of a 5th option; here it is.

Specifically, this is essentially identical to the first option, #1598 (sending a unique key from the content script to the main world script and appending it to event names), but it uses the query parameter on the main world script url instead of a data attribute, which I just think is fun, you know?

Again, as mentioned previously, using a statically specified main world script (#1538) isn't compatible with this, and it doesn't confer any other benefit that I know of, so this is just for reference/to potentially make someone think of an actually useful thing to do with "you can read query parameters on script urls; isn't that neat" after they read it.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Load the extension in Firefox.
- Turn the extension on and off a large number of times.
- Reblog a post with Quick Reblog and confirm that it is only reblogged once.