### PR TITLE
feat: Inform user when Chrome autoupdates

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -113,7 +113,7 @@
    * context javascript immediately.
    */
   const warnOnExtensionContextInvalidated = async () => {
-    const { showUnloadedModal } = await import(browser.runtime.getURL('/utils/modals.js'));
+    const { warnOnExtensionContextInvalidated } = await import(browser.runtime.getURL('/utils/modals.js'));
 
     const isExtensionContextValid = () => { try { browser.runtime.getURL(''); return true; } catch { return false; } };
 
@@ -121,7 +121,7 @@
     while (true) {
       failures = isExtensionContextValid() ? 0 : failures + 1;
       if (failures >= 5 && !document.getElementById('xkit-modal')) {
-        showUnloadedModal();
+        warnOnExtensionContextInvalidated();
         break;
       }
       await new Promise(resolve => setTimeout(resolve, 1000));

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -113,7 +113,7 @@
    * context javascript immediately.
    */
   const warnOnExtensionContextInvalidated = async () => {
-    const { warnOnExtensionContextInvalidated } = await import(browser.runtime.getURL('/utils/modals.js'));
+    const { showContextInvalidatedModal } = await import(browser.runtime.getURL('/utils/modals.js'));
 
     const isExtensionContextValid = () => { try { browser.runtime.getURL(''); return true; } catch { return false; } };
 
@@ -121,7 +121,7 @@
     while (true) {
       failures = isExtensionContextValid() ? 0 : failures + 1;
       if (failures >= 5 && !document.getElementById('xkit-modal')) {
-        warnOnExtensionContextInvalidated();
+        showContextInvalidatedModal();
         break;
       }
       await new Promise(resolve => setTimeout(resolve, 1000));

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -118,14 +118,13 @@
     const isExtensionContextValid = () => { try { browser.runtime.getURL(''); return true; } catch { return false; } };
 
     let failures = 0;
-    while (true) {
+    const intervalID = setInterval(() => {
       failures = isExtensionContextValid() ? 0 : failures + 1;
       if (failures >= 5 && !document.getElementById('xkit-modal')) {
         showContextInvalidatedModal();
-        break;
+        clearInterval(intervalID);
       }
-      await new Promise(resolve => setTimeout(resolve, 1000));
-    }
+    }, 1000);
   };
 
   const init = async function () {

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -107,6 +107,27 @@
     document.documentElement.append(script);
   });
 
+  /**
+   * Shows an informative modal if the extension context is invalidated (e.g. after extension is autoupdated
+   * or manually disabled in Chromium). Should do nothing in Firefox, which stops running all extension
+   * context javascript immediately.
+   */
+  const warnOnExtensionContextInvalidated = async () => {
+    const { showUnloadedModal } = await import(browser.runtime.getURL('/utils/modals.js'));
+
+    const isExtensionContextValid = () => { try { browser.runtime.getURL(''); return true; } catch { return false; } };
+
+    let failures = 0;
+    while (true) {
+      failures = isExtensionContextValid() ? 0 : failures + 1;
+      if (failures >= 5 && !document.getElementById('xkit-modal')) {
+        showUnloadedModal();
+        break;
+      }
+      await new Promise(resolve => setTimeout(resolve, 1000));
+    }
+  };
+
   const init = async function () {
     $('style.xkit, link.xkit').remove();
 
@@ -130,6 +151,8 @@
     installedFeatures
       .filter(featureName => enabledFeatures.includes(featureName))
       .forEach(runFeature);
+
+    warnOnExtensionContextInvalidated();
   };
 
   const waitForReactLoaded = async function () {

--- a/src/features/mass_deleter/index.js
+++ b/src/features/mass_deleter/index.js
@@ -1,6 +1,6 @@
 import { button, form, input, label, small, span } from '../../utils/dom.js';
 import { megaEdit } from '../../utils/mega_editor.js';
-import { createBlogSpan, modalCancelButton, modalCompleteButton, showErrorModal, showModal } from '../../utils/modals.js';
+import { createBlogSpan, hideModal, modalCancelButton, modalCompleteButton, showErrorModal, showModal } from '../../utils/modals.js';
 import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
 import { dateTimeFormat } from '../../utils/text_format.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
@@ -131,7 +131,8 @@ const deleteDrafts = async function ({ blogName, before }) {
       'Refresh the page to see the result.',
     ],
     buttons: [
-      button({ class: 'blue', click: () => location.reload() }, ['Refresh']),
+      button({ click: hideModal }, ['Close']),
+      button({ class: 'blue', click: () => location.reload() }, ['Refresh Now']),
     ],
   });
 };
@@ -225,7 +226,8 @@ const clearQueue = async function ({ blogName }) {
       'Refresh the page to see the result.',
     ],
     buttons: [
-      button({ class: 'blue', click: () => location.reload() }, ['Refresh']),
+      button({ click: hideModal }, ['Close']),
+      button({ class: 'blue', click: () => location.reload() }, ['Refresh Now']),
     ],
   });
 };

--- a/src/features/mass_privater/index.js
+++ b/src/features/mass_privater/index.js
@@ -236,7 +236,7 @@ const privatePosts = async ({ uuid, name, tags, before }) => {
     ],
     buttons: [
       dom('button', null, { click: hideModal }, ['Close']),
-      dom('button', { class: 'blue' }, { click: () => location.reload() }, ['Refresh']),
+      dom('button', { class: 'blue' }, { click: () => location.reload() }, ['Refresh Now']),
     ],
   });
 };

--- a/src/utils/modals.js
+++ b/src/utils/modals.js
@@ -76,7 +76,7 @@ export const showContextInvalidatedModal = () =>
   showModal({
     title: 'XKit Rewritten has become unloaded.',
     message: [
-      'If this is unexpected, this is likely due to your browser automatically applying an XKit version update!',
+      'If this is unexpected, this is likely due to your browser automatically applying an XKit version update.',
       '\n\n',
       'Outdated XKit modifications will be updated/removed after you refresh this Tumblr tab.',
     ],

--- a/src/utils/modals.js
+++ b/src/utils/modals.js
@@ -72,5 +72,19 @@ export const withModalOnError = func =>
     }
   };
 
+export const showContextInvalidatedModal = () =>
+  showModal({
+    title: 'XKit Rewritten has become unloaded.',
+    message: [
+      'If this is unexpected, this is likely due to your browser automatically applying an XKit version update!',
+      '\n\n',
+      'Outdated XKit modifications will be updated/removed after you refresh this Tumblr tab.',
+    ],
+    buttons: [
+      dom('button', null, { click: hideModal }, ['Close']),
+      dom('button', { class: 'blue' }, { click: () => location.reload() }, ['Refresh Now']),
+    ],
+  });
+
 export const createTagSpan = tag => dom('span', { class: 'xkit-modal-tag' }, null, [tag]);
 export const createBlogSpan = name => dom('span', { class: 'xkit-modal-blog' }, null, [name]);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

Resolves #2276:

> I can't 100% verify that this is true—I guess I should go back to Chrome for a while for coverage, one of us probably should—but it's very possible and perhaps likely that when Chrome autoupdates an extension, while it doesn't invalidate the entire javascript context for the extension content script like Firefox does, it **does** make all browser.x namespaced functions throw "extension context invalidated", as can be simulated by disabling the extension. This, of course, breaks some of the extension.
> 
> In [#1486](https://github.com/AprilSylph/XKit-Rewritten/pull/1486) we slightly improved the error handler for this, but a) we apparently don't have error handling on everything that could throw, and b) honestly I think it would be a lot better to not wait for the user to do something to show an error message. Particularly if they have multiple Tumblr tabs open, it makes the most sense to me to show an informative modal on all tabs when an automatic update occurs, which (as mentioned in that PR) we could do via polling.

This shows a modal message if XKit Rewritten stops being able to access `browser.x` functions, which will occur in Chromium-based browsers if the user disables XKit or (possibly, unconfirmed) if there's an automatic update. Basically #1486 on steroids.

If we had a background script, we could try to make this happen only on update, not on disable, but for cross-platform-old-browser compatibility reasons we currently don't, and thus don't have access to the APIs that would let us differentiate.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

<img width="506" src="https://github.com/user-attachments/assets/2bf14f99-aa95-4488-87ec-e103e741adbf" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- In a Chromium-based browser (`npm start -- -t=chromium`), enable XKit Rewritten, open a (logged-in) Tumblr tab, then disable the extension. Confirm that the referenced info modal appears after a short period. You may note that:
  - Enabling the extension again does nothing (unlike in Firefox).
  - If you decline to refresh immediately, you can get the #1486 messages by clicking various extension UI elements.
- Open any XKit modal, then disable the extension. Confirm that the the referenced info modal appears only after you dismiss the other modal.
- In a Firefox, enable XKit Rewritten, open a (logged-in) Tumblr tab, then disable the extension. Confirm that nothing occurs.