### PR TITLE
fix: Add additional guard against infinite loop in preference code

### DIFF
--- a/src/utils/preferences.js
+++ b/src/utils/preferences.js
@@ -25,8 +25,10 @@ export const getPreferences = async function (featureName) {
         }
       }
 
-      Object.assign(unsetPreferences, { [storageKey]: preference.default });
-      preferenceValues[key] = preference.default;
+      if (preference.default !== undefined) {
+        Object.assign(unsetPreferences, { [storageKey]: preference.default });
+        preferenceValues[key] = preference.default;
+      }
     } else {
       preferenceValues[key] = savedPreference;
     }

--- a/src/utils/preferences.js
+++ b/src/utils/preferences.js
@@ -35,7 +35,6 @@ export const getPreferences = async function (featureName) {
   }
 
   if (Object.keys(unsetPreferences).length !== 0) {
-    console.log(Math.random(), unsetPreferences);
     browser.storage.local.set(unsetPreferences);
   }
 

--- a/src/utils/preferences.js
+++ b/src/utils/preferences.js
@@ -35,6 +35,7 @@ export const getPreferences = async function (featureName) {
   }
 
   if (Object.keys(unsetPreferences).length !== 0) {
+    console.log(Math.random(), unsetPreferences);
     browser.storage.local.set(unsetPreferences);
   }
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

As noted in #2231 and https://www.tumblr.com/addons/814806521701646336/24th-april-2026, we accidentally made an infinite loop in the preference code if Quick Tags was enabled, but the user had no tag bundles (and had never added one). This was fixed in the hotfix release https://github.com/AprilSylph/XKit-Rewritten/releases/tag/v1.3.2, specifically by a line in #2229 that fixed the triggering mistake (forgetting to add `component` as one of the excluded preference types in the code that handled default preference values along with `iframe` in #2207.) #2229 removes `iframe` as an option entirely, replacing it with `component,` implicitly adding the correct value.

This is not in a sense the root cause, however, which is that the `unsetPreferences` logic will infinite-loop if any preference it runs on has an undefined default value (it will detect that the preference isn't set, and update it to its default value, which is undefined, which will make it detect that the preference isn't set, and update it to its default value, which is undefined, et cetera).

This PR removes the infinite loop by not processing undefined preference defaults if we accidentally set one.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm working default preference functionality:
- Load XKit Rewritten with no preference data (using `npm start`, by importing `{}` into the backup tab, etc)
- Optionally un-revert the test commit
- Open a Tumblr tab (and, if you un-reverted the test commit, open the js console and watch for the log entries to appear)
- Enable AccessKit
- In the backup tab, confirm that many `accesskit.preferences.` preferences are now set to their default values 
