### PR TITLE
fix(Tag Replacer): Skip posts with too many tags

### DIFF
--- a/src/features/tag_replacer/index.js
+++ b/src/features/tag_replacer/index.js
@@ -5,6 +5,8 @@ import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
 import { userBlogs } from '../../utils/user.js';
 
+const MAX_POST_TAGS = 30;
+
 const getPostsFormId = 'xkit-tag-replacer-get-posts';
 
 const createBlogOption = ({ name, title, uuid }) => dom('option', { value: uuid, title }, null, [name]);
@@ -200,7 +202,18 @@ const replaceTag = async ({ uuid, oldTag, toAdd, toRemove }) => {
     ]);
   }
 
-  const taggedPostIds = taggedPosts.map(({ id }) => id);
+  let tooManyTagsCount = 0;
+
+  const taggedPostIds = taggedPosts
+    .filter(({ tags }) => {
+      if (tags.length + toAdd.length > MAX_POST_TAGS) {
+        tooManyTagsCount++;
+        return false;
+      }
+      return true;
+    })
+    .map(({ id }) => id);
+
   let appendedCount = 0;
   let appendedFailCount = 0;
   let removedCount = 0;
@@ -246,7 +259,8 @@ const replaceTag = async ({ uuid, oldTag, toAdd, toRemove }) => {
     title: 'Thank you, come again!',
     message: [
       toAdd.length ? `Added new tags to ${appendedCount} posts${appendedFailCount ? ` (failed: ${appendedFailCount})` : ''}.\n` : '',
-      toRemove.length ? `Removed old tags from ${removedCount} posts${removedFailCount ? ` (failed: ${removedFailCount})` : ''}.` : '',
+      toRemove.length ? `Removed old tags from ${removedCount} posts${removedFailCount ? ` (failed: ${removedFailCount})` : ''}.\n` : '',
+      tooManyTagsCount ? `Skipped ${tooManyTagsCount} posts with too many tags to edit.\n` : '',
     ],
     buttons: [
       modalCompleteButton,


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Quick fix for the worst part of #2308: avoid trying to add tags to posts that have too many tags, and which would thus silently have incorrect/incomplete changes performed to them.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Make a test post with a replaceable tag (which, interestingly, must be in the first 20 tags?) and a total of 30 tags. Pasteable:`#skdjhfkjs #29 other tags: #2 #3 #4 #5 #6 #7 #8 #9 #10 #11 #12 #13 #14 #15 #16 #17 #18 #19 #20 #21 #22 #23 #24 #25 #26 #27 #28 #29`
- Confirm that the tag can no longer be replaced with Tag Replacer.
- Confirm that the tag *can* be removed by Tag Replacer.
- todo: write more tests here