### PR TITLE
chore: correct JSdoc types for `reactData` in meatballs utils

### DIFF
--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -20,11 +20,12 @@ const meatballItems = {
 
 /**
  * Add a custom button to posts' meatball menus.
+ * @typedef {Awaited<ReturnType<typeof timelineObject>>} TimelineObject
  * @param {object} options Destructured
  * @param {string} options.id Identifier for this button (must be unique)
- * @param {string | (reactData: Awaited<timelineObject>) => string} options.label Button text to display. May be a function accepting the timelineObject data of the post element being actioned on.
+ * @param {string | (reactData: TimelineObject) => string} options.label Button text to display. May be a function accepting the timelineObject data of the post element being actioned on.
  * @param {(event: PointerEvent) => void} options.onclick Button click listener function
- * @param {(reactData: Awaited<timelineObject>) => boolean} [options.postFilter] Filter function, called with the timelineObject data of the post element being actioned on. Must return true for button to be added.
+ * @param {(reactData: TimelineObject) => boolean} [options.postFilter] Filter function, called with the timelineObject data of the post element being actioned on. Must return true for button to be added.
  */
 export const registerMeatballItem = function ({ id, label, onclick, postFilter }) {
   meatballItems.post[id] = { label, onclick, filter: postFilter };
@@ -38,11 +39,12 @@ export const unregisterMeatballItem = id => {
 
 /**
  * Add a custom button to blogs' meatball menus in blog cards and the blog view header.
+ * @typedef {Awaited<ReturnType<typeof blogData>>} BlogData
  * @param {object} options Destructured
  * @param {string} options.id Identifier for this button (must be unique)
- * @param {string | (reactData: Awaited<blogData>) => string} options.label Button text to display. May be a function accepting the blog data of the post element being actioned on.
+ * @param {string | (reactData: BlogData) => string} options.label Button text to display. May be a function accepting the blog data of the post element being actioned on.
  * @param {(event: PointerEvent) => void} options.onclick Button click listener function
- * @param {(reactData: Awaited<blogData>) => boolean} [options.blogFilter] Filter function, called with the blog data of the menu element being actioned on. Must return true for button to be added. Some blog data fields, such as "followed", are not available in blog cards.
+ * @param {(reactData: BlogData) => boolean} [options.blogFilter] Filter function, called with the blog data of the menu element being actioned on. Must return true for button to be added. Some blog data fields, such as "followed", are not available in blog cards.
  */
 export const registerBlogMeatballItem = function ({ id, label, onclick, blogFilter }) {
   meatballItems.blog[id] = { label, onclick, filter: blogFilter };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
- fixes #2310

Before:

```ts
(parameter) postFilter: ((reactData: (postElement: Element) => Promise<object>) => boolean) | undefined
```

After:

```ts
(parameter) postFilter: ((reactData: object) => boolean) | undefined
```

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
N/A

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Pull this branch locally and look at the calculated types of the changed parameters with Intellisense.
The type of `reactData` should be an object, not an async function.
