### PR TITLE
ci(Release Notes): add missing environment variables

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -23,4 +23,6 @@ jobs:
       - name: Generate release notes
         run: dev/release-notes.js >> $GITHUB_STEP_SUMMARY
         env:
+          GITHUB_API_URL: ${{ github.api_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Adds `GITHUB_API_URL` and `GITHUB_REPOSITORY` environment variables to the Release Notes workflow.

Adding the former is more of a completeness thing (it's available on the `github` context, so why not use it) while the latter should enable this workflow to work properly on forks, instead of always querying `AprilSylph/XKit-Rewritten`.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
See https://github.com/AprilSylph/XKit-Rewritten/actions/runs/23543601713 to verify that the workflow is not broken in the source repository by this change.

To validate that this has the intended effect on forks, you will need to:
1. Copy this branch to your fork
2. Drop one or more `src/`-affecting commits from your fork's default<sup>[?]</sup> branch (or just don't update it, if it's behind upstream), to make it differ
3. Run the modified workflow in your fork
    - **Expected result**: The commits printed match those present on your fork's default<sup>[?]</sup> branch