### PR TITLE
feat(Show Originals): Add "Always show reblogs with tags" option

### DIFF
--- a/src/features/show_originals/feature.json
+++ b/src/features/show_originals/feature.json
@@ -18,6 +18,11 @@
       "label": "Always show reblogs with contributed content",
       "default": false
     },
+    "showReblogsWithTags": {
+      "type": "checkbox",
+      "label": "Always show reblogs with tags",
+      "default": false
+    },
     "showReblogsOfNotFollowing": {
       "type": "checkbox",
       "label": "Always show reblogs of blogs I don't follow",

--- a/src/features/show_originals/index.js
+++ b/src/features/show_originals/index.js
@@ -28,6 +28,7 @@ const includeFiltered = true;
 
 let showOwnReblogs;
 let showReblogsWithContributedContent;
+let showReblogsWithTags;
 let showReblogsOfNotFollowing;
 let whitelist;
 let disabledBlogs;
@@ -105,12 +106,13 @@ const processPosts = async function (postElements) {
 
   filterPostElements(postElements, { includeFiltered })
     .forEach(async postElement => {
-      const { rebloggedRootId, content, blogName, community, postAuthor, rebloggedFromFollowing, trail } = await timelineObject(postElement);
+      const { rebloggedRootId, content, tags, blogName, community, postAuthor, rebloggedFromFollowing, trail } = await timelineObject(postElement);
       const myPost = await isMyPost(postElement);
 
       if (!rebloggedRootId) { return; }
       if (showOwnReblogs && myPost) { return; }
       if (showReblogsWithContributedContent && content.length > 0) { return; }
+      if (showReblogsWithTags && tags.length > 0) { return; }
       if (showReblogsOfNotFollowing && !(rebloggedFromFollowing || trail.at(-1)?.blog?.followed)) { return; }
       const visibleBlogName = community ? postAuthor : blogName;
       if (whitelist.includes(visibleBlogName)) { return; }
@@ -124,6 +126,7 @@ export const main = async function () {
   ({
     showOwnReblogs,
     showReblogsWithContributedContent,
+    showReblogsWithTags,
     showReblogsOfNotFollowing,
     whitelistedUsernames,
   } = await getPreferences('show_originals'));


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

It does what it says on the tin.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that the new option works as expected.