### PR TITLE
fix(AccessKit Disable GIFs): Remove small flicker on first hover on certain elements

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -213,7 +213,7 @@ const processGifs = function (gifElements) {
 };
 
 const sourceUrlRegex = /url\(["'][^)]*?\.(?:gif|gifv|webp)["']\)/g;
-const processBackgroundGifs = function (gifBackgroundElements) {
+const processBackgroundGifs = gifBackgroundElements => requestAnimationFrame(() =>
   gifBackgroundElements.forEach(async gifBackgroundElement => {
     const sourceValue = getComputedStyle(gifBackgroundElement).backgroundImage;
 
@@ -237,8 +237,8 @@ const processBackgroundGifs = function (gifBackgroundElements) {
       sourceValue.replace(sourceUrlRegex, `url("${pausedUrl}")`),
     );
     addLabel(gifBackgroundElement, true);
-  });
-};
+  }),
+);
 
 const processRows = function (rowsElements) {
   rowsElements.forEach(rowsElement => {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Currently, there's a slight flicker effect the first time you hover a GIF on https://www.tumblr.com/communities/browse if you have soft navigated to that page (observed in Firefox; have not yet tested in Chrome). 

This is probably because we synchronously change the background-image property during initial processing, so the browser does not immediately begin to render the animated image as the background of the element in question. This is kind of like what #1853 did on purpose to prevent the animated source from being downloaded until the user hovers the element. In this case, we're immediately fetching the animated source ourselves anyway, so there's no bandwidth benefit; the only result of this is that the user hover is the first time the image is rendered (and to my knowledge there's no equivalent of `gifElement.decoding = 'sync';` for background-image css, so this causes a brief flicker of no image being displayed).

The fix is to intentionally _not_ initially process background-image gifs synchronously, making the browser fire the load process with the regular animated `background-image` value (even though by the time it would result in any visible effect, we've changed the value to something else). Then, when the user hover switches it back to the regular value, the processing has already been done and the switch is instant.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

