### PR TITLE
fix(Mutual Checker): do not hide posts from own blogs in mutuals-only mode

### DIFF
--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -4,7 +4,7 @@ import { buildStyle, getTimelineItemWrapper, filterPostElements, getPopoverWrapp
 import { translate } from '../../utils/language_data.js';
 import { onNewPosts, onNewNotifications, pageModifications } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
-import { blogData, notificationObject, timelineObject } from '../../utils/react_props.js';
+import { blogData, notificationObject, timelineObject, isMyPost } from '../../utils/react_props.js';
 import { buildSvg } from '../../utils/remixicon.js';
 import { followingTimelineSelector } from '../../utils/timeline_id.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
@@ -75,6 +75,9 @@ const alreadyProcessed = postElement =>
 const addIcons = function (postElements) {
   filterPostElements(postElements, { includeFiltered: true }).forEach(async postElement => {
     if (alreadyProcessed(postElement)) return;
+
+    const postIsMine = await isMyPost(postElement);
+    if (postIsMine) return;
 
     const postAttribution = postElement.querySelector(postAttributionSelector);
     const blogName = postAttribution?.textContent.trim();

--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -4,11 +4,11 @@ import { buildStyle, getTimelineItemWrapper, filterPostElements, getPopoverWrapp
 import { translate } from '../../utils/language_data.js';
 import { onNewPosts, onNewNotifications, pageModifications } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
-import { blogData, notificationObject, timelineObject, isMyPost } from '../../utils/react_props.js';
+import { blogData, notificationObject, timelineObject } from '../../utils/react_props.js';
 import { buildSvg } from '../../utils/remixicon.js';
 import { followingTimelineSelector } from '../../utils/timeline_id.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
-import { primaryBlogName } from '../../utils/user.js';
+import { primaryBlogName, userBlogNames } from '../../utils/user.js';
 
 const mutualIconClass = 'xkit-mutual-icon';
 const hiddenAttribute = 'data-mutual-checker-hidden';
@@ -76,11 +76,9 @@ const addIcons = function (postElements) {
   filterPostElements(postElements, { includeFiltered: true }).forEach(async postElement => {
     if (alreadyProcessed(postElement)) return;
 
-    const postIsMine = await isMyPost(postElement);
-    if (postIsMine) return;
-
     const postAttribution = postElement.querySelector(postAttributionSelector);
     const blogName = postAttribution?.textContent.trim();
+    if (userBlogNames.includes(blogName)) return;
 
     const followingBlog = blogName
       ? await getIsFollowing(blogName, postElement)
@@ -102,7 +100,7 @@ const addIcons = function (postElements) {
 const addBlogCardIcons = blogCardLinks =>
   blogCardLinks.forEach(async blogCardLink => {
     const blogName = blogCardLink.querySelector(keyToCss('blogLinkShort'))?.textContent || blogCardLink?.textContent;
-    if (!blogName) return;
+    if (!blogName || userBlogNames.includes(blogName)) return;
 
     const followingBlog = await getIsFollowing(blogName, blogCardLink);
     const isFollowingYou = await getIsFollowingYou(blogName);
@@ -122,7 +120,7 @@ const getIsFollowing = async (blogName, element) => {
     ].find((data) => blogName === data?.name);
 
     following[blogName] = blog
-      ? Promise.resolve(blog.followed && !blog.isMember)
+      ? Promise.resolve(blog.followed)
       : apiFetch(`/v2/blog/${blogName}/info`)
         .then(({ response: { blog: { followed } } }) => followed)
         .catch(() => Promise.resolve(false));
@@ -144,7 +142,6 @@ export const main = async function () {
   document.documentElement.append(styleElement);
 
   ({ showOnlyMutuals, showOnlyMutualNotifications } = await getPreferences('mutual_checker'));
-  following[primaryBlogName] = Promise.resolve(false);
 
   onNewPosts.addListener(addIcons);
   pageModifications.register(`${keyToCss('blogCard')} ${keyToCss('blogCardBlogLink')} > a`, addBlogCardIcons);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->
- fixes #2263

Mutual Checker should do nothing to one's own posts. The relationship you have with your own blogs is not a relationship between you and another party, which is what the feature deals with.

If you wanted to hide posts from non-mutuals _and_ your own posts, you would use Mutual Checker &rarr; "Only show posts from mutuals on the dashboard" in combination with Tweaks &rarr; "Hide my own posts on the dashboard".

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Open the Tumblr dashboard
3. Enable Mutual Checker &rarr; "Only show posts from mutuals on the dashboard"
    - **Expected result**: Posts from blogs you are not following are hidden
    - **Expected result**: Posts from blogs you are following, but not mutuals with, are hidden
    - **Expected result**: Posts from blogs you are mutuals with are not hidden, and have mutual icons
    - **Expected result**: Posts from your own blogs are not hidden, and do not have mutual icons
