### PR TITLE
fix(Panorama): Incorrect width for bandcamp embeds

### DIFF
--- a/src/features/panorama/index.js
+++ b/src/features/panorama/index.js
@@ -105,6 +105,7 @@ ${keyToCss('cell')}, ${postSelector}
     ${keyToCss('videoBlock')} iframe
   ) {
   max-width: unset !important;
+  width: unset;
 }
 :root.${expandMediaClass} ${postSelector} ${keyToCss('videoBlock')} iframe[style*="${aspectRatioVar}"] {
   aspect-ratio: var(${aspectRatioVar});


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Tumblr's frontend now appears to set a width value of 100% on bandcamp embeds, making them wider than the — okay actually I am writing this PR description and I don't know why Panorama would change anything about this. Uh. Wait a sec.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that all audio embed types are the correct width. (I have some in https://www.tumblr.com/communities/test-community-46174)
- Confirm that all other—ah, great, this breaks youtube embeds. help
