### PR TITLE
fixes panorama on tagged pages and liked feed

### DIFF
--- a/src/features/panorama/index.js
+++ b/src/features/panorama/index.js
@@ -62,6 +62,13 @@ ${mainContentWrapper} > div > div:has(> div > ${keyToCss('timeline')}) {
 ${mainContentWrapper} > div > div > div:has(> ${keyToCss('timeline')}) {
   max-width: unset;
 }
+
+${keyToCss('grid')}:has(${keyToCss('layoutBody')}) {
+  grid-template-columns: 1fr auto;
+}
+${keyToCss('grid')} ${keyToCss('layoutBody')} {
+  max-width: var(${maxPostWidthVar});
+}
 `);
 mainStyleElement.media = `(min-width: ${widenDashMinWidth}px)`;
 

--- a/src/features/panorama/index.js
+++ b/src/features/panorama/index.js
@@ -51,6 +51,7 @@ ${mainPostColumn} > ${keyToCss('postColumn')} {
 
 ${mainContentWrapper}:has(> div > div > div > ${keyToCss('timeline')}) {
   flex-grow: 1;
+  max-width: calc(var(${maxPostWidthVar}) + ${sidebarOffset}px);
 }
 ${mainContentWrapper} > div:has(> div > div > ${keyToCss('timeline')}) {
   max-width: unset;

--- a/src/features/panorama/index.js
+++ b/src/features/panorama/index.js
@@ -63,11 +63,20 @@ ${mainContentWrapper} > div > div > div:has(> ${keyToCss('timeline')}) {
   max-width: unset;
 }
 
-${keyToCss('grid')}:has(${keyToCss('layoutBody')}) {
-  grid-template-columns: 1fr auto;
+${keyToCss('mainContentWrapper')}:has(> div > div > ${keyToCss('grid')}) {
+  flex-grow: 1;
+  max-width: calc(var(${maxPostWidthVar}) + ${sidebarOffset}px);
 }
-${keyToCss('grid')} ${keyToCss('layoutBody')} {
+${keyToCss('mainContentWrapper')} > div > div > ${keyToCss('grid')}:has(> ${keyToCss('layoutBody')}) {
+  display: flex;
+}
+${keyToCss('mainContentWrapper')} > div > div > ${keyToCss('grid')} > ${keyToCss('layoutBody')} {
   max-width: var(${maxPostWidthVar});
+}
+${keyToCss('mainContentWrapper')} > div > div > ${keyToCss('grid')} > ${keyToCss('sidebar')} {
+  width: auto;
+  min-width: 256px;
+  max-width: 320px;
 }
 `);
 mainStyleElement.media = `(min-width: ${widenDashMinWidth}px)`;

--- a/src/features/panorama/index.js
+++ b/src/features/panorama/index.js
@@ -21,7 +21,7 @@ const aspectRatioVar = '--xkit-panorama-aspect-ratio';
 
 const mainContentWrapper =
   `${keyToCss('mainContentWrapper')}:not(${keyToCss('mainContentIsMasonry', 'mainContentIsFullWidth')})`;
-const mainPostColumn = `main${keyToCss('postColumn', 'postsColumn')}`;
+const mainPostColumn = `main${keyToCss('postColumn', 'postsColumn', 'mainColumnContainer')}`;
 const patioPostColumn = `[id]${keyToCss('columnWide')}`;
 
 const mainStyleElement = buildStyle(`
@@ -43,6 +43,9 @@ ${keyToCss('queueSettings')} {
   width: 100%;
 }
 ${mainPostColumn} > ${keyToCss('tabsHeader')} + ${keyToCss('container')} {
+  max-width: unset;
+}
+${mainPostColumn} > ${keyToCss('postColumn')} {
   max-width: unset;
 }
 `);

--- a/src/features/panorama/index.js
+++ b/src/features/panorama/index.js
@@ -48,6 +48,19 @@ ${mainPostColumn} > ${keyToCss('tabsHeader')} + ${keyToCss('container')} {
 ${mainPostColumn} > ${keyToCss('postColumn')} {
   max-width: unset;
 }
+
+${mainContentWrapper}:has(> div > div > div > ${keyToCss('timeline')}) {
+  flex-grow: 1;
+}
+${mainContentWrapper} > div:has(> div > div > ${keyToCss('timeline')}) {
+  max-width: unset;
+}
+${mainContentWrapper} > div > div:has(> div > ${keyToCss('timeline')}) {
+  max-width: unset;
+}
+${mainContentWrapper} > div > div > div:has(> ${keyToCss('timeline')}) {
+  max-width: unset;
+}
 `);
 mainStyleElement.media = `(min-width: ${widenDashMinWidth}px)`;
 

--- a/src/features/panorama/index.js
+++ b/src/features/panorama/index.js
@@ -63,7 +63,7 @@ ${mainContentWrapper} > div > div > div:has(> ${keyToCss('timeline')}) {
   max-width: unset;
 }
 
-${keyToCss('grid')}:has(${keyToCss('layoutBody')}) {
+${keyToCss('grid')}:has(> ${keyToCss('layoutBody')}) {
   grid-template-columns: 1fr auto;
 }
 ${keyToCss('grid')} ${keyToCss('layoutBody')} {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
i believe this fixes #1785. as far as i can see, the extension already works on the community feeds.

the classes on the tagged page differ from the dash, but the liked page doesn't have a main element at all

| Before | After |
|--------|--------|
| <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/5cb0a848-105e-4322-b5f2-a4c827221823" /> | <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/972a9cf2-018d-4d4a-9fe2-31bf19d77352" /> |
| <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/47a9d805-fbe0-402a-8357-ba7514e31aa0" /> | <img width="1919" height="1079" alt="image" src="https://github.com/user-attachments/assets/9d623267-0cb5-455a-ad1a-a38e0167caab" /> | 

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Go to a [tagged page](https://www.tumblr.com/tagged/xkit)
3. See the wide post width
4. Go to a [the likes feed](https://www.tumblr.com/likes)
3. See the wide post width