### PR TITLE
feat(Panorama): Widen new top-of-dashboard UI 

### DIFF
--- a/src/features/panorama/index.js
+++ b/src/features/panorama/index.js
@@ -42,6 +42,9 @@ ${keyToCss('queueSettings')} {
   box-sizing: border-box;
   width: 100%;
 }
+${mainPostColumn} > ${keyToCss('tabsHeader')} + ${keyToCss('container')} {
+  max-width: unset;
+}
 `);
 mainStyleElement.media = `(min-width: ${widenDashMinWidth}px)`;
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

There's a new version of the Tumblr UI element at the top of the dashboard on some blogs, including my main blog. This makes Panorama widen this element.

Resolves #2249.


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Load Panorama on an account with the `inlinePostEditor` flag. Confirm that the UI atop the dashboard is widened, just like the rest of the post column.
