### PR TITLE
chore: Minor CSS performance optimization

### DIFF
--- a/src/features/tweaks/slim_filtered_screens.js
+++ b/src/features/tweaks/slim_filtered_screens.js
@@ -13,7 +13,7 @@ ${filteredScreenSelector} {
   padding-bottom: var(--post-header-vertical-padding);
 }
 
-${filteredScreenSelector} > p {
+${filteredScreenSelector} > ${keyToCss('message')} {
   flex-shrink: 0;
 }
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

This is more housekeeping than anything, but:

In #1420, I made a performance improvement to one of our CSS selectors, but it was based on a slight misunderstanding of how CSS engines work, so I figured I should fix it. The performance difference is irrelevant, but having the code the wrong way around isn't informative (also, the bad way is semantically worse).

Switching from a any-depth child selector to a `>` is a win; we obviously want to keep that. However, I also switched to `p`, basing the logic around the idea that `:is(.many, .comma, .separated, .class, .selectors)` is many sequential comparisons on every element, while a tagname check is **one** comparison on every element. "It's fine if the final selector matches a few more elements," I thought, "then you just go up one level and check the parent once occasionally. That's **two** comparisons, which is fewer than fifteen, big win. Go hit the showers."

Thinking about it for more than five seconds, I should have recognized that no CSS engine in the modern era would ever sequentially check every css class on every element against every (rightmost) class selector in every active CSS rule on the page. They would use a hash table, and adding 15 entries to that hash table (that are all misses) is zero cost. The thing that minimizes CSS processing cost is to be as precise as possible with your main (rightmost) selector* so that it just lives in an unused hash table slot and misses most of the time, and "15 classes that translate to 'message'" will miss a lot more often than "p", so you should do that.

#1644 is, it should be noted, correct: `~ *` is basically the worst possible thing you can do, since it (cheaply, but that's not the important bit!) hits everything and then triggers a huge number of traverses and checks that you want to do everything you can to avoid. You should be extremely happy to replace that right-side `*` with something that "looks more expensive."

*and the rightmost selector of your :has()

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Find a post with a filtered tag or phrase and conform that it renders as expected with the tweak in question.
