### PR TITLE
fix(Classic Footer): unbreak buttons on mini posts

### DIFF
--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -14,8 +14,16 @@ const reblogLinkClass = 'xkit-classic-footer-reblog-link';
 const postOrRadarSelector = `:is(${postSelector}, aside ${keyToCss('radar')})`;
 const footerContentSelector = `${postOrRadarSelector} article footer ${keyToCss('footerContent')}`;
 const engagementControlsSelector = `${footerContentSelector} ${keyToCss('engagementControls')}`;
-const replyButtonSelector = 'button:has(svg use[href="#managed-icon__ds-reply-outline-24"])';
-const reblogButtonSelector = 'button:has(svg use:is([href="#managed-icon__ds-reblog-24"], [href="#managed-icon__ds-queue-add-24"]))';
+const replyButtonSelector = `button:has(svg use:is(
+  [href="#managed-icon__ds-reply-outline-20"],
+  [href="#managed-icon__ds-reply-outline-24"]
+))`;
+const reblogButtonSelector = `button:has(svg use:is(
+  [href="#managed-icon__ds-reblog-20"],
+  [href="#managed-icon__ds-reblog-24"],
+  [href="#managed-icon__ds-queue-add-20"],
+  [href="#managed-icon__ds-queue-add-24"]
+))`;
 const quickActionsSelector = 'svg[style="--icon-color-primary: var(--brand-blue);"], svg[style="--icon-color-primary: var(--brand-purple);"]';
 const closeNotesButtonSelector = `${postOrRadarSelector} ${keyToCss('postActivity')} [role="tablist"] button:has(svg use[href="#managed-icon__ds-ui-x-20"])`;
 const reblogMenuPortalSelector = 'div[id^="portal/"]:has(div[role="menu"] a[role="menuitem"][href^="/reblog/"])';

--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -162,13 +162,22 @@ export const styleElement = buildStyle(`
     color: var(--brand-green);
   }
 
-  @container (width: 260px) {
-    .${noteCountClass}, .${reblogLinkClass} {
-      padding: 6px;
-    }
-    .${noteCountClass}.${modernStyleClass} {
-      margin-left: 6px;
-    }
+  [${activeAttribute}]:has(${keyToCss('engagementControlsNarrow')}) :is(.${noteCountClass}, .${reblogLinkClass}) {
+    padding: 4px;
+  }
+
+  [${activeAttribute}]:has(${keyToCss('engagementControlsNarrow')}) .${noteCountClass} {
+    font-size: 0.875rem;
+    line-height: 1.125rem;
+  }
+
+  [${activeAttribute}]:has(${keyToCss('engagementControlsNarrow')}) .${noteCountClass}.${modernStyleClass} {
+    padding-block: 6px;
+    padding-inline: 12px;
+    margin-left: 4px;
+
+    font-size: 0.75rem;
+    line-height: 1.125rem;
   }
 
   span:has(svg[style="--icon-color-primary: var(--brand-green);"]) > .${reblogLinkClass} {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- Fixes #2218
- Fixes #2220 

Updates the JS targeting for reply and reblog buttons, fixing the above issues; updates the constructed CSS to better match the dimensions of mini posts.

No changes to Classic Footer's behaviour on full-size posts are expected.

Before | After | Before | After
-|-|-|-
<img width="600" height="912" alt="Screen Shot 2026-04-14 at 10 13 50" src="https://github.com/user-attachments/assets/b89d9eae-212b-4959-bf5a-2deaac9a47ad" /> | <img width="600" height="888" alt="Screen Shot 2026-04-14 at 10 14 43" src="https://github.com/user-attachments/assets/345e02aa-7437-4dbd-a0d7-85f9f67cc4de" /> | <img width="600" height="912" alt="Screen Shot 2026-04-14 at 10 14 01" src="https://github.com/user-attachments/assets/f18e036f-fbd3-4fb0-9b34-a217aaf15198" /> | <img width="600" height="892" alt="Screen Shot 2026-04-14 at 10 14 49" src="https://github.com/user-attachments/assets/d1e3a88e-b89b-4c11-8a07-aeac2ed92cbf" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Enable Classic Footer, keeping the default preferences
3. Open a Tumblr tab, and navigate to the dashboard if necessary
4. Take a look at the Tumblr Radar
    - **Expected result**: The note count button has a reasonable font size, considering the dimension constraints
    - **Expected result**: The note count button is, visually, spaced away from the post's left edge by the same distance as the post's like button is from the post's right edge
5. Click the Radar post's note count
    - **Expected result**: The notes popover is opened, positioned correctly, with the replies tab selected
6. Click the note count again
    - **Expected result**: The notes popover is closed
7. Right-click the reblog icon button
    - **Expected result**: The button is revealed to actually be a link; you can open the URL in a new tab
8. Enable Classic Footer &rarr; "Use a modern look for the note count"
9. Take another look at the Tumblr Radar
    - **Expected result**: The note count button has a reasonable font size, considering the dimension constraints
    - **Expected result**: The note count button is, visually, spaced away from the post's left edge by the same distance as the post's like button is from the post's right edge
