### PR TITLE
fix(Classic Footer): hide updated reblog menus

### DIFF
--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -186,11 +186,7 @@ export const styleElement = buildStyle(`
   span:has(${quickActionsSelector}) > .${reblogLinkClass} {
     display: none;
   }
-
   .${reblogLinkClass} ~ ${reblogButtonSelector}:not(:has(${quickActionsSelector})) {
-    display: none;
-  }
-  body:has(.${reblogLinkClass}) > ${reblogMenuPortalSelector}:not(:has([role="menu"][aria-labelledby])) {
     display: none;
   }
 `);

--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -18,7 +18,7 @@ const replyButtonSelector = 'button:has(svg use[href="#managed-icon__ds-reply-ou
 const reblogButtonSelector = 'button:has(svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__ds-queue-add-24"]))';
 const quickActionsSelector = 'svg[style="--icon-color-primary: var(--brand-blue);"], svg[style="--icon-color-primary: var(--brand-purple);"]';
 const closeNotesButtonSelector = `${postOrRadarSelector} ${keyToCss('postActivity')} [role="tablist"] button:has(svg use[href="#managed-icon__ds-ui-x-20"])`;
-const reblogMenuPortalSelector = 'div[id^="portal/"]:has(div[role="menu"] a[role="menuitem"][href^="/reblog/"])';
+const reblogMenuPortalSelector = ':is(div[id^="portal/"], #glass-container):has(div[role="menu"] a[role="menuitem"][href^="/reblog/"])';
 
 const { lang } = document.documentElement;
 const noteCountFormat = new Intl.NumberFormat(lang);
@@ -285,6 +285,7 @@ const getReblogMenuItem = async (reblogButton, href) => {
       }
     });
     mutationObserver.observe(document.body, { childList: true });
+    mutationObserver.observe(document.getElementById('glass-container'), { childList: true });
 
     // Open the reblog menu for the observer to find.
     reblogButton.click();
@@ -312,19 +313,18 @@ const processReblogButton = (reblogButton, timelineObjectData, trailItemData) =>
 
   const { blog: { name } } = trailItemData ?? timelineObjectData;
   const { canReblog, id } = trailItemData?.post ?? timelineObjectData;
-
-  // trail items have the same reblog key as their parent post
-  const { reblogKey } = timelineObjectData;
+  const { reblogKey } = timelineObjectData; // Trail items have the same reblog key as their parent post
 
   if (!canReblog) return;
 
-  const styleContent = `${reblogMenuPortalSelector}:has([aria-labelledby="${reblogButton.id}"]) { display: none; }`;
+  const reblogLinkPath = `/reblog/${name}/${id}/${reblogKey}`;
+  const styleContent = `${reblogMenuPortalSelector}:has([role="menuitem"][href^="${reblogLinkPath}"]) { display: none; }`;
 
   const reblogLink = a({
     'aria-label': reblogButton.getAttribute('aria-label'),
     class: reblogLinkClass,
     click: onReblogLinkClick,
-    href: `/reblog/${name}/${id}/${reblogKey}`,
+    href: reblogLinkPath,
   }, [
     link({ rel: 'stylesheet', class: 'xkit', href: `data:text/css,${encodeURIComponent(styleContent)}` }),
     reblogButton.firstElementChild.cloneNode(true)],

--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -26,7 +26,7 @@ const reblogButtonSelector = `button:has(svg use:is(
 ))`;
 const quickActionsSelector = 'svg[style="--icon-color-primary: var(--brand-blue);"], svg[style="--icon-color-primary: var(--brand-purple);"]';
 const closeNotesButtonSelector = `${postOrRadarSelector} ${keyToCss('postActivity')} [role="tablist"] button:has(svg use[href="#managed-icon__ds-ui-x-20"])`;
-const reblogMenuPortalSelector = ':is(div[id^="portal/"], #glass-container):has(div[role="menu"] a[role="menuitem"][href^="/reblog/"])';
+const reblogMenuPortalSelector = ':is(div[id^="portal/"], #glass-container > div):has(div[role="menu"] a[role="menuitem"][href^="/reblog/"])';
 
 const { lang } = document.documentElement;
 const noteCountFormat = new Intl.NumberFormat(lang);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- Fixes #2212 

Updates the targeting for the reblog menu portal and reblog link menu item.

This code aims to be compatible with the prior version of the reblog menu as well, in case this change is reverted.

Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2026-04-14 at 08 48 00" src="https://github.com/user-attachments/assets/69cd355d-2895-43ef-85de-a0d018d3ece2" /> | <img width="3840" height="2400" alt="Screen Shot 2026-04-14 at 08 49 19" src="https://github.com/user-attachments/assets/263dccef-fbbb-430e-bb68-1894cd796d3c" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Open a Tumblr tab
3. Click a reblog button to make the reblog menu appear
4. Enable Classic Footer, leaving its preferences as their defaults
    - **Expected result**: The reblog menu disappears
5. Click a reblog icon link on a post
    - **Expected result**: The reblog form is opened, without the reblog menu being visible for even a single frame
6. (Optional) Click a reblog icon link on a post with advertising data (you may have to temporarily disable the feature to find one accurately; we're looking for a post whose reblog menu has a reblog link href that doesn't perfectly match `/reblog/${name}/${id}/${reblogKey}`
    - **Expected result**: The reblog form is opened, without the reblog menu being visible for even a single frame
