### PR TITLE
feat(UI): add link to `tumblr.com/addons` to Links tab

### DIFF
--- a/src/action/popup.html
+++ b/src/action/popup.html
@@ -123,6 +123,12 @@
       </section>
       <section id="links-panel" role="tabpanel" aria-labelledby="links-tab" tabindex="0" hidden>
         <section>
+          <h3>Follow the blog</h3>
+          <ul>
+            <li><a href="https://www.tumblr.com/addons" target="_blank">@addons on Tumblr</a></li>
+          </ul>
+        </section>
+        <section>
           <h3>Help & information</h3>
           <ul>
             <li><a href="https://github.com/AprilSylph/XKit-Rewritten/wiki" target="_blank">User guide</a></li>

--- a/src/action/popup.html
+++ b/src/action/popup.html
@@ -147,10 +147,6 @@
           <ul>
             <li><a href="https://github.com/AprilSylph/XKit-Rewritten" target="_blank">Source code</a></li>
             <li><a href="https://github.com/AprilSylph/XKit-Rewritten/issues" target="_blank">Issue tracker</a></li>
-            <ul>
-              <li><a href="https://github.com/AprilSylph/XKit-Rewritten/issues?q=is%3Aopen+is%3Aissue+label%3Abug" target="_blank">Known bugs</a></li>
-              <li><a href="https://github.com/AprilSylph/XKit-Rewritten/issues?q=is%3Aopen+is%3Aissue+label%3Aenhancement" target="_blank">Suggested features</a></li>
-            </ul>
           </ul>
         </section>
         <section>


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Before | After | Before | After
-|-|-|-
<img width="750" height="1334" alt="Screen Shot 2026-04-29 at 10 28 49" src="https://github.com/user-attachments/assets/cb9d4c50-33aa-4d41-8984-a68ce07af812" /> | <img width="750" height="1334" alt="Screen Shot 2026-05-20 at 16 01 29" src="https://github.com/user-attachments/assets/4e4713a8-c8a5-4e9d-970e-3726f151d45d" /> | <img width="750" height="1334" alt="Screen Shot 2026-04-29 at 10 28 52" src="https://github.com/user-attachments/assets/4535fb4b-7881-4d06-8c36-889c76730a78" /> | <img width="750" height="1334" alt="Screen Shot 2026-05-20 at 16 01 33" src="https://github.com/user-attachments/assets/a70306b5-570b-4b43-ae89-832ef08f27a6" />

I landed on this as the best title/text verbiage combo I could think up. Title is worded like a CTA; link text matches the tab title of the linked page; the word "Tumblr" isn't repeated. Do you have any suggestions for improving it?

On my machine, this makes the Links tab just a bit too big to be contained within the Firefox popup, and allows me to scroll when I couldn't before. Is it worth removing any of the other links to prevent this? I'm leaning towards "no", but it is worth noting that the "Related projects" links are essentially duplicated between this panel and the pinned post on `@addons`, so I could be persuaded towards "yes".

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Share your opinions on the above points; approve when you're happy with the current changes.