### PR TITLE
fix(Mutual Checker): hide posts from non-followed blogs in mutuals-only mode

### DIFF
--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -77,16 +77,19 @@ const addIcons = function (postElements) {
     if (alreadyProcessed(postElement)) return;
 
     const postAttribution = postElement.querySelector(postAttributionSelector);
-    if (postAttribution === null) { return; }
+    const blogName = postAttribution?.textContent.trim();
 
-    const blogName = postAttribution.textContent.trim();
-    if (!blogName) return;
+    if (postAttribution === null || !blogName) {
+      if (showOnlyMutuals) {
+        getTimelineItemWrapper(postElement)?.setAttribute(hiddenAttribute, '');
+      }
+      return;
+    }
 
     const followingBlog = await getIsFollowing(blogName, postElement);
-    if (!followingBlog) { return; }
-
     const isMutual = await getIsFollowingYou(blogName);
-    if (isMutual) {
+
+    if (followingBlog && isMutual) {
       postElement.classList.add(mutualsClass);
       const iconTarget = getPopoverWrapper(postAttribution) ?? postAttribution;
       iconTarget?.before(createIcon(isMutual, blogName));

--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -79,17 +79,14 @@ const addIcons = function (postElements) {
     const postAttribution = postElement.querySelector(postAttributionSelector);
     const blogName = postAttribution?.textContent.trim();
 
-    if (postAttribution === null || !blogName) {
-      if (showOnlyMutuals) {
-        getTimelineItemWrapper(postElement)?.setAttribute(hiddenAttribute, '');
-      }
-      return;
-    }
+    const followingBlog = blogName
+      ? await getIsFollowing(blogName, postElement)
+      : false;
+    const isMutual = followingBlog
+      ? await getIsFollowingYou(blogName)
+      : false;
 
-    const followingBlog = await getIsFollowing(blogName, postElement);
-    const isMutual = await getIsFollowingYou(blogName);
-
-    if (followingBlog && isMutual) {
+    if (isMutual) {
       postElement.classList.add(mutualsClass);
       const iconTarget = getPopoverWrapper(postAttribution) ?? postAttribution;
       iconTarget?.before(createIcon(isMutual, blogName));


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
Fixes #1209 
Hides posts from non-mutuals (specifically posts without attribution, without a blog name, or that the user isn't following) that would've previously gone unfiltered

| Before | After |
|--------|--------|
| <img width="1344" height="1017" alt="image" src="https://github.com/user-attachments/assets/6358f4ed-5853-4d34-8e95-d8157c014c61" /> | <img width="1342" height="805" alt="image" src="https://github.com/user-attachments/assets/b5dab245-0dcc-40dc-b679-64d7ba15cad5" /> | 

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->


1. Load the **un**modified addon
2. Enable Mutual Checker
3. Check only show posts from mutuals
4. Find post from non-mutual (may require following a tag to see "because you follow x") 
6. Load modified add on
7. See that the post is hidden on the dash