### PR TITLE
chore: Improve release notes script error logging

### DIFF
--- a/dev/release-notes.js
+++ b/dev/release-notes.js
@@ -24,7 +24,9 @@ try {
   }
 
   if (!refs.isSubsetOf(commits)) {
-    console.log('⚠️ Could not find commit info for one or more commits:', [...refs.difference(commits)].join(', '));
+    console.log('> [!WARNING]');
+    console.log('> The GitHub REST API did not return info for these commits:');
+    refs.difference(commits).forEach(ref => console.log(`> - \`${ref}\``));
   }
 
   console.log('```md');


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

> Two slightly interesting notes from testing a #1843 merge:
> 
> - console.warn writes to stderr, so `dev/release-notes.js >> $GITHUB_STEP_SUMMARY` will not include the "Could not find commit info" message.
> - Set.prototype.intersection() uses the order of the smaller set; this means that in the case where we create more than 100 commits between releases, the commits will be listed in reverse-chronological order.

_Originally posted by @marcustyphoon in https://github.com/AprilSylph/XKit-Rewritten/issues/2113#issuecomment-3919987465_

This fixes the first point, so that the "Could not find commit info" message appears in the workflow output, and also prints the missing commits because why not.

(Does not address the second.)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

See https://github.com/marcustyphoon/XKit-Rewritten/actions/runs/23562650175 for a run with this commit.