### PR TITLE
feat(AccessKit Disable GIFs): Pause additional elements; fix misc position/hover issues

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -11,6 +11,7 @@ const pausedBackgroundImageVar = '--xkit-paused-gif-background-image';
 const hoverContainerAttribute = 'data-paused-gif-hover-container';
 const labelAttribute = 'data-paused-gif-label';
 const labelSizeAttribute = 'data-paused-gif-label-size';
+const hoverFixAttribute = 'data-paused-gif-hover-fix';
 const containerClass = 'xkit-paused-gif-container';
 
 let loadingMode;
@@ -85,6 +86,11 @@ ${keyToCss('background')}[${labelAttribute}="before"]::before {
 
 [style*="${pausedBackgroundImageVar}"]:not(${hovered}) {
   background-image: var(${pausedBackgroundImageVar}) !important;
+}
+
+[${hoverFixAttribute}] {
+  position: relative;
+  pointer-events: auto !important;
 }
 `);
 
@@ -182,6 +188,10 @@ const pauseGif = async function (gifElement) {
       canvasElement.getContext('2d').drawImage(image, 0, 0);
       gifElement.after(canvasElement);
       addLabel(gifElement);
+
+      gifElement.closest(keyToCss(
+        'imgLink', // trending tag: https://www.tumblr.com/explore/trending
+      ))?.setAttribute(hoverFixAttribute, '');
     }
   };
 };
@@ -237,6 +247,11 @@ const processBackgroundGifs = function (gifBackgroundElements) {
       sourceValue.replace(sourceUrlRegex, `url("${pausedUrl}")`),
     );
     addLabel(gifBackgroundElement, true);
+
+    gifBackgroundElement.closest(keyToCss(
+      'media', // old activity item: "liked your post", "reblogged your post", "mentioned you in a post"
+      'activityMedia', // new activity item: "replied to your post", "replied to you in a post"
+    ))?.setAttribute(hoverFixAttribute, '');
   });
 };
 
@@ -281,6 +296,7 @@ export const main = async function () {
         'typeaheadRow', // modal search dropdown entry
         'tagImage', // search page sidebar related tags, recommended tag carousel entry: https://www.tumblr.com/search/gif, https://www.tumblr.com/explore/recommended-for-you
         'topPost', // activity page top post
+        'colorfulListItemWrapper', // trending tag: https://www.tumblr.com/explore/trending
         'takeoverBanner', // advertisement
         'mrecContainer', // advertisement
       )}
@@ -290,6 +306,8 @@ export const main = async function () {
 
   const gifBackgroundImage = `
     ${keyToCss(
+      'media', // old activity item: "liked your post", "reblogged your post", "mentioned you in a post"
+      'activityMedia', // new activity item: "replied to your post", "replied to you in a post"
       'communityHeaderImage', // search page tags section header: https://www.tumblr.com/search/gif?v=tag
       'bannerImage', // tagged page sidebar header: https://www.tumblr.com/tagged/gif
       'tagChicletWrapper', // "trending" / "your tags" timeline carousel entry: https://www.tumblr.com/dashboard/trending, https://www.tumblr.com/dashboard/hubs
@@ -301,6 +319,7 @@ export const main = async function () {
   const hoverableElement = [
     `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}`, // recommended blog carousel entry
     `div:has(> a${keyToCss('cover')}):has(${keyToCss('communityCategoryImage')})`, // tumblr communities browse page entry: https://www.tumblr.com/communities/browse
+    `${keyToCss('gridTimelineObject')}`, // likes page or patio grid view post: https://www.tumblr.com/likes
   ].join(', ');
   pageModifications.register(hoverableElement, processHoverableElements);
 
@@ -329,6 +348,7 @@ export const clean = async function () {
   $(`[${labelSizeAttribute}]`).removeAttr(labelSizeAttribute);
   $(`[${pausedPosterAttribute}]`).removeAttr(pausedPosterAttribute);
   $(`[${hoverContainerAttribute}]`).removeAttr(hoverContainerAttribute);
+  $(`[${hoverFixAttribute}]`).removeAttr(hoverFixAttribute);
   [...document.querySelectorAll(`[style*="${pausedBackgroundImageVar}"]`)]
     .forEach(element => element.style.removeProperty(pausedBackgroundImageVar));
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -328,7 +328,7 @@ export const main = async function () {
     `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}`, // recommended blog carousel entry
     `div:has(> a${keyToCss('cover')}):has(${keyToCss('communityCategoryImage')})`, // tumblr communities browse page entry: https://www.tumblr.com/communities/browse
     `${keyToCss('gridTimelineObject')}`, // likes page or patio grid view post: https://www.tumblr.com/likes
-    `${keyToCss('fixedHeightTile')} ${keyToCss('contentWrapper')}`, // trending tag preview card: https://www.tumblr.com/explore/trending
+    `${keyToCss('fixedHeightTile')} ${keyToCss('contentWrapper')}`, // trending tag preview card, post-redesign: https://www.tumblr.com/explore/trending
   ].join(', ');
   pageModifications.register(hoverableElement, processHoverableElements);
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -191,6 +191,7 @@ const pauseGif = async function (gifElement) {
 
       gifElement.closest(keyToCss(
         'imgLink', // trending tag: https://www.tumblr.com/explore/trending
+        'adContainer', // sidebar advertisement
       ))?.setAttribute(positionHoverFixAttribute, '');
     }
   };
@@ -305,7 +306,7 @@ export const main = async function () {
         'topPost', // activity page top post
         'colorfulListItemWrapper', // trending tag: https://www.tumblr.com/explore/trending
         'takeoverBanner', // advertisement
-        'mrecContainer', // advertisement
+        'mrecContainer', // sidebar advertisement
       )}
     ) img:is([srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]):not(${keyToCss('poster')})
   `;

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -327,6 +327,7 @@ export const main = async function () {
     `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')} ${keyToCss('postCard')}`, // recommended blog carousel entry
     `div:has(> a${keyToCss('cover')}):has(${keyToCss('communityCategoryImage')})`, // tumblr communities browse page entry: https://www.tumblr.com/communities/browse
     `${keyToCss('gridTimelineObject')}`, // likes page or patio grid view post: https://www.tumblr.com/likes
+    `${keyToCss('fixedHeightTile')} ${keyToCss('contentWrapper')}`, // trending tag preview card: https://www.tumblr.com/explore/trending
   ].join(', ');
   pageModifications.register(hoverableElement, processHoverableElements);
 

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -14,7 +14,7 @@ const pausedBackgroundImageVar = '--xkit-paused-gif-background-image';
 const hoverContainerAttribute = 'data-paused-gif-hover-container';
 const labelAttribute = 'data-paused-gif-label';
 const labelSizeAttribute = 'data-paused-gif-label-size';
-const hoverFixAttribute = 'data-paused-gif-hover-fix';
+const positionHoverFixAttribute = 'data-paused-gif-position-hover-fix';
 const containerClass = 'xkit-paused-gif-container';
 
 const hovered = `:is(:hover, [${hoverContainerAttribute}]:hover *)`;
@@ -89,7 +89,7 @@ ${keyToCss('background')}[${labelAttribute}="before"]::before {
   background-image: var(${pausedBackgroundImageVar}) !important;
 }
 
-[${hoverFixAttribute}] {
+[${positionHoverFixAttribute}] {
   position: relative;
   pointer-events: auto !important;
 }
@@ -191,7 +191,7 @@ const pauseGif = async function (gifElement) {
 
       gifElement.closest(keyToCss(
         'imgLink', // trending tag: https://www.tumblr.com/explore/trending
-      ))?.setAttribute(hoverFixAttribute, '');
+      ))?.setAttribute(positionHoverFixAttribute, '');
     }
   };
 };
@@ -256,7 +256,7 @@ const processBackgroundGifs = function (gifBackgroundElements) {
     gifBackgroundElement.closest(keyToCss(
       'media', // old activity item: "liked your post", "reblogged your post", "mentioned you in a post"
       'activityMedia', // new activity item: "replied to your post", "replied to you in a post"
-    ))?.setAttribute(hoverFixAttribute, '');
+    ))?.setAttribute(positionHoverFixAttribute, '');
   });
 };
 
@@ -357,7 +357,7 @@ export const clean = async function () {
   $(`[${labelSizeAttribute}]`).removeAttr(labelSizeAttribute);
   $(`[${pausedPosterAttribute}]`).removeAttr(pausedPosterAttribute);
   $(`[${hoverContainerAttribute}]`).removeAttr(hoverContainerAttribute);
-  $(`[${hoverFixAttribute}]`).removeAttr(hoverFixAttribute);
+  $(`[${positionHoverFixAttribute}]`).removeAttr(positionHoverFixAttribute);
   [...document.querySelectorAll(`[style*="${pausedBackgroundImageVar}"]`)]
     .forEach(element => element.style.removeProperty(pausedBackgroundImageVar));
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This:
- Adds Disable GIFs pausing to trending tag card elements (on the **current** trending page, not the in-testing future one) and activity item preview images of both legacy and new ("generic") types.
- Fixes positioning of the sidebar house ad pause overlay (#2317).
- Fixes hover-to-unpause on grid view posts (i.e. on the likes page) and trending tag card elements (on the **in-testing/future** trending page, not the current one).

Initially cherry-picked from #1862.

Let me know if you would like this split into stacked PRs.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- [x] On an account with the current trending page, confirm that Disable GIFs pauses GIFs in a trending tag card, and that they unpause when the card is hovered. ~~(At time of writing, there aren't any trending tags with GIFs, but I recall having tested this before, of course.)~~ *edit: found one; they work but don't have rounded corners, as that's one of the tumblr css rules that ends in `img` like the labs header and thus only works with an img content override based codepath or manual hacks.*
- [x] Like and comment on one of your own posts with a GIF. Confirm that the generated activity items have their images paused, and that they unpause on hover.
- [x] Find a sufficiently racy post that the house sidebar ad for Tumblr Premium appears and confirm that it's paused correctly.
- [x] Like a post with a GIF. View your likes page in grid view and confirm that hovering the square grid image unpauses the GIF. (It still has a grey overlay, so I can see the argument that this looks kind of odd. It also looks kind of odd for the GIF to not unpause, though.)
- [x] On an account with the new trending page, confirm that Disable GIFs pauses GIFs in a trending tag card, and that they unpause when the post content is hovered.