### PR TITLE
feat(UI): use `number` input type for percent-type preferences

### DIFF
--- a/docs/Chapter 4.1 - Feature metadata.md
+++ b/docs/Chapter 4.1 - Feature metadata.md
@@ -67,7 +67,7 @@ It is recommended to use camelCase for each preference name, so that the feature
 - Type: String
 - Required: Yes
 
-Type of preference. Supported values: `"checkbox"`, `"text"`, `"color"`, `"select"`, `"textarea"`, `"component"`, `"percent"`
+Type of preference. Supported values: `"checkbox"`, `"color"`, `"component"`, `"percent"`, `"select"`, `"text"`, `"textarea"`
 
 #### `"preferences"`: \<preference name\>: `"label"`
 - Type: String
@@ -97,10 +97,10 @@ Unused for other preference types.
 Default value of the preference to display to the user.
 
 If the preference `type` is `"checkbox"`, this value should be a boolean.  
-If the preference `type` is `"text"` or `"textarea"`, this value should be a string.  
-If the preference `type` is `"percent"`, this value should be a string representation of an integer between 0 and 100.  
 If the preference `type` is `"color"`, this value should either be a string representing a hexadecimal colour code (i.e. `"#1a2b3c"`) or an empty string.  
-If the preference `type` is `"select"`, this value should be a string that matches one of the `"options"` item's `"value"`.
+If the preference `type` is `"percent"`, this value should be an integer in the range of 0–100.  
+If the preference `type` is `"select"`, this value should be a string that matches one of the `"options"` item's `"value"`.  
+If the preference `type` is `"text"` or `"textarea"`, this value should be a string.
 
 #### `"preferences"`: \<preference name\>: `"inherit"`
 - Type: String

--- a/src/action/acorn.css
+++ b/src/action/acorn.css
@@ -21,6 +21,7 @@
   --border-color: #bfbfc9;
   --border-color-deemphasized: #bac2ca;
   --border-color-interactive: #8f8f9d;
+  --border-color-error: #b20037;
   --badge-border-color-filled: #fbfbfe66;
   --message-bar-border-color: #84c6ff33;
   --message-bar-border-color-error: #cf174833;
@@ -107,6 +108,7 @@
     --border-color: #5b5b66;
     --border-color-deemphasized: #5b5b66;
     --border-color-interactive: #bfbfc9;
+    --border-color-error: #ffa0aa;
     --badge-border-color-filled: #15141a66;
     --message-bar-border-color: #84c6ff33;
     --message-bar-border-color-error: #ffa0aa33;

--- a/src/action/acorn.css
+++ b/src/action/acorn.css
@@ -473,9 +473,10 @@ input[type="checkbox"]:checked:hover:active {
   }
 }
 
+/* https://firefoxux.github.io/firefox-desktop-components/?path=/story/ui-widgets-input-number--default */
 /* https://firefoxux.github.io/firefox-desktop-components/?path=/story/ui-widgets-input-text--default */
 
-input:is([type="text"], [type="search"]) {
+input:is([type="number"], [type="search"], [type="text"]) {
   min-height: 32px;
   width: 100%;
   padding-block: 1px;
@@ -487,12 +488,12 @@ input:is([type="text"], [type="search"]) {
   color: var(--input-text-color);
 }
 
-input:is([type="text"], [type="search"]):focus-visible {
+input:is([type="number"], [type="search"], [type="text"]):focus-visible {
   outline: 2px solid var(--color-accent-primary);
   outline-offset: 0;
 }
 
-label + input:is([type="text"], [type="search"]) {
+label + input:is([type="number"], [type="search"], [type="text"]) {
   margin-block-start: var(--space-xsmall);
 }
 

--- a/src/action/components/percent-preference/index.css
+++ b/src/action/components/percent-preference/index.css
@@ -1,3 +1,11 @@
 :host {
   display: block;
 }
+
+input[type="number"]:invalid:focus-visible {
+  outline-color: var(--border-color-error);
+}
+
+input[type="number"]:invalid:not(:focus-visible) {
+  border-color: var(--border-color-error);
+}

--- a/src/action/components/percent-preference/index.js
+++ b/src/action/components/percent-preference/index.js
@@ -5,7 +5,7 @@ const localName = 'percent-preference';
 const templateDocument = new DOMParser().parseFromString(`
   <template id="${localName}">
     <label for="percent"></label>
-    <input id="percent" type="number" min="0" max="100" required>
+    <input id="percent" type="number" inputmode="numeric" min="0" max="100" required>
   </template>
 `, 'text/html');
 

--- a/src/action/components/percent-preference/index.js
+++ b/src/action/components/percent-preference/index.js
@@ -21,6 +21,7 @@ class PercentPreferenceElement extends CustomElement {
 
   /** @type {HTMLInputElement} */ #inputElement;
   /** @type {HTMLLabelElement} */ #labelElement;
+  /** @type {ReturnType<Window['setTimeout']>} */ #timeoutID;
 
   constructor () {
     super(templateDocument, adoptedStyleSheets);
@@ -38,10 +39,13 @@ class PercentPreferenceElement extends CustomElement {
   get value () { return this.#inputElement.value; }
 
   /** @type {(event: InputEvent) => void} */ #onInput = () => {
-    if (this.#inputElement.reportValidity() === false) return;
+    clearTimeout(this.#timeoutID);
+    this.#timeoutID = setTimeout(() => {
+      if (this.#inputElement.reportValidity() === false) return;
 
-    const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
-    browser.storage.local.set({ [storageKey]: this.#inputElement.value });
+      const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
+      browser.storage.local.set({ [storageKey]: this.#inputElement.value });
+    }, 500);
   };
 
   connectedCallback () {

--- a/src/action/components/percent-preference/index.js
+++ b/src/action/components/percent-preference/index.js
@@ -34,9 +34,15 @@ class PercentPreferenceElement extends CustomElement {
   set label (label) { this.#labelElement.textContent = label; }
   get label () { return this.#labelElement.textContent; }
 
-  /** @param {string} value The saved or default value of this preference. */
-  set value (value = '') { this.#inputElement.value = value; }
-  get value () { return this.#inputElement.value; }
+  /** @param {string | number} value The saved or default value of this preference. */
+  set value (value = 0) {
+    typeof value === 'number'
+      ? this.#inputElement.valueAsNumber = value
+      : this.#inputElement.value = value;
+  }
+
+  /** @returns {number} The current value of this preference. */
+  get value () { return this.#inputElement.valueAsNumber; }
 
   /** @type {(event: InputEvent) => void} */ #onInput = () => {
     clearTimeout(this.#timeoutID);
@@ -44,7 +50,7 @@ class PercentPreferenceElement extends CustomElement {
       if (this.#inputElement.reportValidity() === false) return;
 
       const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
-      browser.storage.local.set({ [storageKey]: this.#inputElement.value });
+      browser.storage.local.set({ [storageKey]: this.#inputElement.valueAsNumber });
     }, 500);
   };
 

--- a/src/action/components/percent-preference/index.js
+++ b/src/action/components/percent-preference/index.js
@@ -5,7 +5,7 @@ const localName = 'percent-preference';
 const templateDocument = new DOMParser().parseFromString(`
   <template id="${localName}">
     <label for="percent"></label>
-    <input id="percent" type="text" size="28" spellcheck="false">
+    <input id="percent" type="number" min="0" max="100" required>
   </template>
 `, 'text/html');
 
@@ -21,7 +21,6 @@ class PercentPreferenceElement extends CustomElement {
 
   /** @type {HTMLInputElement} */ #inputElement;
   /** @type {HTMLLabelElement} */ #labelElement;
-  /** @type {ReturnType<Window['setTimeout']>} */ #timeoutID;
 
   constructor () {
     super(templateDocument, adoptedStyleSheets);
@@ -39,12 +38,10 @@ class PercentPreferenceElement extends CustomElement {
   get value () { return this.#inputElement.value; }
 
   /** @type {(event: InputEvent) => void} */ #onInput = () => {
-    const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
-    this.#inputElement.value = this.#inputElement.value.match(/\d+/) ? Math.min(this.#inputElement.value.match(/\d+/)[0], 100) : 0;
-    const storageValue = this.#inputElement.value;
+    if (this.#inputElement.reportValidity() === false) return;
 
-    clearTimeout(this.#timeoutID);
-    this.#timeoutID = setTimeout(() => browser.storage.local.set({ [storageKey]: storageValue }), 500);
+    const storageKey = `${this.featureName}.preferences.${this.preferenceName}`;
+    browser.storage.local.set({ [storageKey]: this.#inputElement.value });
   };
 
   connectedCallback () {

--- a/src/features/vanilla_audio/feature.json
+++ b/src/features/vanilla_audio/feature.json
@@ -12,7 +12,7 @@
     "defaultVolume": {
       "type": "percent",
       "label": "Default Volume",
-      "default": "100"
+      "default": 100
     }
   }
 }

--- a/src/features/vanilla_video/feature.json
+++ b/src/features/vanilla_video/feature.json
@@ -12,7 +12,7 @@
     "defaultVolume": {
       "type": "percent",
       "label": "Default Volume",
-      "default": "100"
+      "default": 100
     },
     "tumblrTvEnable": {
       "type": "checkbox",


### PR DESCRIPTION
<sub>cc @theIncandescentAnteater</sub>

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- see https://github.com/AprilSylph/XKit-Rewritten/pull/2255#pullrequestreview-4326961276

Refactors the new `percent`-type preference to use number-type inputs. This adds increment/decrement buttons, <kbd>▲</kbd> and <kbd>▼</kbd> shortcuts, and allows us to offload validation to the user agent.

Invalid/empty values are no longer refused by the input, but are not saved; instead, the element is just put into a visibly invalid state. This results in slightly better UX when typos occur; typing a letter in between two digits of a valid number no longer erases the proceeding numbers, and <kbd>CTRL</kbd>+<kbd>Z</kbd>/<kbd>Command</kbd>+<kbd>Z</kbd> can now undo input clearing.

I assume using a number-type input is also better for mobile compatibility, since the browser should tell the OS to bring up a number-focused keyboard. That's just an assumption, though.

Before | After | Before | After
-|-|-|-
<img width="750" height="1334" alt="Screen Shot 2026-05-21 at 11 28 42" src="https://github.com/user-attachments/assets/502a197f-6a0e-46eb-8aa3-bad3d7c5a5f6" /> | <img width="750" height="1334" alt="Screen Shot 2026-05-21 at 11 29 09" src="https://github.com/user-attachments/assets/9b05b152-d172-4bcb-a724-15c9504a938b" /> | <img width="750" height="1334" alt="Screen Shot 2026-05-21 at 11 28 46" src="https://github.com/user-attachments/assets/0e0df47b-e70d-4f30-bd27-9e2b04a6a6b9" /> | <img width="750" height="1334" alt="Screen Shot 2026-05-21 at 11 29 13" src="https://github.com/user-attachments/assets/5cb25828-6502-4f26-aa20-ff0c1ecff4e4" />

https://github.com/user-attachments/assets/f664f7e8-513a-44e4-92f7-bbef03ceaf2e

This doesn't make the preference save as a number, which I think is fine. We could change this if we wanted to, by reading `this.#inputElement.valueAsNumber` instead of `this.#inputElement.value`, but existing installations have these preferences saved as strings already, and they're working just fine. Maybe it would be worth doing if we anticipated a need to use this preference type in more features.

Interestingly, we don't explicitly parse these values as numbers in Vanilla Audio/Vanilla Video... they just get cast as numbers when they get divided by 100. Apparently, leading zeroes cause no issues with this.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon in a fresh profile
2. Open Vanilla Audio and Vanilla Video's preferences
    - **Expected result**: Both features' default volume is 100
3. Click one of the "Default Volume" preferences to focus it
4. Press <kbd>▲</kbd>/<kbd>▼</kbd>, or use the on-screen buttons, to adjust the value
    - **Expected result**: The value cannot go above 100
    - **Expected result**: The value cannot go below 0
5. Use your keyboard to type values, including invalid and empty values
    - **Expected result**: Values of 0-100 are accepted; the change is reflected in the Backup tab
    - **Expected result**: Numbers above 100 or below 0 are not accepted; the input border/outline turns red, and the change is not saved
    - **Expected result**: Non-number characters are not accepted
    - **Expected result**: An empty value is not accepted