### PR TITLE
feat(AccessKit Disable GIFs): Re-implement download-GIF-on-hover feature

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -4,9 +4,10 @@ import { buildStyle, postSelector } from '../../utils/interface.js';
 import { memoize } from '../../utils/memoize.js';
 import { pageModifications } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
+import { posterImages } from '../../utils/react_props.js';
 
 const canvasClass = 'xkit-paused-gif-placeholder';
-const pausedPosterAttribute = 'data-paused-gif-use-poster';
+const downloadOnHoverAttribute = 'data-paused-gif-download-on-hover';
 const pausedBackgroundImageVar = '--xkit-paused-gif-background-image';
 const hoverContainerAttribute = 'data-paused-gif-hover-container';
 const labelAttribute = 'data-paused-gif-label';
@@ -61,10 +62,9 @@ export const styleElement = buildStyle(`
   background-color: rgb(var(--white));
 }
 
-.${canvasClass}${parentHovered},
+.${canvasClass}${parentHovered}:not(:has(~ ${keyToCss('loader')} > ${keyToCss('knightRiderLoader')})),
 [${labelAttribute}="after"]${hovered}::after,
 [${labelAttribute}="before"]${hovered}::before,
-[${pausedPosterAttribute}]:not(${hovered}) > ${keyToCss('loader')} > ${keyToCss('knightRiderLoader')},
 [${labelAttribute}]:not(${hovered}) > ${keyToCss('loader')} > ${keyToCss('knightRiderLoader')} {
   display: none !important;
 }
@@ -74,13 +74,7 @@ ${keyToCss('background')}[${labelAttribute}="before"]::before {
   display: none;
 }
 
-[${pausedPosterAttribute}]:not(${hovered}) > img${keyToCss('poster')} {
-  visibility: visible !important;
-}
-[${pausedPosterAttribute}="eager"]:not(${hovered}) > img:not(${keyToCss('poster')}) {
-  visibility: hidden !important;
-}
-[${pausedPosterAttribute}="lazy"]:not(${hovered}) > img:not(${keyToCss('poster')}) {
+[${downloadOnHoverAttribute}]:not(${hovered}) > img {
   display: none;
 }
 
@@ -167,11 +161,11 @@ const createPausedUrlIfAnimated = memoize(async sourceUrl => {
   return URL.createObjectURL(blob);
 });
 
-const pauseGif = async function (gifElement) {
-  if (gifElement.currentSrc.endsWith('.webp') && !(await isAnimated(gifElement.currentSrc))) return;
+const pauseGif = async function (gifElement, currentSrc = gifElement.currentSrc) {
+  if (currentSrc.endsWith('.webp') && !(await isAnimated(currentSrc))) return;
 
   const image = new Image();
-  image.src = gifElement.currentSrc;
+  image.src = currentSrc;
   image.onload = () => {
     if (gifElement.parentNode && gifElement.parentNode.querySelector(`.${canvasClass}`) === null) {
       const canvasElement = canvas({
@@ -188,7 +182,7 @@ const pauseGif = async function (gifElement) {
 };
 
 const processGifs = function (gifElements) {
-  gifElements.forEach(gifElement => {
+  gifElements.forEach(async gifElement => {
     if (gifElement.closest(`${keyToCss('avatarImage', 'subAvatarImage')}, .block-editor-writing-flow`)) return;
     const pausedGifElements = [...gifElement.parentNode.querySelectorAll(`.${canvasClass}`)];
     if (pausedGifElements.length) {
@@ -198,11 +192,20 @@ const processGifs = function (gifElements) {
 
     gifElement.decoding = 'sync';
 
-    const posterElement = gifElement.parentElement.querySelector(keyToCss('poster'));
-    if (posterElement) {
-      gifElement.parentElement.setAttribute(pausedPosterAttribute, loadingMode);
-      addLabel(posterElement);
-      return;
+    if (
+      loadingMode === 'lazy' &&
+      gifElement.loading === 'lazy' &&
+      gifElement.parentElement.matches(keyToCss('placeholder'))
+    ) {
+      const placeholderElement = gifElement.parentElement;
+      const posterImagesArray = await posterImages(placeholderElement);
+      const posterSrc = Array.isArray(posterImagesArray) && posterImagesArray.at(-1)?.url;
+
+      if (posterSrc && gifElement.isConnected) {
+        placeholderElement.setAttribute(downloadOnHoverAttribute, '');
+        pauseGif(gifElement, posterSrc);
+        return;
+      }
     }
 
     if (gifElement.complete && gifElement.currentSrc) {
@@ -333,7 +336,7 @@ export const clean = async function () {
   $(`.${canvasClass}`).remove();
   $(`[${labelAttribute}]`).removeAttr(labelAttribute);
   $(`[${labelSizeAttribute}]`).removeAttr(labelSizeAttribute);
-  $(`[${pausedPosterAttribute}]`).removeAttr(pausedPosterAttribute);
+  $(`[${downloadOnHoverAttribute}]`).removeAttr(downloadOnHoverAttribute);
   $(`[${hoverContainerAttribute}]`).removeAttr(hoverContainerAttribute);
   [...document.querySelectorAll(`[style*="${pausedBackgroundImageVar}"]`)]
     .forEach(element => element.style.removeProperty(pausedBackgroundImageVar));

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -290,6 +290,7 @@ export const main = async function () {
     ) img:is([srcset*=".gif"], [src*=".gif"], [srcset*=".webp"], [src*=".webp"]):not(${keyToCss('poster')})
   `;
   pageModifications.register(gifImage, processGifs);
+  pageModifications.register(`${gifImage} ~ ${keyToCss('playButton')}`, processNativeGifPlayButtons);
 
   const gifBackgroundImage = `
     ${keyToCss(
@@ -311,8 +312,6 @@ export const main = async function () {
     `:is(${postSelector}, ${keyToCss('blockEditorContainer')}) ${keyToCss('rows')}`,
     processRows,
   );
-
-  pageModifications.register(`${gifImage} ~ ${keyToCss('playButton')}`, processNativeGifPlayButtons);
 
   browser.storage.local.onChanged.addListener(onStorageChanged);
 };

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -64,7 +64,8 @@ export const styleElement = buildStyle(`
 .${canvasClass}${parentHovered},
 [${labelAttribute}="after"]${hovered}::after,
 [${labelAttribute}="before"]${hovered}::before,
-[${pausedPosterAttribute}]:not(${hovered}) > div > ${keyToCss('knightRiderLoader')} {
+[${pausedPosterAttribute}]:not(${hovered}) > ${keyToCss('loader')} > ${keyToCss('knightRiderLoader')},
+[${labelAttribute}]:not(${hovered}) > ${keyToCss('loader')} > ${keyToCss('knightRiderLoader')} {
   display: none !important;
 }
 ${keyToCss('background')}[${labelAttribute}="after"]::after,
@@ -266,6 +267,8 @@ const onStorageChanged = async function (changes) {
   loadingMode = modeChanges.newValue;
 };
 
+const processNativeGifPlayButtons = buttons => buttons.forEach(button => button.click());
+
 export const main = async function () {
   ({ disable_gifs_loading_mode: loadingMode } = await getPreferences('accesskit'));
 
@@ -309,6 +312,8 @@ export const main = async function () {
     processRows,
   );
 
+  pageModifications.register(`${gifImage} ~ ${keyToCss('playButton')}`, processNativeGifPlayButtons);
+
   browser.storage.local.onChanged.addListener(onStorageChanged);
 };
 
@@ -319,6 +324,8 @@ export const clean = async function () {
   pageModifications.unregister(processBackgroundGifs);
   pageModifications.unregister(processRows);
   pageModifications.unregister(processHoverableElements);
+
+  pageModifications.unregister(processNativeGifPlayButtons);
 
   [...document.querySelectorAll(`.${containerClass}`)].forEach(wrapper =>
     wrapper.replaceWith(...wrapper.children),

--- a/src/main_world/unbury_poster_images.js
+++ b/src/main_world/unbury_poster_images.js
@@ -1,0 +1,14 @@
+export default function unburyPosterImages () {
+  const placeholderElement = this;
+  const reactKey = Object.keys(placeholderElement).find(key => key.startsWith('__reactFiber'));
+  let fiber = placeholderElement[reactKey];
+
+  while (fiber !== null) {
+    const { posterImages } = fiber.memoizedProps || {};
+    if (posterImages !== undefined) {
+      return posterImages;
+    } else {
+      fiber = fiber.return;
+    }
+  }
+}

--- a/src/utils/react_props.js
+++ b/src/utils/react_props.js
@@ -31,6 +31,15 @@ export const notificationObject = notificationElement => {
 };
 
 /**
+ * @param {Element} imagePlaceholderElement An on-screen image placeholder
+ * @returns {Promise<object>} The image placeholder's buried posterImages property
+ */
+export const posterImages = imagePlaceholderElement => {
+  imagePlaceholderElement.posterImagesPromise ??= inject('/main_world/unbury_poster_images.js', [], imagePlaceholderElement);
+  return imagePlaceholderElement.posterImagesPromise;
+};
+
+/**
  * @param {Element} meatballMenu An on-screen meatball menu element in a blog modal header or blog card
  * @returns {Promise<object>} The post's buried blog or blogSettings property. Some blog data fields, such as "followed," are not available in blog cards.
  */


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Bit of an experiment. Kind of surprised this appears to (maybe?) work, though in writing up the technique it seems rather obvious in retrospect.

Implemented in #1853, the "Download paused GIFs: when hovered" feature of AccessKit Disable GIFs made use of a Tumblr layout with both a "poster" stationary image element and an animated image element. It overrode the poster to be visible and the animated image element to be `display: none` when the user was not hovering over the GIF, and because Tumblr sets `loading="lazy"` on the animated image*, the browser did not download it eagerly.

As noted in #2243, this doesn't work anymore, since Tumblr now uses a single image element, swapping the source out for a poster version in some circumstances (media autoplay disabled; image element offscreen—I don't know why the latter condition, but I digress). Disable GIFs still works, using its good old fashioned code path of rendering the GIF onto a canvas element to make a "poster".

This PR attempts to bring back the behavior by setting the animated image element to `display: none` when not hovered, as before, and by grabbing the poster source URL from the react data and feeding it to our canvas-making code. Note that:

- We probably only want to use this code path in lazy mode. Downloading a poster image is way cheaper than downloading an animated GIF, but if we're in eager mode we're downloading the animated GIF eagerly anyway, so we may as well use it. (Using this code in both modes does make the paused image appear faster if you turn throttling on, though.)
- Tumblr's new code (with media autoplay enabled) doesn't show the poster while the animated image is downloading, like the old one did (I assume this was one reason they switched; it saves bandwidth if you were going to download the animated source anyway). Thus, naively implementing this means that when you hover a paused image, it turns into a gradient while the animated image is downloading. `.${canvasClass}${parentHovered}:not(:has(~ ${keyToCss('loader')} > ${keyToCss('knightRiderLoader')}))` is a fix for this (showing the canvas during the load). Hopefully there's a more elegant solution to this.

Not currently working with media autoplay disabled (#2270 clicks the images when they're first processed, which downloads the animated versions; this seems like it will be annoying to fix).

Oh, also, I have no idea if "the last image in the `posterImages` array" is actually the right source to pick. Realistically, if we were confident about mirroring Tumblr's processing, "`display: none` all of Tumblr's elements, grab the paused and animated source values from react data, and make two of our own image elements" would be a quite elegant solution that doesn't care about the media autoplay setting at all. Am I confident about that? Well... no.

*unless you're in blog view; I don't know why

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

tba

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

tba
