### PR TITLE
fix: force update of bottom sheet container height

### DIFF
--- a/src/main_world/update_bottom_sheet_container_height.js
+++ b/src/main_world/update_bottom_sheet_container_height.js
@@ -1,0 +1,14 @@
+export default function updateBottomSheetContainerHeight () {
+  const container = this;
+  const reactKey = Object.keys(container).find(key => key.startsWith('__reactFiber'));
+  const fiber = container[reactKey];
+
+  /**
+   * Re-run the callback that is executed when this element is added to the DOM.
+   * In this case, the Tumblr frontend queries this.clientHeight and saves it in a state hook.
+   * @see https://react.dev/reference/react-dom/components/common#ref-callback
+   */
+  if (typeof fiber?.ref === 'function') {
+    fiber.ref(container);
+  }
+}

--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -1,10 +1,13 @@
 import { keyToCss } from './css_map.js';
 import { button } from './dom.js';
+import { inject } from './inject.js';
 import { displayBlockUnlessDisabledAttr, displayFlexUnlessDisabledAttr, getClosestRenderedElement, postSelector } from './interface.js';
 import { pageModifications } from './mutations.js';
 import { blogData, timelineObject } from './react_props.js';
 
 const ariakitMenuSelector = '#glass-container [role="menu"][aria-orientation="vertical"]';
+const ariakitBottomSheetContainerSelector = `[style*="transform"] > ${keyToCss('container')}`;
+
 const menuSelector = `${keyToCss('meatballMenu')}, ${ariakitMenuSelector}`;
 
 const postHeaderSelector = `${postSelector} :is(article > header, article > div > header)`;
@@ -113,6 +116,11 @@ const addTypedMeatballItems = async ({ meatballMenu, type, reactData, reactDataK
     }
 
     meatballMenu.append(meatballItemButton);
+
+    if (menuIsAriakit) {
+      const bottomSheetContainer = meatballMenu.closest(ariakitBottomSheetContainerSelector);
+      bottomSheetContainer && inject('/main_world/update_bottom_sheet_container_height.js', [], bottomSheetContainer);
+    }
   });
 };
 

--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -118,6 +118,7 @@ const addTypedMeatballItems = async ({ meatballMenu, type, reactData, reactDataK
     meatballMenu.append(meatballItemButton);
 
     if (menuIsAriakit) {
+      // Bottom-of-viewport slide-up menu layout used in mobile viewport widths
       const bottomSheetContainer = meatballMenu.closest(ariakitBottomSheetContainerSelector);
       bottomSheetContainer && inject('/main_world/update_bottom_sheet_container_height.js', [], bottomSheetContainer);
     }


### PR DESCRIPTION
Stacked PR on #2268.

### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
--> 

This fixes an issue where the mobile layout of the parent PR suffered from an issue where Tumblr's code did not take the added meatball items into account when calculating the bottom sheet container height.

Apparently this is queried in a react ref callback. Thus, this calls the ref callback again.

Obviously I would love a less convoluted way to do this. Any ideas? Notably, resizing the window also seems to update it, but I have no idea why.

(To quickly find the relevant code, search `\w\(Math.min\(\w.clientHeight,` in the Firefox debugger tab.)

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

Before | After
-|-
<video src="https://github.com/user-attachments/assets/09c58abf-6d49-4c6f-8ae3-41154a6e1521" > | <video src="https://github.com/user-attachments/assets/e01de12c-37dc-4e4a-a4ca-1006f2e30933" >

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

See parent PR.