### PR TITLE
fix(No Recommended): Non-joined communities option hiding posts in blog comments view

### DIFF
--- a/src/utils/timeline_id.js
+++ b/src/utils/timeline_id.js
@@ -85,10 +85,9 @@ export const tagTimelineFilter = tag =>
     timelineId?.startsWith(`hubsTimeline-${tag}-recent-`) ||
     timelineId?.match(exactly(`tag-${uuidV4}-${tag}-recent`));
 
-export const searchPostsTimelineFilter = search =>
-  ({ dataset: { timeline, timelineId } }) =>
-    timelineId?.startsWith('searchTimeline-post-') ||
-    timelineId?.match(startsWith(`search-${uuidV4}-`));
+export const searchPostsTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
+  timelineId?.startsWith('searchTimeline-post-') ||
+  timelineId?.match(startsWith(`search-${uuidV4}-`));
 
 export const anyCommunityTimelineFilter = ({ dataset: { timeline, timelineId } }) =>
   timelineId?.match(exactly(`communities-${anyBlogName}-recent`)) ||


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Resolves #2287 by fixing a typo I made in #2130 (incorrect copy-paste when making searchPostsTimelineFilter, which made it always return a truthy value).

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Find a community post in a blog's comments view (https://www.tumblr.com/chaos-triangle/comments). Enable the "Hide posts from non-joined communities in For You and search results" No Recommended feature and confirm that it is **not** hidden.
- Find a community post in a search result (https://www.tumblr.com/search/evil%20science/recent). Enable the "Hide posts from non-joined communities in For You and search results" No Recommended feature and confirm that it is hidden.