### PR TITLE
feat(UI): use Acorn typography and link styles in Links tab

### DIFF
--- a/src/action/links.css
+++ b/src/action/links.css
@@ -1,32 +1,10 @@
 #links-panel {
+  font-size: 15px;
   padding: 8px;
 }
 
-#links-panel ul {
-  margin-block-start: 0;
-  margin-block-end: 16px;
-}
-
-#links-panel ul:last-child {
-  margin-block-end: 8px;
-}
-
-#links-panel ul li {
-  margin-bottom: 8px;
-}
-
-#links-panel a {
-  font-weight: bold;
-  text-decoration: none;
-}
-
-#links-panel :link,
-#links-panel :visited {
-  color: rgb(var(--accent));
-}
-
 #version {
-  margin-left: 1ch;
+  margin-left: 7.5px;
   user-select: all;
 }
 

--- a/src/action/popup.css
+++ b/src/action/popup.css
@@ -367,8 +367,31 @@ h3 {
   margin: 0;
 }
 
-h4 {
-  margin-block: 8px;
+:is(ol, ul) {
+  margin-block: 7.5px 22.5px;
+}
+
+:is(ol, ul) li {
+  margin-block: 7.5px;
+}
+
+:any-link {
+  color: var(--color-accent-primary);
+}
+
+:any-link:hover {
+  color: var(--color-accent-primary-hover);
+}
+
+:any-link:hover:active {
+  color: var(--color-accent-primary-active);
+  text-decoration: none;
+}
+
+:any-link:focus-visible {
+  border-radius: 4px;
+  outline: var(--focus-outline);
+  outline-offset: 1px;
 }
 
 textarea {

--- a/src/action/popup.html
+++ b/src/action/popup.html
@@ -111,31 +111,39 @@
         </dialog>
       </section>
       <section id="links-panel" role="tabpanel" aria-labelledby="links-tab" tabindex="0" hidden>
-        <h4>Help & information</h4>
-        <ul>
-          <li><a href="https://github.com/AprilSylph/XKit-Rewritten/wiki" target="_blank">User guide</a></li>
-          <li><a href="https://github.com/AprilSylph/XKit-Rewritten/discussions" target="_blank">Support & discussion</a></li>
-          <li><a href="https://github.com/AprilSylph/XKit-Rewritten/releases" target="_blank">Changelog</a><small id="version"></small></li>
-        </ul>
-        <h4>Donate</h4>
-        <ul>
-          <li><a href="https://github.com/AprilSylph/XKit-Rewritten?sponsor=1#readme" target="_blank">Sponsor the project</a></li>
-        </ul>
-        <h4>Get involved</h4>
-        <ul>
-          <li><a href="https://github.com/AprilSylph/XKit-Rewritten" target="_blank">Source code</a></li>
-          <li><a href="https://github.com/AprilSylph/XKit-Rewritten/issues" target="_blank">Issue tracker</a></li>
+        <section>
+          <h3>Help & information</h3>
           <ul>
-            <li><a href="https://github.com/AprilSylph/XKit-Rewritten/issues?q=is%3Aopen+is%3Aissue+label%3Abug" target="_blank">Known bugs</a></li>
-            <li><a href="https://github.com/AprilSylph/XKit-Rewritten/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement" target="_blank">Suggested features</a></li>
+            <li><a href="https://github.com/AprilSylph/XKit-Rewritten/wiki" target="_blank">User guide</a></li>
+            <li><a href="https://github.com/AprilSylph/XKit-Rewritten/discussions" target="_blank">Support & discussion</a></li>
+            <li><a href="https://github.com/AprilSylph/XKit-Rewritten/releases" target="_blank">Changelog</a><small id="version"></small></li>
           </ul>
-        </ul>
-        <h4>Related projects</h4>
-        <ul>
-          <li><a href="https://github.com/AprilSylph/Palettes-for-Tumblr#readme" target="_blank">Palettes for Tumblr</a></li>
-          <li><a href="https://github.com/AprilSylph/Outbox-for-Tumblr#readme" target="_blank">Outbox for Tumblr</a></li>
-          <li><a href="https://github.com/AprilSylph/Filtering-Plus#readme" target="_blank">Filtering+ for Tumblr</a></li>
-        </ul>
+        </section>
+        <section>
+          <h3>Donate</h3>
+          <ul>
+            <li><a href="https://github.com/AprilSylph/XKit-Rewritten?sponsor=1#readme" target="_blank">Sponsor the project</a></li>
+          </ul>
+        </section>
+        <section>
+          <h3>Get involved</h3>
+          <ul>
+            <li><a href="https://github.com/AprilSylph/XKit-Rewritten" target="_blank">Source code</a></li>
+            <li><a href="https://github.com/AprilSylph/XKit-Rewritten/issues" target="_blank">Issue tracker</a></li>
+            <ul>
+              <li><a href="https://github.com/AprilSylph/XKit-Rewritten/issues?q=is%3Aopen+is%3Aissue+label%3Abug" target="_blank">Known bugs</a></li>
+              <li><a href="https://github.com/AprilSylph/XKit-Rewritten/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement" target="_blank">Suggested features</a></li>
+            </ul>
+          </ul>
+        </section>
+        <section>
+          <h3>Related projects</h3>
+          <ul>
+            <li><a href="https://github.com/AprilSylph/Palettes-for-Tumblr#readme" target="_blank">Palettes for Tumblr</a></li>
+            <li><a href="https://github.com/AprilSylph/Outbox-for-Tumblr#readme" target="_blank">Outbox for Tumblr</a></li>
+            <li><a href="https://github.com/AprilSylph/Filtering-Plus#readme" target="_blank">Filtering+ for Tumblr</a></li>
+          </ul>
+        </section>
       </section>
     </main>
     <sponsor-progress role="contentinfo"></sponsor-progress>


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- Storybook: [UI Widgets / Support Link - Primary](https://firefoxux.github.io/firefox-desktop-components/?path=/story/ui-widgets-support-link--primary)

I couldn't find any examples of an unordered list within the Acorn design system, so I kinda just made it up (although still using legal Acorn spacing, of course).

Before | After | Before | After
-|-|-|-
<img width="750" height="1334" alt="Screen Shot 2026-03-27 at 14 53 07" src="https://github.com/user-attachments/assets/d635e322-f303-435c-bb91-23f9b935a9c4" /> | <img width="750" height="1334" alt="Screen Shot 2026-03-27 at 14 53 30" src="https://github.com/user-attachments/assets/b8ebdec4-6403-416f-a6af-3df2914d2df9" /> | <img width="750" height="1334" alt="Screen Shot 2026-03-27 at 14 53 11" src="https://github.com/user-attachments/assets/f0129706-7d21-40ce-b939-36005798b93a" /> | <img width="750" height="1334" alt="Screen Shot 2026-03-27 at 14 53 35" src="https://github.com/user-attachments/assets/d13effd8-0205-4875-96d5-f3da6f0b01fb" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Anchor elements in the Links tab should now have hover, active, and focus-visible styles matching those of the Storybook entry linked above.

Help links on feature elements should be unchanged, apart from the new focus outline.
