### PR TITLE
feat(Vanilla Audio, Vanilla Video): allow fine-tuning of default volume

### DIFF
--- a/docs/Chapter 4.1 - Feature metadata.md
+++ b/docs/Chapter 4.1 - Feature metadata.md
@@ -67,7 +67,7 @@ It is recommended to use camelCase for each preference name, so that the feature
 - Type: String
 - Required: Yes
 
-Type of preference. Supported values: `"checkbox"`, `"text"`, `"color"`, `"select"`, `"textarea"`, `"component"`
+Type of preference. Supported values: `"checkbox"`, `"text"`, `"color"`, `"select"`, `"textarea"`, `"component"`, `"percent"`
 
 #### `"preferences"`: \<preference name\>: `"label"`
 - Type: String
@@ -98,6 +98,7 @@ Default value of the preference to display to the user.
 
 If the preference `type` is `"checkbox"`, this value should be a boolean.  
 If the preference `type` is `"text"` or `"textarea"`, this value should be a string.  
+If the preference `type` is `"percent"`, this value should be a string representation of an integer between 0 and 100.  
 If the preference `type` is `"color"`, this value should either be a string representing a hexadecimal colour code (i.e. `"#1a2b3c"`) or an empty string.  
 If the preference `type` is `"select"`, this value should be a string that matches one of the `"options"` item's `"value"`.
 

--- a/src/action/components/percent-preference/index.css
+++ b/src/action/components/percent-preference/index.css
@@ -1,0 +1,3 @@
+:host {
+  display: block;
+}

--- a/src/action/components/percent-preference/index.js
+++ b/src/action/components/percent-preference/index.js
@@ -1,0 +1,72 @@
+import { CustomElement, fetchStyleSheets } from '../index.js';
+
+const localName = 'percent-preference';
+
+const templateDocument = new DOMParser().parseFromString(`
+  <template id="${localName}">
+    <label for="percent"></label>
+    <input id="percent" type="text" size="28" spellcheck="false">
+  </template>
+`, 'text/html');
+
+const adoptedStyleSheets = await fetchStyleSheets([
+  '/lib/modern-normalize.css',
+  '/action/acorn.css',
+  './index.css',
+].map(import.meta.resolve));
+
+class PercentPreferenceElement extends CustomElement {
+  /** @type {string} */ featureName;
+  /** @type {string} */ preferenceName;
+
+  /** @type {HTMLInputElement} */ #inputElement;
+  /** @type {HTMLLabelElement} */ #labelElement;
+  /** @type {ReturnType<Window['setTimeout']>} */ #timeoutID;
+
+  constructor () {
+    super(templateDocument, adoptedStyleSheets);
+
+    this.#inputElement = this.shadowRoot.getElementById('percent');
+    this.#labelElement = this.shadowRoot.querySelector('label[for="percent"]');
+  }
+
+  /** @param {string} label Label displayed to the user to describe the preference. */
+  set label (label) { this.#labelElement.textContent = label; }
+  get label () { return this.#labelElement.textContent; }
+
+  /** @param {string} value The saved or default value of this preference. */
+  set value (value = '') { this.#inputElement.value = value; }
+  get value () { return this.#inputElement.value; }
+
+  /** @type {(event: InputEvent) => void} */ #onInput = () => {
+    const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
+    this.#inputElement.value = this.#inputElement.value.match(/\d+/) ? Math.min(this.#inputElement.value.match(/\d+/)[0], 100) : 0;
+    const storageValue = this.#inputElement.value;
+
+    clearTimeout(this.#timeoutID);
+    this.#timeoutID = setTimeout(() => browser.storage.local.set({ [storageKey]: storageValue }), 500);
+  };
+
+  connectedCallback () {
+    this.role ||= 'listitem';
+    this.slot ||= 'preferences';
+    this.#inputElement.addEventListener('input', this.#onInput);
+  }
+
+  disconnectedCallback () {
+    this.#inputElement.removeEventListener('input', this.#onInput);
+  }
+}
+
+customElements.define(localName, PercentPreferenceElement);
+
+/**
+ * @typedef PercentPreferenceProps
+ * @property {string} featureName The feature's internal name (e.g. `"quick_tags"`).
+ * @property {string} preferenceName The preference's internal name (e.g. `"originalPostTag"`).
+ * @property {string} label The preference's label (e.g. `"Original post tag"`).
+ * @property {string} value The preference's current value (as set by the user, or the preference's default).
+ */
+
+/** @type {(props: PercentPreferenceProps) => PercentPreferenceElement} */
+export const PercentPreference = (props = {}) => Object.assign(document.createElement(localName), props);

--- a/src/action/components/percent-preference/index.js
+++ b/src/action/components/percent-preference/index.js
@@ -62,9 +62,9 @@ customElements.define(localName, PercentPreferenceElement);
 
 /**
  * @typedef PercentPreferenceProps
- * @property {string} featureName The feature's internal name (e.g. `"quick_tags"`).
- * @property {string} preferenceName The preference's internal name (e.g. `"originalPostTag"`).
- * @property {string} label The preference's label (e.g. `"Original post tag"`).
+ * @property {string} featureName The feature's internal name (e.g. `"vanilla_audio"`).
+ * @property {string} preferenceName The preference's internal name (e.g. `"defaultVolume"`).
+ * @property {string} label The preference's label (e.g. `"Default Volume"`).
  * @property {string} value The preference's current value (as set by the user, or the preference's default).
  */
 

--- a/src/action/popup.js
+++ b/src/action/popup.js
@@ -1,4 +1,4 @@
-const preferenceSelector = 'checkbox-preference, color-preference, select-preference, text-preference, textarea-preference';
+const preferenceSelector = 'checkbox-preference, color-preference, percent-preference, select-preference, text-preference, textarea-preference';
 
 const checkForNoResults = function () {
   /** @type {HTMLElement[]} */ const featureElements = [...document.querySelectorAll('xkit-feature')];

--- a/src/action/render_features.js
+++ b/src/action/render_features.js
@@ -1,5 +1,6 @@
 import { CheckboxPreference } from './components/checkbox-preference/index.js';
 import { ColorPreference } from './components/color-preference/index.js';
+import { PercentPreference } from './components/percent-preference/index.js';
 import { SelectPreference } from './components/select-preference/index.js';
 import { TextPreference } from './components/text-preference/index.js';
 import { TextAreaPreference } from './components/textarea-preference/index.js';
@@ -133,6 +134,9 @@ const renderFeatures = async function () {
                   }),
                 ),
             );
+            break;
+          case 'percent':
+            preferenceElements.push(PercentPreference({ featureName, preferenceName, label, value }));
             break;
           case 'select':
             preferenceElements.push(SelectPreference({ featureName, preferenceName, label, options, value }));

--- a/src/features/vanilla_audio/feature.json
+++ b/src/features/vanilla_audio/feature.json
@@ -10,15 +10,8 @@
   "relatedTerms": [ "Audio Downloader", "Audio Plus", "Audio+" ],
   "preferences": {
     "defaultVolume": {
-      "type": "select",
+      "type": "percent",
       "label": "Default Volume",
-      "options": [
-        { "value": "0", "label": "Muted" },
-        { "value": "25", "label": "25%" },
-        { "value": "50", "label": "50%" },
-        { "value": "75", "label": "75%" },
-        { "value": "100", "label": "100%" }
-      ],
       "default": "100"
     }
   }

--- a/src/features/vanilla_video/feature.json
+++ b/src/features/vanilla_video/feature.json
@@ -10,15 +10,8 @@
   "relatedTerms": [ "Video Downloader", "autoplay" ],
   "preferences": {
     "defaultVolume": {
-      "type": "select",
+      "type": "percent",
       "label": "Default Volume",
-      "options": [
-        { "value": "0", "label": "Muted" },
-        { "value": "25", "label": "25%" },
-        { "value": "50", "label": "50%" },
-        { "value": "75", "label": "75%" },
-        { "value": "100", "label": "100%" }
-      ],
       "default": "100"
     },
     "tumblrTvEnable": {

--- a/src/lib/modern-normalize.css
+++ b/src/lib/modern-normalize.css
@@ -128,8 +128,7 @@ button,
 input,
 optgroup,
 select,
-textarea,
-percent {
+textarea {
 	font-family: inherit; /* 1 */
 	font-size: 100%; /* 1 */
 	line-height: 1.15; /* 1 */

--- a/src/lib/modern-normalize.css
+++ b/src/lib/modern-normalize.css
@@ -128,7 +128,8 @@ button,
 input,
 optgroup,
 select,
-textarea {
+textarea,
+percent {
 	font-family: inherit; /* 1 */
 	font-size: 100%; /* 1 */
 	line-height: 1.15; /* 1 */


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Fixes #1797 

Also adds "percent" input type, which takes only integers 0-100.

| Before | After|
|--------|--------|
| <img width="365" height="138" alt="image" src="https://github.com/user-attachments/assets/ee7de2a5-51f8-415a-8506-2612b84c542b" /> | <img width="365" height="130" alt="image" src="https://github.com/user-attachments/assets/db04d454-fe32-4631-becb-dc673860cda3" /> |
| <img width="366" height="171" alt="image" src="https://github.com/user-attachments/assets/799ef5c2-39ec-4799-92a1-ce1b7326da88" /> | <img width="366" height="170" alt="image" src="https://github.com/user-attachments/assets/636db316-02cb-44a2-8dea-226b6e1f55e5" /> |


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

1. Load the modified addon
2. Enable Vanilla Audio
3. Set Default Volume
Expected behavior: Non-digit characters are not displayed. Numbers over 100 get rounded down to 100. When no digits are entered, the value should set to 0.
4. Find an audio post
Expected behavior: The volume slider should be at the entered percentage


2. Enable Vanilla Video
3. Set Default Volume
Expected behavior: Non-digit characters are not displayed. Numbers over 100 get rounded down to 100. When no digits are entered, the value should set to 0.
4. Find a video post
Expected behavior: The volume slider should be at the entered percentage