### PR TITLE
chore: Remove unused attribute value from hide posts util

### DIFF
--- a/src/utils/hide_posts.js
+++ b/src/utils/hide_posts.js
@@ -104,7 +104,7 @@ export const createPostHideFunctions = ({ id, permalinkPageControls }) => {
       timelineItemWrapper.toggleAttribute(controlledHiddenAttribute, true);
 
       const { message } = permalinkPageControls;
-      const controlsElement = div({ class: controlsClass, [controlsAttribute]: id }, [
+      const controlsElement = div({ class: controlsClass, [controlsAttribute]: '' }, [
         message,
         button({ click: () => controlsElement.remove() }, ['View post']),
       ]);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Small cleanup of something I presumably forgot to remove when writing the hide posts utility function. The `controlsAttribute` already contains the id value, so there's no reason to set it to the id value (`data-xkit-postblock-hidden-controls="postblock"`), and the value is not referenced elsewhere in the code.

Note that one could, of course, switch to a single non-dynamic `controlsAttribute` string and make use of the value. But one can't do this for `controlledHiddenAttribute`, since a post can be hidden by multiple utilities at once, so the code would no longer be as symmetrical.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Smoke test the permalink page controls of a hidden post, such as by hiding one with PostBlock and then navigating to it.