### PR TITLE
Fix recommendation hiding selectors

### DIFF
--- a/src/features/no_recommended/hide_recommended_blogs_modal.js
+++ b/src/features/no_recommended/hide_recommended_blogs_modal.js
@@ -1,8 +1,13 @@
 import { keyToCss } from '../../utils/css_map.js';
 import { blogViewSelector, buildStyle } from '../../utils/interface.js';
+import { translate } from '../../utils/language_data.js';
 import { pageModifications } from '../../utils/mutations.js';
 
 const hiddenAttribute = 'data-no-recommended-blogs-modal-hidden';
+const recommendedBlogTitles = [
+  'Check out these blogs',
+  'Check these out',
+].map(translate);
 
 export const styleElement = buildStyle(`[${hiddenAttribute}] { display: none; }`);
 
@@ -11,12 +16,20 @@ const hideModalRecommended = blogsLists =>
     .filter(ul => ul.matches(blogViewSelector))
     .forEach(ul => ul.parentNode.setAttribute(hiddenAttribute, ''));
 
+const hideModalRecommendedTitles = sidebarTitles =>
+  sidebarTitles
+    .filter(h1 => h1.matches(blogViewSelector))
+    .filter(h1 => recommendedBlogTitles.includes(h1.textContent.trim()))
+    .forEach(h1 => h1.closest('aside > *').setAttribute(hiddenAttribute, ''));
+
 export const main = async function () {
   const blogsListSelector = `${keyToCss('desktopContainer')} > ${keyToCss('recommendedBlogs')}`;
   pageModifications.register(blogsListSelector, hideModalRecommended);
+  pageModifications.register('aside h1', hideModalRecommendedTitles);
 };
 
 export const clean = async function () {
   pageModifications.unregister(hideModalRecommended);
+  pageModifications.unregister(hideModalRecommendedTitles);
   $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };

--- a/src/features/no_recommended/hide_search_communities.js
+++ b/src/features/no_recommended/hide_search_communities.js
@@ -3,5 +3,5 @@ import { buildStyle } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
 
 export const styleElement = buildStyle(`
-${keyToCss('typeaheadSection')}:has(> [aria-label="${translate('Suggested communities')}"]) { display: none; }
+${keyToCss('typeaheadSection')}:has([aria-label="${translate('Suggested communities')}"]) { display: none; }
 `);


### PR DESCRIPTION
### Description

Fixes #2252.

This updates No Recommended in the two confirmed places:

- hides the blog-view sidebar recommendation section when Tumblr labels it `Check these out`
- hides suggested-communities typeahead sections when the `Suggested communities` label is nested instead of a direct child

### Testing steps

- `npm ci --no-audit --no-fund --progress=false`
- `node --check src/features/no_recommended/hide_recommended_blogs_modal.js`
- `node --check src/features/no_recommended/hide_search_communities.js`
- `npm test`
- `npm run build`
- `git diff --check HEAD~1 HEAD`
- `git show --format= --patch HEAD | gitleaks stdin --no-banner --redact --timeout 30`

`npm test` exited 0. `web-ext lint` reported existing warnings, then `eslint src/ --cache` passed.

I did not run a live Tumblr UI smoke; this was validated with static checks, extension lint, and build.
