### PR TITLE
fix: make `getTimelineItemWrapper` idempotent

### DIFF
--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -9,22 +9,23 @@ export const blogViewSelector = '[style*="--blog-title-color"] *';
 export const notificationSelector = `:is(${keyToCss('notification')}[role="listitem"], ${keyToCss('activityItem')})`;
 
 const listTimelineObjectSelector = keyToCss('listTimelineObject');
-const cellSelector = keyToCss('cell');
+const gridTimelineObjectSelector = keyToCss('gridTimelineObject');
+
+/**
+ * @param {Element} element An element that is contained within a timeline item.
+ * @returns {Element | null} The element that wraps the entire timeline item.
+ */
+export const getTimelineItemWrapper = element =>
+  element.closest(`.sortableContainer ${listTimelineObjectSelector}`) ??
+  element.closest(`:has(> ${listTimelineObjectSelector})`) ??
+  element.closest(gridTimelineObjectSelector);
+
 const targetWrapperSelector = keyToCss(
   'targetWrapper',
   'targetWrapperBlock',
   'targetWrapperFlex',
   'targetWrapperInline',
 );
-
-/**
- * @param {Element} element Element within a timeline item
- * @returns {Element | null} The timeline item wrapper
- */
-export const getTimelineItemWrapper = element =>
-  (element.closest('[data-timeline-id]') && element.closest(listTimelineObjectSelector)?.parentElement) ||
-  element.closest(cellSelector) ||
-  element.closest(listTimelineObjectSelector);
 
 /**
  * @param {Element} element Element within a popover wrapper


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
- resolves #2290

This utility currently relies on an outdated assumption: that Timeline V1s don't render cells. This is not the case anymore!

- When a TimelineV1 renders a sortable list, it **never** renders cells of any kind.
- When a TimelineV1 renders any other timeline, it **always** renders full cells.
  - Yes, regardless of display mode or endless scrolling status.

There doesn't seem to be such thing as a Timeline V1 grid. Maybe on Patio? We don't currently target grid timeline items for anything (`postSelector` doesn't match them) so it's not really worth the $6.99 to verify their exact structure.

- When a TimelineV2 renders a list, it **always** renders cells.
  - If endless scrolling is disabled, they will be dummy cells (bare `div` elements with no virtualisation capabilities).
- When a TimelineV2 renders masonry, it doesn't render cells, but **always** renders `div[tabindex]` wrappers for focus management.
- When a TimelineV2 renders a grid, it **never** renders any kind of wrapper for the `.gridTimelineObject` elements.
- When a TimelineV2 renders an expanded item within a grid, it **always** gets its own wrapper.
  - `.expandedGridObjectContainer`

There's no such thing as a TimelineV2 sortable list. Virtualisation and SortableJS compatibility are mutually exclusive.

If Tumblr axed the drag-and-drop feature of reordering the Queue, we can assume the Queue would become indistinguishable from a regular Timeline V2 list for the purposes of this utility.

Final vital point of context, masonry timeline items also have the classnames of list timeline items.

With this, we can condense the logic down into the following:
- Are we in the Queue? If yes, look for the closest `.listTimelineObject`.
  - ✅ TimelineV1 Sortable
- Are we in a list/masonry timeline object? If yes, look for the closest _parent of_ a `.listTimelineObject`.
  - ✅ TimelineV1 List
  - ✅ TimelineV1 Masonry
  - ❓ TimelineV1 Grid Expanded
  - ✅ TimelineV2 List
  - ✅ TimelineV2 Masonry
  - ✅ TimelineV2 Grid Expanded
- Are we in a grid timeline object? If yes, look for the closest `.gridTimelineObject`.
  - ❓ TimelineV1 Grid
  - ✅ TimelineV2 Grid

The utility becomes idempotent by only using `Element.closest()` to implement this. The secret ingredient is using `:has(> ...)` to find parents of list timeline objects directly, instead of finding list timeline objects and then going one parent up.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
N/A, no visual changes expected.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Test every feature/option that uses `getTimelineItemWrapper`, directly or via `createPostHideFunctions`.
Do this on _every type of timeline_, as laid out above.
Then, toggle Settings &rarr; Dashboard &rarr; "Endless scrolling" and do it all again.
Good luck!