### PR TITLE
feat(UI): use Acorn badges on features

### DIFF
--- a/src/action/components/xkit-feature/index.css
+++ b/src/action/components/xkit-feature/index.css
@@ -177,11 +177,16 @@ summary:focus-visible {
 }
 
 .badge ::slotted(span) {
-  padding: 2px 6px;
-  border-radius: 1em;
+  width: fit-content;
+  padding-inline: 3.75px;
+  border: 1px solid var(--badge-border-color-filled);
+  border-radius: 4px;
 
-  background-color: #ff62ce;
-  color: var(--text-color);
+  background-color: var(--badge-background-color-filled);
+  color: var(--badge-text-color-filled);
+  font-size: 13px;
+  font-weight: 600;
+  text-transform: uppercase;
 }
 
 .title,

--- a/src/action/popup.css
+++ b/src/action/popup.css
@@ -44,6 +44,9 @@
   --icon-color-success: #008e00;
   --icon-color-warning: #b16a00;
   --icon-color-critical: #cf1748;
+  --badge-background-color-filled: #007700;
+  --badge-border-color-filled: #fbfbfe66;
+  --badge-text-color-filled: #ffffff;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -92,6 +95,9 @@
     --icon-color-success: #8adf8d;
     --icon-color-warning: #f5cc58;
     --icon-color-critical: #ffa0aa;
+    --badge-background-color-filled: #37b847;
+    --badge-border-color-filled: #15141a66;
+    --badge-text-color-filled: #15141a;
   }
 }
 

--- a/src/action/render_features.js
+++ b/src/action/render_features.js
@@ -99,7 +99,8 @@ const renderFeatures = async function () {
     } else {
       const spanElement = document.createElement('span');
       spanElement.setAttribute('slot', 'badge');
-      spanElement.textContent = 'New!';
+      spanElement.setAttribute('role', 'note');
+      spanElement.textContent = 'New';
       featureElement.append(spanElement);
     }
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- [Storybook: UI Widgets / Badge - New](https://firefoxux.github.io/firefox-desktop-components/?path=/story/ui-widgets-badge--new)

This is another Storybook entry that looks broken—it's referencing CSS variables which are found in the tokens table, but are not present in the rendered story itself. I'm assuming this is not intentional, and have attempted to compensate.

To be honest, I liked them more the way they looked before, when they weren't uppercased. Oh well...

Before | After | Before | After
-|-|-|-
<img width="750" height="1334" alt="Screen Shot 2026-04-01 at 15 33 42" src="https://github.com/user-attachments/assets/ce89ce5c-25f5-45cb-86b8-5831d937b4a9" /> | <img width="750" height="1334" alt="Screen Shot 2026-04-01 at 16 22 40" src="https://github.com/user-attachments/assets/ec8f91be-c90f-45e3-89b9-fba99af75fb4" /> | <img width="750" height="1334" alt="Screen Shot 2026-04-01 at 15 33 46" src="https://github.com/user-attachments/assets/0ba19d8d-1d08-4907-b541-ee897678ef1f" /> | <img width="750" height="1334" alt="Screen Shot 2026-04-01 at 16 22 44" src="https://github.com/user-attachments/assets/37f57a48-6af6-467f-89ca-f888af30ba75" />

This PR also gives [`role="note"`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Roles/note_role) to "New" and deprecated badges, since I would personally classify this information as "parenthetic". Is that silly? Should feature descriptions be considered the more ancillary part of the summary?

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon and open the XKit control panel
    - **Expected result**: Help icons still display on all features
    - **Expected result**: Help icons still link to their appropriate wiki sections
2. Use the Backup tab to give yourself access to at least one deprecated feature
    - **Expected result**: Deprecated features have Acorn warning icons
    - **Expected result**: Hovering a deprecated feature warning icon informs you that "This feature is deprecated."