### PR TITLE
chore: Set `allowScripts` package value for upcoming npm 12

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "remixicon": "^4.9.1",
     "sortablejs": "^1.15.7"
   },
+  "allowScripts": {
+    "unrs-resolver": false
+  },
   "webExt": {
     "sourceDir": "src/",
     "build": {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

npm 12 (which, to my knowledge, will ship for the first time with some random non-major version of node, making ci runners switch to it spontaneously) has the breaking change that dependency postinstall scripts are blocked unless explicitly allowed. Besides the odd rollout, this is a good thing. npm-using projects should probably check if they need to configure postinstall scripts in advance.

This project doesn't need to allow any, so we don't have to do anything. Explicitly denying the only one we have cleans up the `npm warn install-scripts 1 package had install scripts blocked because they are not covered by allowScripts` warning every time you install, though.

Generated by running `npm rebuild` and, in this case, `npm deny-scripts --all`.

unrs-resolver honestly isn't that clear about why it has a postinstall, but it's to mitigate an old npm bug apparently, so whatever:
https://github.com/unrs/unrs-resolver/issues/85
https://github.com/npm/cli/issues/4828

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Delete node_modules. `npm install` and `npm run posttest`.
- If desired, do this with both npm@11 and npm@12 (`npm install -g npm`).