### PR TITLE
feat(Panorama): Widen misc informative popups

### DIFF
--- a/src/features/panorama/index.js
+++ b/src/features/panorama/index.js
@@ -112,8 +112,8 @@ ${keyToCss('cell')}, ${postSelector}
   height: unset !important;
 }
 
-/* Fix ad containers */
-${keyToCss('adTimelineObject', 'instreamAd', 'nativeIponWebAd', 'takeoverBanner')},
+/* Fix advertisement/miscellaneous containers */
+${keyToCss('adTimelineObject', 'instreamAd', 'nativeIponWebAd', 'takeoverBanner', 'signpostCta')},
 ${keyToCss('adTimelineObject', 'instreamAd', 'nativeIponWebAd', 'takeoverBanner')} header {
   max-width: unset !important;
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

<img width="675" src="https://github.com/user-attachments/assets/25723ab5-ff08-46e4-827e-d3407be60282" />

Panorama didn't widen this element (on "channel" pages). Now it does!

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Code review only is probably fine if you don't have one of these on any of your blogs.