### PR TITLE
fix(Quick Tags): Post editor button not removed on feature disable

### DIFF
--- a/src/utils/post_actions.js
+++ b/src/utils/post_actions.js
@@ -50,6 +50,6 @@ export const registerPostOption = async function ({ id, symbolId, onclick, showI
  * @param {string} id Identifier for the previously registered post option
  */
 export const unregisterPostOption = id => {
-  postOptions[id]?.remove();
+  postOptions[id]?.element?.remove();
   delete postOptions[id];
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Fixes a refactor failure on my part from #2138.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable Quick Tags.
- Open the Tumblr post form.
- Disable Quick Tags. Confirm that the Quick Tags button disappears from the post form.