### PR TITLE
feat(UI): add all state styles to Acorn toggle switches

### DIFF
--- a/src/action/components/xkit-feature/index.css
+++ b/src/action/components/xkit-feature/index.css
@@ -35,28 +35,41 @@ summary:focus {
   height: var(--toggle-height);
   width: var(--toggle-width);
   padding: 0;
-  border-color: rgb(var(--black));
+  border-color: var(--border-color-interactive);
   border-style: solid;
   border-width: var(--toggle-border-width);
   border-radius: 9999px;
 
-  background-color: rgb(var(--passive-grey));
-  color: rgb(var(--black));
+  background-color: var(--button-background-color);
+  color: var(--border-color-interactive);
 }
 
 [role="switch"]:hover {
-  background-color: rgb(var(--active-grey));
+  background-color: var(--button-background-color-hover);
+}
+
+[role="switch"]:hover:active {
+  background-color: var(--button-background-color-active);
 }
 
 [role="switch"]:focus-visible {
+  outline: var(--focus-outline);
   outline-offset: 2px;
 }
 
 [role="switch"]:checked {
   border-color: transparent;
 
-  background-color: rgb(var(--accent));
-  color: rgb(var(--white));
+  background-color: var(--color-accent-primary);
+  color: var(--background-color-canvas);
+}
+
+[role="switch"]:checked:hover {
+  background-color: var(--color-accent-primary-hover);
+}
+
+[role="switch"]:checked:hover:active {
+  background-color: var(--color-accent-primary-active);
 }
 
 [role="switch"]::before {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- Storybook: [UI Widgets / Toggle - Default](https://firefoxux.github.io/firefox-desktop-components/?path=/story/ui-widgets-toggle--default)

The above Storybook entry is actually broken for me right now, so I used `about:addons` as a reference instead.

Makes our feature toggles use Acorn colour tokens, and adds all the missing state styles.

Screenshots are ordered by Stateless &rarr; Hovered &rarr; Active &rarr; Focused.

Before | After
-|-
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 52 16" src="https://github.com/user-attachments/assets/afc8284f-0169-4c29-b536-fee69bd91563" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 55 13" src="https://github.com/user-attachments/assets/c604c1a5-cdac-4b25-bdae-119403f9cb92" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 38 23" src="https://github.com/user-attachments/assets/4679ed0b-a58a-431b-b810-b6d868649d2b" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 45 24" src="https://github.com/user-attachments/assets/da36232e-d465-4fc5-bbf8-275b3c30e551" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 38 33" src="https://github.com/user-attachments/assets/a80f23b2-4b8d-419a-bbea-3b4f012f2abb" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 45 31" src="https://github.com/user-attachments/assets/22ec113f-b237-402e-9df3-8a7ca054e9e4" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 39 34" src="https://github.com/user-attachments/assets/fd60eff3-36e2-40fd-a139-c1a99ce208a5" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 45 44" src="https://github.com/user-attachments/assets/e1c89a2b-9fff-41aa-a6dc-c642b1d22394" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 52 30" src="https://github.com/user-attachments/assets/718576eb-b965-465f-8bca-9b371c9dc309" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 55 46" src="https://github.com/user-attachments/assets/5f78452f-34b6-412b-80b8-256fa13669f9" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 39 55" src="https://github.com/user-attachments/assets/fa64ba04-3b03-4035-a205-86bc21cb1b5e" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 46 02" src="https://github.com/user-attachments/assets/0e778e60-c935-433f-823e-609b730bbc30" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 40 17" src="https://github.com/user-attachments/assets/a4b43f6a-a79e-4c63-9e51-c07cb2688e5f" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 46 17" src="https://github.com/user-attachments/assets/b7b2efd8-d953-422d-a19a-02954fc76fd5" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 40 31" src="https://github.com/user-attachments/assets/17642ad1-0de0-406b-b142-5bd9247dacf8" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 46 32" src="https://github.com/user-attachments/assets/00db0c0b-3024-4a55-ada6-b44560e45b66" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 53 41" src="https://github.com/user-attachments/assets/fc13fdd6-34c9-4278-8f68-e85a0673d947" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 55 54" src="https://github.com/user-attachments/assets/95cb457d-017a-4a54-9f6e-2b65aab15f3c" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 41 45" src="https://github.com/user-attachments/assets/d9e28868-3420-49ed-a9a4-cea5cabab76d" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 46 52" src="https://github.com/user-attachments/assets/84c444ac-00f1-48ac-8a5e-def70540a638" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 41 55" src="https://github.com/user-attachments/assets/7a572233-640c-4b86-9e5f-cab0e3c0851d" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 47 02" src="https://github.com/user-attachments/assets/ddbeb622-32ed-4a0a-874f-1e7b3620bb63" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 42 08" src="https://github.com/user-attachments/assets/e6e9882c-cec2-4511-a89a-453e49c3a401" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 47 17" src="https://github.com/user-attachments/assets/e70f7d9f-7d2a-48e5-b11e-b49f095aee5a" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 53 54" src="https://github.com/user-attachments/assets/90a4ca33-4299-4aa1-9a17-831707f86998" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 56 01" src="https://github.com/user-attachments/assets/20697e44-97ea-4aca-89bb-848dbf243dea" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 42 30" src="https://github.com/user-attachments/assets/6b0a2e80-6117-4198-bc4b-e5c37dd56b44" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 47 39" src="https://github.com/user-attachments/assets/5e1ab184-65dd-45ab-ba52-5db966438216" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 42 36" src="https://github.com/user-attachments/assets/b7660600-e725-43e4-88da-7f3cfd79d9a3" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 47 51" src="https://github.com/user-attachments/assets/6f6892f1-ea8c-455e-b2fb-a9abb6a10644" />
<img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 42 48" src="https://github.com/user-attachments/assets/4368d34c-3697-4119-8879-e6927cb80257" /> | <img width="750" height="98" alt="Screen Shot 2026-03-27 at 15 48 04" src="https://github.com/user-attachments/assets/a65bb4b7-66ea-4131-b946-311d8c1c9975" />

I'm starting to wonder if we still need the disabled/deprecated suffixes on feature titles...

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Load the modified addon, play with feature switches. They should feel more interactive now, especially when toggled on.
