### PR TITLE
chore(Quick Reblog): remove unused `list` attribute from tags input

### DIFF
--- a/src/features/quick_reblog/index.js
+++ b/src/features/quick_reblog/index.js
@@ -41,7 +41,6 @@ const quickTagsPanel = div({ 'aria-labelledby': quickTagsTabId, id: quickTagsPan
 const suggestedTagsPanel = div({ 'aria-labelledby': suggestedTagsTabId, id: suggestedTagsPanelId, role: 'tabpanel' });
 const tagsInput = input({
   autocomplete: 'off',
-  list: 'quick-reblog-tag-suggestions',
   placeholder: 'Tags (comma separated)',
   input: onTagsInput,
   keydown: onTextFieldKeyDown,


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
- see #2009

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
N/A

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Pull this branch locally and search for `quick-reblog-tag-suggestions`. There should be zero results.

