### PR TITLE
fix(Quick Reblog): unbreak feature on masonry posts

### DIFF
--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -1,5 +1,5 @@
 #quick-reblog {
-  --origin-clearance: 4px;
+  --origin-clearance: 6px;
 
   position: absolute;
   z-index: 97;

--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -1,4 +1,6 @@
 #quick-reblog {
+  --origin-clearance: 4px;
+
   position: absolute;
   z-index: 97;
   box-shadow: 0 0 15px 0 rgba(0, 0, 0, 0.5);
@@ -21,24 +23,15 @@
   display: none !important;
 }
 
-#quick-reblog {
-  --icon-spacing: 12px;
-}
-@media not (min-width: 990px) {
-  #quick-reblog {
-    --icon-spacing: 0px;
-  }
-}
-
 #quick-reblog[data-position="below"] {
   inset: 100% 50% auto auto;
-  transform: translate(calc(50% + var(--horizontal-offset, 0%)), var(--icon-spacing));
+  transform: translate(calc(50% + var(--horizontal-offset, 0%)), var(--origin-clearance));
 }
 #quick-reblog[data-position="above"] {
   inset: auto 50% 100% auto;
   transform: translate(
     calc(50% + var(--horizontal-offset, 0%)),
-    calc(0px - var(--icon-spacing))
+    calc(0px - var(--origin-clearance))
   );
 }
 

--- a/src/features/quick_reblog/index.css
+++ b/src/features/quick_reblog/index.css
@@ -281,15 +281,35 @@
 
 /* === AlreadyReblogged === */
 
-footer.published :is(a, button):has(svg use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"])) { color: rgb(var(--green)); }
-footer.queue :is(a, button):has(svg use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"])) { color: rgb(var(--purple)); }
-footer.draft :is(a, button):has(svg use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"])) { color: rgb(var(--red)); }
+footer.published :is(a, button):has(svg use:is(
+  [href="#managed-icon__reblog"],
+  [href="#managed-icon__ds-reblog-20"],
+  [href="#managed-icon__ds-reblog-24"])
+) { color: rgb(var(--green)); }
+footer.queue :is(a, button):has(svg use:is(
+  [href="#managed-icon__reblog"],
+  [href="#managed-icon__ds-reblog-20"],
+  [href="#managed-icon__ds-reblog-24"])
+) { color: rgb(var(--purple)); }
+footer.draft :is(a, button):has(svg use:is(
+  [href="#managed-icon__reblog"],
+  [href="#managed-icon__ds-reblog-20"],
+  [href="#managed-icon__ds-reblog-24"]
+)) { color: rgb(var(--red)); }
 
-footer:is(.published, .queue, .draft) :is(a, button) svg use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"]) {
+footer:is(.published, .queue, .draft) :is(a, button) svg use:is(
+  [href="#managed-icon__reblog"],
+  [href="#managed-icon__ds-reblog-20"],
+  [href="#managed-icon__ds-reblog-24"]
+) {
   --icon-color-primary: currentColor; /* Ensure that colouration is applied to icon */
 }
 
-footer:is(.published, .queue, .draft) :is(a, button):has(svg use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"])) {
+footer:is(.published, .queue, .draft) :is(a, button):has(svg use:is(
+  [href="#managed-icon__reblog"],
+  [href="#managed-icon__ds-reblog-20"],
+  [href="#managed-icon__ds-reblog-24"]
+)) {
   position: relative; /* For absolute positioning of tick pseudo-element */
 }
 
@@ -307,8 +327,26 @@ footer:is(.published, .queue, .draft) :is(a, button) svg:has(use[href="#managed-
   );
 }
 
+/* Cut-out for tick in 2026 mini post footer */
+footer:is(.published, .queue, .draft) :is(a, button) svg:has(use[href="#managed-icon__ds-reblog-20"]) {
+  -webkit-mask-image: radial-gradient(
+    calc(12.4px / 2) calc(15px / 2) at bottom 4px left 18px,
+    transparent 99%,
+    white 100%
+  );
+  mask-image: radial-gradient(
+    calc(12.4px / 2) calc(15px / 2) at bottom 4px left 18px,
+    transparent 99%,
+    white 100%
+  );
+}
+
 /* Styles for tick pseudo-element */
-footer:is(.published, .queue, .draft) :is(a, button):has(use:is([href="#managed-icon__reblog"], [href="#managed-icon__ds-reblog-24"]))::after {
+footer:is(.published, .queue, .draft) :is(a, button):has(use:is(
+  [href="#managed-icon__reblog"],
+  [href="#managed-icon__ds-reblog-20"],
+  [href="#managed-icon__ds-reblog-24"]
+))::after {
   position: absolute;
 
   display: inline-block;
@@ -334,6 +372,14 @@ footer:is(.published, .queue, .draft) a:has(use[href="#managed-icon__reblog"])::
 footer:is(.published, .queue, .draft) :is(a, button):has(use[href="#managed-icon__ds-reblog-24"])::after {
   bottom: 4px;
   left: 21px;
+}
+
+/* 2026 mini post footer */
+footer:is(.published, .queue, .draft) :is(a, button):has(use[href="#managed-icon__ds-reblog-20"])::after {
+  bottom: 1px;
+  left: 15px;
+
+  font-size: 11px;
 }
 
 /* === XKit 7 override === */

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -84,7 +84,13 @@ const blogHashes = new Map();
 const avatarUrls = new Map();
 
 const buttonSelector = `${postSelector} footer a, ${postSelector} footer button`;
-const reblogButtonSelector = `${postSelector} footer :is(a[href*="/reblog/"], button:has(use[href="#managed-icon__ds-reblog-24"])):not(${keyToCss('reblog')} *)`;
+const reblogButtonSelector = `${postSelector} footer :is(
+  a[href*="/reblog/"],
+  button:has(
+    use[href="#managed-icon__ds-reblog-20"],
+    use[href="#managed-icon__ds-reblog-24"]
+  )
+):not(${keyToCss('reblog')} *)`;
 const buttonDivSelector = `${keyToCss('controls', 'reblogsControl', 'engagementControls')} > *`;
 
 export const styleElement = buildStyle(`


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- Fixes #2213 

Updates the JS to make the feature able to activate on mini posts (excl. the Tumblr Radar); updates the CSS to make AlreadyReblogged work on the new small reblog buttons.

Before | After
-|-
<img width="1112" height="128" alt="Screenshot 2026-04-14 at 09-34-21 Tumblr" src="https://github.com/user-attachments/assets/9deca043-1257-4640-bd7f-791ccf4b60d0" /> | <img width="1112" height="128" alt="Screenshot 2026-04-14 at 09-34-46 Tumblr" src="https://github.com/user-attachments/assets/c1922ced-80eb-45ee-8463-42b5717075b1" />
<img width="600" height="104" alt="Screenshot 2026-04-14 at 09-34-34 Trending topics on Tumblr" src="https://github.com/user-attachments/assets/2bec9667-ec73-4951-9704-4445fd83fb3e" /> | <img width="600" height="104" alt="Screenshot 2026-04-14 at 09-34-52 Trending topics on Tumblr" src="https://github.com/user-attachments/assets/707bb5d2-172e-4697-b79d-155cd65c9338" />
<img width="575" height="283" alt="Screenshot 2026-04-14 at 9 40 30 am" src="https://github.com/user-attachments/assets/b00fce00-1e1f-4762-92f1-ced20c1d1912" /> | <img width="575" height="283" alt="Screenshot 2026-04-14 at 9 40 49 am" src="https://github.com/user-attachments/assets/8b9fb6e9-09f9-4729-9005-40daece90c80" />

Also reduces the gap between the reblog button and the top/bottom of the Quick Reblog mini-form, since the 12px value is really designed to match the pre-2025 post footer dimensions.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Enable Quick Reblog
3. Open a Tumblr tab, and open a timeline in list display mode
4. Hover a post's reblog button
    - **Expected result**: The Quick Reblog mini-form appears, anchored to that button
5. Reblog the post using Quick Reblog
    - **Expected result**: The reblog icon in the button gains a tick, as per the first row of screenshots
    - **Expected result**: The reblog button colour changes to match the action taken
      (Green for reblogged, purple for queued, red for drafted)
6. Open a timeline in masonry display mode
7. Hover a mini post's reblog button
    - **Expected result**: The Quick Reblog mini-form appears, anchored to that button
8. Reblog the post using Quick Reblog
    - **Expected result**: The reblog icon in the button gains a tick, as per the second row of screenshots
    - **Expected result**: The reblog button colour changes to match the action taken
