### PR TITLE
fix(AccessKit Disable GIFs): stop pausing GIFs when option is disabled

### DIFF
--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -5,6 +5,9 @@ import { memoize } from '../../utils/memoize.js';
 import { pageModifications } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
 
+/** @type {AbortController}   */ let loadEventController;
+/** @type {"eager" | "lazy"}  */ let loadingMode;
+
 const canvasClass = 'xkit-paused-gif-placeholder';
 const pausedPosterAttribute = 'data-paused-gif-use-poster';
 const pausedBackgroundImageVar = '--xkit-paused-gif-background-image';
@@ -12,8 +15,6 @@ const hoverContainerAttribute = 'data-paused-gif-hover-container';
 const labelAttribute = 'data-paused-gif-label';
 const labelSizeAttribute = 'data-paused-gif-label-size';
 const containerClass = 'xkit-paused-gif-container';
-
-let loadingMode;
 
 const hovered = `:is(:hover, [${hoverContainerAttribute}]:hover *)`;
 const parentHovered = `:is(:hover > *, [${hoverContainerAttribute}]:hover *)`;
@@ -186,9 +187,11 @@ const pauseGif = async function (gifElement) {
   };
 };
 
+/** @type {(gifElements: HTMLImageElement[]) => void} */
 const processGifs = function (gifElements) {
   gifElements.forEach(gifElement => {
     if (gifElement.closest(`${keyToCss('avatarImage', 'subAvatarImage')}, .block-editor-writing-flow`)) return;
+
     const pausedGifElements = [...gifElement.parentNode.querySelectorAll(`.${canvasClass}`)];
     if (pausedGifElements.length) {
       gifElement.after(...pausedGifElements);
@@ -207,7 +210,8 @@ const processGifs = function (gifElements) {
     if (gifElement.complete && gifElement.currentSrc) {
       pauseGif(gifElement);
     } else {
-      gifElement.onload = () => pauseGif(gifElement);
+      const { signal } = loadEventController;
+      gifElement.addEventListener('load', () => pauseGif(gifElement), { signal });
     }
   });
 };
@@ -267,6 +271,8 @@ const onStorageChanged = async function (changes) {
 };
 
 export const main = async function () {
+  loadEventController = new AbortController();
+
   ({ disable_gifs_loading_mode: loadingMode } = await getPreferences('accesskit'));
 
   const gifImage = `
@@ -313,6 +319,7 @@ export const main = async function () {
 };
 
 export const clean = async function () {
+  loadEventController.abort();
   browser.storage.local.onChanged.removeListener(onStorageChanged);
 
   pageModifications.unregister(processGifs);

--- a/src/features/accesskit/disable_gifs.js
+++ b/src/features/accesskit/disable_gifs.js
@@ -210,8 +210,10 @@ const processGifs = function (gifElements) {
     if (gifElement.complete && gifElement.currentSrc) {
       pauseGif(gifElement);
     } else {
-      const { signal } = loadEventController;
-      gifElement.addEventListener('load', () => pauseGif(gifElement), { signal });
+      gifElement.addEventListener('load', () => pauseGif(gifElement), {
+        once: true,
+        signal: loadEventController.signal,
+      });
     }
   });
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
- fixes #2297

I went with the `AbortController` method to limit unintended effects. I don't know why there would be multiple `load` events on one image element, but we're running callbacks on all of them currently with no downsides... other than the fact that they keep firing after the option is disabled, which is obviously not good.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

Before | After
-|-
<video src="https://github.com/user-attachments/assets/5458417c-6e23-4324-bbed-3c9fabef0ba1"></video> | <video src="https://github.com/user-attachments/assets/187efc48-0a03-4bf6-a5ff-520f2f698b6e"></video>

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Go to [Tumblr &rarr; Settings &rarr; Dashboard](https://www.tumblr.com/settings/dashboard) and set "Media auto-play" to "Never auto-play"
2. Load the modified addon, and enable AccessKit &rarr; "Pause GIFs until they are hovered over"
3. Reload your Tumblr tab
4. Go to Explore &rarr; More &rarr; GIFs
    - **Expected result**: Both AccessKit's and Tumblr's GIF labels are present on the GIFs in posts
    - **Expected result**: Hovering a GIF removes its AccessKit GIF label, but not its Tumblr GIF label
5. Disable AccessKit &rarr: "Pause GIFs until they are hovered over"
    - **Expected result**: AccessKit's GIF labels disappear, leaving only Tumblr's GIF labels
6. Click a Tumblr-paused GIF
    - **Expected result**:  🆕 The GIF starts animating
