### PR TITLE
fix(No Recommended): update blog view sidebar section targeting

### DIFF
--- a/src/features/no_recommended/hide_recommended_blogs_modal.js
+++ b/src/features/no_recommended/hide_recommended_blogs_modal.js
@@ -6,17 +6,20 @@ const hiddenAttribute = 'data-no-recommended-blogs-modal-hidden';
 
 export const styleElement = buildStyle(`[${hiddenAttribute}] { display: none; }`);
 
-const hideModalRecommended = blogsLists =>
-  blogsLists
-    .filter(ul => ul.matches(blogViewSelector))
-    .forEach(ul => ul.parentNode.setAttribute(hiddenAttribute, ''));
+const desktopContainerSelector = keyToCss('desktopContainer');
+const recommendedBlogsSelector = keyToCss('recommendedBlogs');
+const sidebarSectionSelector = `${desktopContainerSelector}:is(${blogViewSelector}):has(${recommendedBlogsSelector})`;
+
+/** @type {(sidebarSections: HTMLElement[]) => void} */
+const hideSidebarSections = sidebarSections => sidebarSections.forEach(
+  sidebarSection => sidebarSection.toggleAttribute(hiddenAttribute, true),
+);
 
 export const main = async function () {
-  const blogsListSelector = `${keyToCss('desktopContainer')} > ${keyToCss('recommendedBlogs')}`;
-  pageModifications.register(blogsListSelector, hideModalRecommended);
+  pageModifications.register(sidebarSectionSelector, hideSidebarSections);
 };
 
 export const clean = async function () {
-  pageModifications.unregister(hideModalRecommended);
+  pageModifications.unregister(hideSidebarSections);
   $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
- fixes #2279

Problem: There's a wrapper between `style-desktopContainer--B15CE` and `style-recommendedBlogs--PwJi6` now, which breaks both our targeting and element-hiding logic in this option.

Solution: Stop looking for direct descendants. Select `style-desktopContainer--B15CE` elements directly, using CSS `:is()` and `:has()` to filter to the correct candidates for hiding.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

Before | After
-|-
<img width="3840" height="2400" alt="Screen Shot 2026-06-23 at 14 54 43" src="https://github.com/user-attachments/assets/e38284aa-f788-473e-a4b2-4bcfb3780c24" /> | <img width="3840" height="2400" alt="Screen Shot 2026-06-23 at 14 55 12" src="https://github.com/user-attachments/assets/3179e1a7-bb6e-414a-b13f-ddc18571089b" />
<img width="3840" height="2400" alt="Screen Shot 2026-06-23 at 14 55 49" src="https://github.com/user-attachments/assets/f22fb6cb-417a-4eab-ba02-25acffb80f3b" /> | <img width="3840" height="2400" alt="Screen Shot 2026-06-23 at 14 56 01" src="https://github.com/user-attachments/assets/66863014-ff56-4e7d-bfcc-aca9f89d4609" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Enable No Recommended &rarr; "Hide recommended blogs in the blog view sidebar"
    - **Expected result**: Recommended blogs in the blog view sidebar are hidden 
    - **Expected result**: Recommended blogs in the dashboard sidebar are not hidden
