### PR TITLE
feat: add schema for feature manifest files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,8 +1,14 @@
 {
   "editor.codeActionsOnSave": { "source.fixAll.eslint": "explicit" },
   "eslint.validate": ["javascript"],
-  "javascript.preferences.autoImportFileExcludePatterns": ["node_modules/**/*"],
-  "javascript.preferences.importModuleSpecifier": "relative",
-  "javascript.preferences.importModuleSpecifierEnding": "js",
-  "javascript.suggest.paths": true
+  "js/ts.preferences.autoImportFileExcludePatterns": ["node_modules/**/*"],
+  "js/ts.preferences.importModuleSpecifier": "relative",
+  "js/ts.preferences.importModuleSpecifierEnding": "js",
+  "js/ts.suggest.paths": true,
+  "json.schemas": [
+    {
+      "fileMatch": ["src/features/**/feature.json"],
+      "url": "./schemas/feature.json"
+    }
+  ]
 }

--- a/schemas/feature.json
+++ b/schemas/feature.json
@@ -1,0 +1,268 @@
+{
+  "type": "object",
+  "properties": {
+    "title": {
+      "type": "string",
+      "description": "The feature's title to be displayed in the control panel."
+    },
+    "description": {
+      "type": "string",
+      "description": "The feature's description to be displayed in the control panel."
+    },
+    "icon": {
+      "type": "object",
+      "description": "Properties for customising how the feature's `icon.svg` renders in the control panel.",
+      "properties": {
+        "color": {
+          "type": "string",
+          "description": "Foreground colour for the feature icon.",
+          "default": "#000000"
+        },
+        "background_color": {
+          "type": "string",
+          "description": "Background colour for the feature icon.",
+          "default": "#ffffff"
+        }
+      },
+      "additionalProperties": false
+    },
+    "help": {
+      "type": "string",
+      "description": "Wiki link for this feature. If omitted, the feature is marked as \"New\"."
+    },
+    "relatedTerms": {
+      "type": "array",
+      "description": "Search terms that should match this feature.",
+      "items": {
+        "type": "string"
+      },
+      "unevaluatedItems": false,
+      "uniqueItems": true
+    },
+    "preferences": {
+      "type": "object",
+      "description": "Preferences for this feature, keyed by internal preference name.",
+      "additionalProperties": {
+        "anyOf": [
+          { "$ref": "#/$defs/checkboxPreference" },
+          { "$ref": "#/$defs/colorPreference" },
+          { "$ref": "#/$defs/componentPreference" },
+          { "$ref": "#/$defs/percentPreference" },
+          { "$ref": "#/$defs/selectPreference" },
+          { "$ref": "#/$defs/textPreference" },
+          { "$ref": "#/$defs/textareaPreference" }
+        ]
+      }
+    },
+    "deprecated": {
+      "type": "boolean",
+      "description": "Whether or not this feature is deprecated.",
+      "default": false
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "label": {
+      "type": "string",
+      "description": "The preference's label to be displayed in the control panel."
+    },
+    "inherit": {
+      "type": "string",
+      "description": "The storage key to inherit the value of."
+    },
+    "checkboxPreference": {
+      "type": "object",
+      "description": "A checkbox-type preference.",
+      "properties": {
+        "type": {
+          "const": "checkbox"
+        },
+        "label": {
+          "$ref": "#/$defs/label"
+        },
+        "default": {
+          "type": "boolean",
+          "description": "The default value of this preference."
+        },
+        "inherit": {
+          "$ref": "#/$defs/inherit"
+        }
+      },
+      "required": [
+        "type",
+        "label",
+        "default"
+      ],
+      "additionalProperties": false
+    },
+    "colorPreference": {
+      "type": "object",
+      "description": "A color-type preference.",
+      "properties": {
+        "type": {
+          "const": "color"
+        },
+        "label": {
+          "$ref": "#/$defs/label"
+        },
+        "default": {
+          "type": "string",
+          "description": "The default value of this preference."
+        },
+        "inherit": {
+          "$ref": "#/$defs/inherit"
+        }
+      },
+      "required": [
+        "type",
+        "label",
+        "default"
+      ],
+      "additionalProperties": false
+    },
+    "componentPreference": {
+      "type": "object",
+      "description": "A component-type preference.",
+      "properties": {
+        "type": {
+          "const": "component"
+        },
+        "src": {
+          "type": "string",
+          "description": "The URI, relative to `src/`, for this preference's web component."
+        }
+      },
+      "required": [
+        "type",
+        "src"
+      ],
+      "additionalProperties": false
+    },
+    "percentPreference": {
+      "type": "object",
+      "description": "A percent-type preference.",
+      "properties": {
+        "type": {
+          "const": "percent"
+        },
+        "label": {
+          "$ref": "#/$defs/label"
+        },
+        "default": {
+          "type": "number",
+          "description": "The default value of this preference.",
+          "minimum": 0,
+          "maximum": 100
+        },
+        "inherit": {
+          "$ref": "#/$defs/inherit"
+        }
+      },
+      "required": [
+        "type",
+        "label",
+        "default"
+      ],
+      "additionalProperties": false
+    },
+    "selectPreference": {
+      "type": "object",
+      "description": "A select-type preference.",
+      "properties": {
+        "type": {
+          "const": "select"
+        },
+        "label": {
+          "$ref": "#/$defs/label"
+        },
+        "options": {
+          "type": "array",
+          "description": "The available options for this preference.",
+          "items": {
+            "type": "object",
+            "properties": {
+              "label": {
+                "type": "string",
+                "description": "The label shown to the user for this option."
+              },
+              "value": {
+                "type": "string",
+                "description": "The value stored for this option."
+              }
+            },
+            "required": [
+              "label",
+              "value"
+            ],
+            "additionalProperties": false
+          }
+        },
+        "default": {
+          "type": "string",
+          "description": "The default value of this preference."
+        },
+        "inherit": {
+          "$ref": "#/$defs/inherit"
+        }
+      },
+      "required": [
+        "type",
+        "label",
+        "options",
+        "default"
+      ],
+      "additionalProperties": false
+    },
+    "textPreference": {
+      "type": "object",
+      "description": "A text-type preference.",
+      "properties": {
+        "type": {
+          "const": "text"
+        },
+        "label": {
+          "$ref": "#/$defs/label"
+        },
+        "default": {
+          "type": "string",
+          "description": "The default value of this preference."
+        },
+        "inherit": {
+          "$ref": "#/$defs/inherit"
+        }
+      },
+      "required": [
+        "type",
+        "label",
+        "default"
+      ],
+      "additionalProperties": false
+    },
+    "textareaPreference": {
+      "type": "object",
+      "description": "A textarea-type preference.",
+      "properties": {
+        "type": {
+          "const": "textarea"
+        },
+        "label": {
+          "$ref": "#/$defs/label"
+        },
+        "default": {
+          "type": "string",
+          "description": "The default value of this preference."
+        },
+        "inherit": {
+          "$ref": "#/$defs/inherit"
+        }
+      },
+      "required": [
+        "type",
+        "label",
+        "default"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "$schema": "https://json-schema.org/draft/2020-12/schema"
+}

--- a/schemas/feature.json
+++ b/schemas/feature.json
@@ -24,6 +24,7 @@
           "default": "#ffffff"
         }
       },
+      "minProperties": 1,
       "additionalProperties": false
     },
     "help": {
@@ -36,6 +37,7 @@
       "items": {
         "type": "string"
       },
+      "minItems": 1,
       "unevaluatedItems": false,
       "uniqueItems": true
     },

--- a/schemas/feature.json
+++ b/schemas/feature.json
@@ -195,7 +195,9 @@
               "value"
             ],
             "additionalProperties": false
-          }
+          },
+          "unevaluatedItems": false,
+          "uniqueItems": true
         },
         "default": {
           "type": "string",

--- a/schemas/feature.json
+++ b/schemas/feature.json
@@ -42,6 +42,7 @@
     "preferences": {
       "type": "object",
       "description": "Preferences for this feature, keyed by internal preference name.",
+      "minProperties": 1,
       "additionalProperties": {
         "anyOf": [
           { "$ref": "#/$defs/checkboxPreference" },
@@ -107,7 +108,11 @@
         },
         "default": {
           "type": "string",
-          "description": "The default value of this preference."
+          "description": "The default value of this preference.",
+          "anyOf": [
+            { "const": "" },
+            { "pattern": "^#[0-9a-fA-F]{6}$" }
+          ]
         },
         "inherit": {
           "$ref": "#/$defs/inherit"
@@ -129,7 +134,8 @@
         },
         "src": {
           "type": "string",
-          "description": "The URI, relative to `src/`, for this preference's web component."
+          "description": "The URL, relative to `src/`, for this preference's web component.",
+          "pattern": "^/features/.+/.+\\.js$"
         }
       },
       "required": [
@@ -196,6 +202,7 @@
             ],
             "additionalProperties": false
           },
+          "minItems": 1,
           "unevaluatedItems": false,
           "uniqueItems": true
         },


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
I keep getting annoyed at how juvenile [docs/Chapter 4.1 - Feature metadata.md](https://github.com/AprilSylph/XKit-Rewritten/blob/master/docs/Chapter%204.1%20-%20Feature%20metadata.md) seems. Better documentation would look more like the pages on Google's Chrome extension developer docs, with its own type definitions and better clarity about what can and cannot overlap.

Well, that sounds awfully like a schema to me. I think that maybe creating a schema could be a great starting point for writing better documentation, since it forces accurate recording of definitions without the additional effort of explaining too much of anything in English.

As a bonus, we get basic IntelliSense descriptions for properties in `feature.json` files.

I have to admit—I had fun doing this.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
N/A, dev changes only

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Pull this branch locally
2. Validate our `feature.json` files against the new schema:
    ```
    npx ajv-cli validate --spec=draft2020 -s schemas/feature.json -d 'src/features/*/feature.json'
    ```
