### PR TITLE
fix(UI): ensure contrast in dropdowns on Chromium

### DIFF
--- a/src/action/acorn.css
+++ b/src/action/acorn.css
@@ -280,6 +280,16 @@ label + select {
   margin-block-start: var(--space-xsmall);
 }
 
+optgroup {
+  background-color: var(--background-color-box);
+  color: var(--text-color-deemphasized);
+}
+
+option {
+  background-color: var(--background-color-box);
+  color: var(--text-color);
+}
+
 /* https://firefoxux.github.io/firefox-desktop-components/?path=/story/ui-widgets-multiline-editor--default */
 
 textarea {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- Fixes #2214

Before | After
-|-
<img width="960" height="1034" alt="image" src="https://github.com/user-attachments/assets/8e5478d2-3110-4ddf-af55-a73b931733bd" /> | <img width="960" height="1034" alt="image" src="https://github.com/user-attachments/assets/de18d195-3965-4c34-b38a-88527eb5bf6b" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon on all the following browser/OS combinations:
    - Chromium, Windows/Linux
    - Chromium, macOS
    - Firefox, Windows/Linux
    - Firefox, macOS
2. Open the XKit control panel, and open the "Filter by..." dropdown
    - **Expected result**: The optgroup label is legible in both light and dark colour schemes
    - **Expected result**: The selected option is legible in both light and dark colour schemes
    - **Expected result**: Non-selected options are legible in both light and dark colour schemes
