### PR TITLE
feat(No Recommended): Split community-posts-in-search-results into separate option

### DIFF
--- a/src/features/no_recommended/feature.json
+++ b/src/features/no_recommended/feature.json
@@ -18,6 +18,11 @@
       "label": "Hide posts from non-joined communities in For You",
       "default": false
     },
+    "hide_search_community_posts": {
+      "type": "checkbox",
+      "label": "Hide posts from non-joined communities in search results",
+      "default": false
+    },
     "hide_answertime": {
       "type": "checkbox",
       "label": "Hide the answertime banner",

--- a/src/features/no_recommended/feature.json
+++ b/src/features/no_recommended/feature.json
@@ -15,7 +15,7 @@
     },
     "hide_recommended_community_posts": {
       "type": "checkbox",
-      "label": "Hide posts from non-joined communities in For You and search results",
+      "label": "Hide posts from non-joined communities in For You",
       "default": false
     },
     "hide_answertime": {

--- a/src/features/no_recommended/hide_recommended_community_posts.js
+++ b/src/features/no_recommended/hide_recommended_community_posts.js
@@ -2,10 +2,10 @@ import { createPostHideFunctions } from '../../utils/hide_posts.js';
 import { filterPostElements } from '../../utils/interface.js';
 import { onNewPosts } from '../../utils/mutations.js';
 import { timelineObject } from '../../utils/react_props.js';
-import { forYouTimelineFilter, searchPostsTimelineFilter } from '../../utils/timeline_id.js';
+import { forYouTimelineFilter } from '../../utils/timeline_id.js';
 import { joinedCommunityUuids } from '../../utils/user.js';
 
-const timeline = [forYouTimelineFilter, searchPostsTimelineFilter];
+const timeline = forYouTimelineFilter;
 const includeFiltered = true;
 
 const { hidePost, showPosts } = createPostHideFunctions({ id: 'no-recommended-community-posts' });

--- a/src/features/no_recommended/hide_search_community_posts.js
+++ b/src/features/no_recommended/hide_search_community_posts.js
@@ -1,0 +1,28 @@
+import { createPostHideFunctions } from '../../utils/hide_posts.js';
+import { filterPostElements } from '../../utils/interface.js';
+import { onNewPosts } from '../../utils/mutations.js';
+import { timelineObject } from '../../utils/react_props.js';
+import { searchPostsTimelineFilter } from '../../utils/timeline_id.js';
+import { joinedCommunityUuids } from '../../utils/user.js';
+
+const timeline = searchPostsTimelineFilter;
+const includeFiltered = true;
+
+const { hidePost, showPosts } = createPostHideFunctions({ id: 'no-recommended-community-posts' });
+
+const processPosts = postElements =>
+  filterPostElements(postElements, { timeline, includeFiltered }).forEach(async postElement => {
+    const { community } = await timelineObject(postElement);
+    if (community && !joinedCommunityUuids.includes(community.uuid)) {
+      hidePost(postElement);
+    }
+  });
+
+export const main = async function () {
+  onNewPosts.addListener(processPosts);
+};
+
+export const clean = async function () {
+  onNewPosts.removeListener(processPosts);
+  showPosts();
+};


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

As discussed in #2286, this splits the "Hide posts from non-joined communities in For You and search results" option in No Recommended into the original "Hide posts from non-joined communities in For You" and a separate new "Hide posts from non-joined communities in search results."

As I said in that discussion, I think this is probably a net negative on "giving the majority of affected users what they desire." I do, though, ultimately not view that as the end goal here. XKit features should make sense, be internally consistent, not have unexpected effects, respect the design intent of the site, etc, *even when it conflicts with what some users desire* (I, for example, will always outright refuse to make the frequently-requested "hide the explore button" tweak because the explore tab is a legitimate part of the site whether or not a user currently ever wants to use it and that is the single place in the UI to access it, so logically it should be visible there).

I think it's ultimately thus the most logical to follow the suggestion in the discussion and split this preference, *not* making it inherit from the old one. This errs on the side of "users who want something hidden should have to go find the setting to hide that thing." XKit does nothing when you first enable it for a reason. We're not the developer of Tumblr Savior.

Blocked by #2288.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Find a community post in a search result ([tumblr.com/search/evil%20science/recent](https://www.tumblr.com/search/evil%20science/recent) is usually pretty good). Enable the search-result-specific No Recommended feature and confirm that it is hidden.