### PR TITLE
feat(UI): use Acorn dimensions+colours in `sponsor-progress`

### DIFF
--- a/src/action/components/sponsor-progress/index.css
+++ b/src/action/components/sponsor-progress/index.css
@@ -40,7 +40,7 @@
 
 @media (prefers-reduced-motion: no-preference) {
   #progress-bar {
-    transition: width 1s ease-in-out;
+    transition: width 0.5s ease-in;
   }
 }
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Updates `SponsorProgressElement` for full Acorn adherence.

Also fixes a bug where the contents of the Configuration tab could become visible in a 1px line south of this element.

Before | After | Before | After
-|-|-|-
<img width="750" height="1334" alt="Screen Shot 2026-04-01 at 13 53 44" src="https://github.com/user-attachments/assets/b1bbfa83-9e32-42ad-8a8d-afb51de18f30" /> | <img width="750" height="1334" alt="Screen Shot 2026-04-01 at 13 56 05" src="https://github.com/user-attachments/assets/905194da-abe1-4bc8-8e9e-5cd925c5b62c" /> | <img width="750" height="1334" alt="Screen Shot 2026-04-01 at 13 53 49" src="https://github.com/user-attachments/assets/addf8c9e-8a30-4b66-b893-bab198017b32" /> | <img width="750" height="1334" alt="Screen Shot 2026-04-01 at 13 56 10" src="https://github.com/user-attachments/assets/37b3e8f1-4811-4c70-bae9-452d20ebbda5" />
<img width="490" height="670" alt="Screenshot 2026-04-01 at 1 55 21 pm" src="https://github.com/user-attachments/assets/4691bf8e-0171-401c-abf0-83ec15e4f614" /> | <img width="490" height="670" alt="Screenshot 2026-04-01 at 1 56 34 pm" src="https://github.com/user-attachments/assets/694db5f1-a9c0-487d-b23b-6b2275dc2141" /> | <img width="490" height="670" alt="Screenshot 2026-04-01 at 1 55 42 pm" src="https://github.com/user-attachments/assets/65e639f9-6e65-40be-bc21-ba022842cdd3" /> | <img width="490" height="670" alt="Screenshot 2026-04-01 at 1 56 51 pm" src="https://github.com/user-attachments/assets/8918501c-311d-4c7c-a993-4852cedc7208" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Load the modified addon and <kbd>Tab</kbd> to the sponsor progress link. The focus outline should be fully visible on all sides.

If you're seeing the pixel rounding bug on the `acorn` branch (it showed up for me in Chrome 146, but not Firefox 150), you should not be able to reproduce it on this branch/build.
