### PR TITLE
fix: prevent unbounded recursion on boot

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -1,6 +1,8 @@
 'use strict';
 
 {
+  const MAX_BOOT_ATTEMPTS = 3600; // 60 seconds on 60Hz displays; 10 seconds on 360Hz displays
+
   const enabledFeaturesKey = 'enabledScripts';
 
   const redpop = [...document.scripts].some(({ src }) => src.includes('/pop/'));
@@ -8,8 +10,7 @@
 
   const restartListeners = {};
 
-  // prevent referencing outdated resources after firefox extension update/restart
-  const timestamp = Date.now();
+  const timestamp = Date.now(); // Prevent referencing outdated resources after Firefox extension update/restart
 
   const runFeature = async function (name) {
     const {
@@ -121,7 +122,7 @@
     ]);
 
     /**
-     * fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await
+     * Fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await
      * @see https://github.com/sveltejs/kit/issues/7805#issuecomment-1330078207
      */
     await Promise.all(['css_map', 'language_data', 'user'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
@@ -131,11 +132,29 @@
       .forEach(runFeature);
   };
 
-  const waitForReactLoaded = () => new Promise(resolve => {
-    window.requestAnimationFrame(() => isReactLoaded() ? resolve() : waitForReactLoaded().then(resolve));
+  const waitForReactLoaded = () => new Promise((resolve, reject) => {
+    let attempts = 0;
+
+    const checkForReactLoaded = () => {
+      if (isReactLoaded()) {
+        resolve();
+      } else if (++attempts >= MAX_BOOT_ATTEMPTS) {
+        reject(new Error('XKit Rewritten boot failed; React did not load after 10+ seconds.'));
+      } else {
+        window.requestAnimationFrame(checkForReactLoaded);
+      }
+    };
+
+    checkForReactLoaded();
   });
 
   if (redpop) {
-    isReactLoaded() ? init() : waitForReactLoaded().then(init);
+    if (isReactLoaded()) {
+      init();
+    } else {
+      waitForReactLoaded()
+        .then(init)
+        .catch(console.error);
+    }
   }
 }

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -132,29 +132,19 @@
       .forEach(runFeature);
   };
 
-  const waitForReactLoaded = () => new Promise((resolve, reject) => {
-    let attempts = 0;
+  const waitForReactLoaded = async function () {
+    for (let attempts = 0; attempts < MAX_BOOT_ATTEMPTS; attempts++) {
+      if (isReactLoaded()) return;
 
-    const checkForReactLoaded = () => {
-      if (isReactLoaded()) {
-        resolve();
-      } else if (++attempts >= MAX_BOOT_ATTEMPTS) {
-        reject(new Error('XKit Rewritten boot failed; React did not load after 10+ seconds.'));
-      } else {
-        window.requestAnimationFrame(checkForReactLoaded);
-      }
-    };
+      await new Promise((resolve) => window.requestAnimationFrame(resolve));
+    }
 
-    checkForReactLoaded();
-  });
+    throw new Error('XKit Rewritten boot failed; React did not load after 10+ seconds.');
+  };
 
   if (redpop) {
-    if (isReactLoaded()) {
-      init();
-    } else {
-      waitForReactLoaded()
-        .then(init)
-        .catch(console.error);
-    }
+    waitForReactLoaded()
+      .then(init)
+      .catch(console.error);
   }
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
A theoretical improvement. Caps the maximum number of boot attempts at 3600, which is a very safe one minute on a 60Hz display, decreasing as refresh rate increases.

I think it's very safe to assume that devices able to output 360 frames per second can load React in a lot less than 10 seconds.

I would be very interested in revisiting #1971 after this.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Enable some features, ideally ones that take visible effect immediately upon activating
3. Open a Tumblr tab
    - **Expected result**: XKit boots normally
4. Open devtools &rarr; Network and enable throttling
5. Reload the Tumblr tab
    - **Expected result**: The tab is sloooooow to load
    - **Expected result**: When the tab finally does load, React loads normally
    - **Expected result**: XKit boots normally after this
    (Proving that `"run_at": "document_end"` is working as intended)
