### PR TITLE
fix(Show Originals): Functionality in masonry views

### DIFF
--- a/src/features/show_originals/index.css
+++ b/src/features/show_originals/index.css
@@ -1,4 +1,5 @@
-[data-show-originals="on"] ~ div > [data-show-originals-hidden] {
+[data-show-originals="on"] ~ div > [data-show-originals-hidden],
+[data-show-originals="on"] ~ div > div > [data-show-originals-hidden] {
   content: linear-gradient(transparent, transparent);
   height: 0;
 }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Resolves #2324.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Open a blog that has both original posts and reblogs in blog view and change its timeline to the masonry display mode. Confirm that the Show Originals toggle changes between showing and hiding reblogs.