### PR TITLE
chore(Timeformat): Disable feature on unreleased UI elements (for now)

### DIFF
--- a/src/features/timeformat/index.js
+++ b/src/features/timeformat/index.js
@@ -1,12 +1,15 @@
 import moment from '../../lib/moment.js';
 import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle } from '../../utils/interface.js';
+import { translate } from '../../utils/language_data.js';
 import { pageModifications } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
 import { constructRelativeTimeString } from '../../utils/text_format.js';
 
 let format;
 let displayRelative;
+
+const excludeSelector = `${keyToCss('chatListItem')}, ul[aria-label="${translate('Conversations')}"]`;
 
 export const styleElement = buildStyle(`
 [data-formatted-time] {
@@ -91,6 +94,7 @@ const observer = new MutationObserver(mutations =>
 
 const formatTimeElements = function (timeElements) {
   timeElements.forEach(timeElement => {
+    if (timeElement.closest(excludeSelector)) return;
     const momentDate = moment(timeElement.dateTime, moment.ISO_8601);
     timeElement.dataset.formattedTime = momentDate.format(format);
     if (displayRelative) {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

This disables Timeformat on some UI elements that appear in the Tumblr code but that aren't released. (We can make layout fixes for and enable it in these locations later if and when they launch).

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that Timeformat continues to work normally.