### PR TITLE
refactor: Use `toggleAttribute`/`hasAttribute` functions

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -257,7 +257,7 @@ const processRows = function (rowsElements) {
 };
 
 const processHoverableElements = elements =>
-  elements.forEach(element => element.setAttribute(hoverContainerAttribute, ''));
+  elements.forEach(element => element.toggleAttribute(hoverContainerAttribute, true));
 
 const onStorageChanged = async function (changes) {
   const { 'accesskit.preferences.disable_gifs_loading_mode': modeChanges } = changes;

--- a/src/features/anti_capitalism/index.js
+++ b/src/features/anti_capitalism/index.js
@@ -12,7 +12,7 @@ export const styleElement = buildStyle();
 const processVideoCTAs = videoCTAs => videoCTAs
   .map(getTimelineItemWrapper)
   .filter(Boolean)
-  .forEach(timelineItem => timelineItem.setAttribute(hiddenAttribute, ''));
+  .forEach(timelineItem => timelineItem.toggleAttribute(hiddenAttribute, true));
 
 export const main = async () => {
   const { includeBlazed } = await getPreferences('anti_capitalism');

--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -284,7 +284,7 @@ const processPosts = (postElements) => postElements.forEach(async postElement =>
         click: onNoteCountClick,
       }, getButtonChildren(noteCount));
 
-      engagementControls.closest('footer').setAttribute(activeAttribute, '');
+      engagementControls.closest('footer').toggleAttribute(activeAttribute, true);
       engagementControls.before(noteCountButton);
 
       if (noReblogMenu) {

--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -92,7 +92,7 @@ const addIcons = function (postElements) {
       const iconTarget = getPopoverWrapper(postAttribution) ?? postAttribution;
       iconTarget?.before(createIcon(isMutual, blogName));
     } else if (showOnlyMutuals) {
-      getTimelineItemWrapper(postElement)?.setAttribute(hiddenAttribute, '');
+      getTimelineItemWrapper(postElement)?.toggleAttribute(hiddenAttribute, true);
     }
   });
 };

--- a/src/features/no_recommended/hide_blog_carousels.js
+++ b/src/features/no_recommended/hide_blog_carousels.js
@@ -22,8 +22,8 @@ const hideBlogCarousels = carousels =>
         timelineItem.previousElementSibling.querySelector(keyToCss('titleObject')) ||
         timelineItem.previousElementSibling.dataset.cellId?.startsWith('timelineObject:title')
       ) {
-        timelineItem.setAttribute(hiddenAttribute, '');
-        timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
+        timelineItem.toggleAttribute(hiddenAttribute, true);
+        timelineItem.previousElementSibling.toggleAttribute(hiddenAttribute, true);
       }
     }
   });

--- a/src/features/no_recommended/hide_community_carousels.js
+++ b/src/features/no_recommended/hide_community_carousels.js
@@ -22,8 +22,8 @@ const hideCommunityCarousels = carousels =>
         timelineItem.previousElementSibling.querySelector(keyToCss('titleObject')) ||
         timelineItem.previousElementSibling.dataset.cellId?.startsWith('timelineObject:title')
       ) {
-        timelineItem.setAttribute(hiddenAttribute, '');
-        timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
+        timelineItem.toggleAttribute(hiddenAttribute, true);
+        timelineItem.previousElementSibling.toggleAttribute(hiddenAttribute, true);
       }
     }
   });

--- a/src/features/no_recommended/hide_radar.js
+++ b/src/features/no_recommended/hide_radar.js
@@ -9,7 +9,7 @@ export const styleElement = buildStyle(`[${hiddenAttribute}] { display: none; }`
 const checkForRadar = function (sidebarTitles) {
   sidebarTitles
     .filter(h1 => h1.textContent === translate('Radar'))
-    .forEach(h1 => h1.closest('aside > *').setAttribute(hiddenAttribute, ''));
+    .forEach(h1 => h1.closest('aside > *').toggleAttribute(hiddenAttribute, true));
 };
 
 export const main = async function () {

--- a/src/features/no_recommended/hide_recommended_blogs.js
+++ b/src/features/no_recommended/hide_recommended_blogs.js
@@ -10,13 +10,13 @@ export const styleElement = buildStyle(`[${hiddenAttribute}] { display: none; }`
 const hideDashboardRecommended = function (sidebarTitles) {
   sidebarTitles
     .filter(h1 => h1.textContent === translate('Check out these blogs'))
-    .forEach(h1 => h1.closest('aside > *').setAttribute(hiddenAttribute, ''));
+    .forEach(h1 => h1.closest('aside > *').toggleAttribute(hiddenAttribute, true));
 };
 
 const hideTagPageRecommended = blogsLists =>
   blogsLists
     .filter(ul => !ul.matches(blogViewSelector))
-    .forEach(ul => ul.parentNode.setAttribute(hiddenAttribute, ''));
+    .forEach(ul => ul.parentNode.toggleAttribute(hiddenAttribute, true));
 
 export const main = async function () {
   pageModifications.register('aside h1', hideDashboardRecommended);

--- a/src/features/no_recommended/hide_recommended_blogs_modal.js
+++ b/src/features/no_recommended/hide_recommended_blogs_modal.js
@@ -9,7 +9,7 @@ export const styleElement = buildStyle(`[${hiddenAttribute}] { display: none; }`
 const hideModalRecommended = blogsLists =>
   blogsLists
     .filter(ul => ul.matches(blogViewSelector))
-    .forEach(ul => ul.parentNode.setAttribute(hiddenAttribute, ''));
+    .forEach(ul => ul.parentNode.toggleAttribute(hiddenAttribute, true));
 
 export const main = async function () {
   const blogsListSelector = `${keyToCss('desktopContainer')} > ${keyToCss('recommendedBlogs')}`;

--- a/src/features/no_recommended/hide_recommended_posts.js
+++ b/src/features/no_recommended/hide_recommended_posts.js
@@ -57,10 +57,10 @@ const processPosts = async function (postElements) {
 
     const timelineItem = getTimelineItemWrapper(postElement);
 
-    timelineItem.setAttribute(hiddenAttribute, '');
+    timelineItem.toggleAttribute(hiddenAttribute, true);
 
     if (precedingHiddenPosts(timelineItem) >= 10) {
-      timelineItem.setAttribute(unHiddenAttribute, '');
+      timelineItem.toggleAttribute(unHiddenAttribute, true);
     }
   });
 };

--- a/src/features/no_recommended/hide_tag_carousels.js
+++ b/src/features/no_recommended/hide_tag_carousels.js
@@ -18,8 +18,8 @@ const hideTagCarousels = carouselWrappers => carouselWrappers
   .filter(carouselWrapper => carouselWrapper.querySelector(tagCardSelector) !== null)
   .map(getTimelineItemWrapper)
   .forEach(timelineItem => {
-    timelineItem.setAttribute(hiddenAttribute, '');
-    timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
+    timelineItem.toggleAttribute(hiddenAttribute, true);
+    timelineItem.previousElementSibling.toggleAttribute(hiddenAttribute, true);
   });
 
 export const main = async function () {

--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -121,13 +121,13 @@ function onTabClick ({ currentTarget }) {
     previousSelectedTab.ariaSelected = 'false';
     previousSelectedTab.getAttribute('aria-controls').split(',')
       .map(elementId => document.getElementById(elementId))
-      .forEach(tabPanel => tabPanel.setAttribute('hidden', ''));
+      .forEach(tabPanel => tabPanel.toggleAttribute('hidden', true));
   }
 
   currentTarget.ariaSelected = 'true';
   currentTarget.getAttribute('aria-controls').split(',')
     .map(elementId => document.getElementById(elementId))
-    .forEach(tabPanel => tabPanel.removeAttribute('hidden'));
+    .forEach(tabPanel => tabPanel.toggleAttribute('hidden', false));
 }
 
 /** @param {KeyboardEvent} event commentInput/tagsInput keydown event object */

--- a/src/features/scroll_to_bottom/index.js
+++ b/src/features/scroll_to_bottom/index.js
@@ -78,7 +78,7 @@ const addButtonToPage = async function ([scrollToTopButton]) {
     scrollToBottomButton.style.transform = 'rotate(180deg)';
     scrollToBottomButton.addEventListener('click', onclick);
     scrollToBottomButton.id = scrollToBottomButtonId;
-    scrollToBottomButton.setAttribute(displayBlockUnlessDisabledAttr, '');
+    scrollToBottomButton.toggleAttribute(displayBlockUnlessDisabledAttr, true);
 
     scrollToBottomButton.classList.toggle(activeClass, active);
   }

--- a/src/features/seen_posts/index.js
+++ b/src/features/seen_posts/index.js
@@ -62,12 +62,12 @@ const dimPosts = function (postElements, reprocessPosts = false) {
     const timelineItem = getTimelineItemWrapper(postElement);
 
     const isFirstRender = timelineItem.hasAttribute(excludeAttribute) === false;
-    timelineItem.setAttribute(excludeAttribute, '');
+    timelineItem.toggleAttribute(excludeAttribute, true);
 
     if (seenPosts.includes(id) === false) {
       observer.observe(postElement.querySelector('article header + *'));
     } else if (isFirstRender || reprocessPosts) {
-      timelineItem.setAttribute(dimAttribute, '');
+      timelineItem.toggleAttribute(dimAttribute, true);
     }
   }
 };

--- a/src/features/seen_posts/index.js
+++ b/src/features/seen_posts/index.js
@@ -61,7 +61,7 @@ const dimPosts = function (postElements, reprocessPosts = false) {
     const { id } = postElement.dataset;
     const timelineItem = getTimelineItemWrapper(postElement);
 
-    const isFirstRender = timelineItem.getAttribute(excludeAttribute) === null;
+    const isFirstRender = timelineItem.hasAttribute(excludeAttribute) === false;
     timelineItem.setAttribute(excludeAttribute, '');
 
     if (seenPosts.includes(id) === false) {

--- a/src/features/show_originals/index.js
+++ b/src/features/show_originals/index.js
@@ -115,7 +115,7 @@ const processPosts = async function (postElements) {
       const visibleBlogName = community ? postAuthor : blogName;
       if (whitelist.includes(visibleBlogName)) { return; }
 
-      getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
+      getTimelineItemWrapper(postElement).toggleAttribute(hiddenAttribute, true);
     });
 };
 

--- a/src/features/tweaks/caught_up_line.js
+++ b/src/features/tweaks/caught_up_line.js
@@ -34,8 +34,8 @@ const createCaughtUpLine = tagChicletCarouselItems => tagChicletCarouselItems
   .map(getTimelineItemWrapper)
   .filter((element, index, array) => array.indexOf(element) === index)
   .forEach(timelineItem => {
-    timelineItem.setAttribute(borderAttribute, '');
-    timelineItem.previousElementSibling.setAttribute(hiddenAttribute, '');
+    timelineItem.toggleAttribute(borderAttribute, true);
+    timelineItem.previousElementSibling.toggleAttribute(hiddenAttribute, true);
   });
 
 export const main = async function () {

--- a/src/features/tweaks/create_button_no_bubbles.js
+++ b/src/features/tweaks/create_button_no_bubbles.js
@@ -12,7 +12,7 @@ const processCreateButtons = (createButtons) => {
   createButtons.forEach(createButton => {
     createButton.dataset.originalHref ??= createButton.getAttribute('href');
 
-    createButton.setAttribute(modifiedAttribute, '');
+    createButton.toggleAttribute(modifiedAttribute, true);
     createButton.setAttribute('href', createButton.dataset.originalHref.replace(/\/new$/, '/new/text'));
     createButton.addEventListener('click', onClickNavigate);
   });

--- a/src/features/tweaks/hide_mini_follow.js
+++ b/src/features/tweaks/hide_mini_follow.js
@@ -11,7 +11,7 @@ article ${keyToCss('followButton')}:not(${keyToCss('postMeatballsContainer')} *)
 
 const processButtons = buttons => buttons.forEach(button => {
   if (button.textContent === translate('Follow')) {
-    button.setAttribute(hiddenAttribute, '');
+    button.toggleAttribute(hiddenAttribute, true);
   }
 });
 

--- a/src/utils/hide_posts.js
+++ b/src/utils/hide_posts.js
@@ -100,7 +100,7 @@ export const createPostHideFunctions = ({ id, permalinkPageControls }) => {
   const addPermalinkPageControls = (postElement, timelineElement) => {
     const timelineItemWrapper = getTimelineItemWrapper(postElement);
     if (timelineItemWrapper.hasAttribute(controlledHiddenAttribute) === false) {
-      timelineItemWrapper.setAttribute(controlledHiddenAttribute, '');
+      timelineItemWrapper.toggleAttribute(controlledHiddenAttribute, true);
 
       const { message } = permalinkPageControls;
       const controlsElement = div({ class: controlsClass, [controlsAttribute]: id }, [
@@ -122,7 +122,7 @@ export const createPostHideFunctions = ({ id, permalinkPageControls }) => {
         // do nothing; avoid hiding single post and making permalink page look broken
       }
     } else {
-      getTimelineItemWrapper(postElement).setAttribute(hiddenAttribute, '');
+      getTimelineItemWrapper(postElement).toggleAttribute(hiddenAttribute, true);
     }
   };
   const showPost = postElement => {

--- a/src/utils/hide_posts.js
+++ b/src/utils/hide_posts.js
@@ -99,7 +99,7 @@ export const createPostHideFunctions = ({ id, permalinkPageControls }) => {
 
   const addPermalinkPageControls = (postElement, timelineElement) => {
     const timelineItemWrapper = getTimelineItemWrapper(postElement);
-    if (timelineItemWrapper.getAttribute(controlledHiddenAttribute) !== '') {
+    if (timelineItemWrapper.hasAttribute(controlledHiddenAttribute) === false) {
       timelineItemWrapper.setAttribute(controlledHiddenAttribute, '');
 
       const { message } = permalinkPageControls;


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Hey, April, did you know that javascript... ah, #2139; yes you did.

This makes use of the `hasAttribute` and `toggleAttribute` functions that are more semantically correct, rather than `getAttribute` and `setAttribute` with values that are/comparisons to empty strings, in places where we use boolean data attributes.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

I have not extensively tested this at present.