### PR TITLE
refactor: use new element shorthands in modules using `buildSvg()`

### DIFF
--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -1,5 +1,5 @@
 import { keyToCss } from '../../utils/css_map.js';
-import { dom } from '../../utils/dom.js';
+import { path, svg, title } from '../../utils/dom.js';
 import { buildStyle, getTimelineItemWrapper, filterPostElements, getPopoverWrapper, notificationSelector } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
 import { onNewPosts, onNewNotifications, pageModifications } from '../../utils/mutations.js';
@@ -17,7 +17,7 @@ const postAttributionSelector = 'header a[rel="author"]';
 
 const onlyMutualsStyleElement = buildStyle(`${notificationSelector}:not([data-mutuals]) { display: none !important; }`);
 
-const path = 'M593 500q0-45-22.5-64.5T500 416t-66.5 19-18.5 65 18.5 64.5T500 583t70.5-19 22.5-64zm-90 167q-44 0-83.5 18.5t-63 51T333 808v25h334v-25q0-39-22-71.5t-59.5-51T503 667zM166 168l14-90h558l12-78H180q-8 0-51 63l-42 63v209q-19 3-52 3t-33-3q-1 1 0 27 3 53 0 53l32-2q35-1 53 2v258H2l-3 40q-2 41 3 41 42 0 64-1 7-1 21 1v246h756q25 0 42-13 14-10 22-27 5-13 8-28l1-13V275q0-47-3-63-5-24-22.5-34T832 168H166zm667 752H167V754q17 0 38.5-6.5T241 730q16-12 16-26 0-21-33-28-19-4-57-4-3 0-1-51 2-37 1-36V421q88 0 90-48 1-20-33-30-24-6-57-6-4 0-2-44l2-43h635q14 0 22.5 11t8.5 26v543q0 5 4 26 5 30 5 42 1 22-9 22z';
+const drawPathMutuals = 'M593 500q0-45-22.5-64.5T500 416t-66.5 19-18.5 65 18.5 64.5T500 583t70.5-19 22.5-64zm-90 167q-44 0-83.5 18.5t-63 51T333 808v25h334v-25q0-39-22-71.5t-59.5-51T503 667zM166 168l14-90h558l12-78H180q-8 0-51 63l-42 63v209q-19 3-52 3t-33-3q-1 1 0 27 3 53 0 53l32-2q35-1 53 2v258H2l-3 40q-2 41 3 41 42 0 64-1 7-1 21 1v246h756q25 0 42-13 14-10 22-27 5-13 8-28l1-13V275q0-47-3-63-5-24-22.5-34T832 168H166zm667 752H167V754q17 0 38.5-6.5T241 730q16-12 16-26 0-21-33-28-19-4-57-4-3 0-1-51 2-37 1-36V421q88 0 90-48 1-20-33-30-24-6-57-6-4 0-2-44l2-43h635q14 0 22.5 11t8.5 26v543q0 5 4 26 5 30 5 42 1 22-9 22z';
 
 const following = {};
 const followingYou = {};
@@ -153,22 +153,18 @@ export const main = async function () {
 };
 
 const createIcon = (isMutual, blogName, color = 'rgb(var(--black))') =>
-  dom('svg', {
+  svg({
     xmlns: 'http://www.w3.org/2000/svg',
     class: mutualIconClass,
     viewBox: '0 0 1000 1000',
     fill: color,
-  }, null, isMutual
+  }, isMutual
     ? [
-        dom('title', { xmlns: 'http://www.w3.org/2000/svg' }, null, [
-          translate('Mutuals'),
-        ]),
-        dom('path', { xmlns: 'http://www.w3.org/2000/svg', d: path }),
+        title({ xmlns: 'http://www.w3.org/2000/svg' }, [translate('Mutuals')]),
+        path({ xmlns: 'http://www.w3.org/2000/svg', d: drawPathMutuals }),
       ]
     : [
-        dom('title', { xmlns: 'http://www.w3.org/2000/svg' }, null, [
-          translate('{{blogNameLink /}} follows you!').replace('{{blogNameLink /}}', blogName),
-        ]),
+        title({ xmlns: 'http://www.w3.org/2000/svg' }, [translate('{{blogNameLink /}} follows you!').replace('{{blogNameLink /}}', blogName)]),
         buildSvg('ri-user-follow-line').firstElementChild,
       ],
   );

--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -154,17 +154,16 @@ export const main = async function () {
 
 const createIcon = (isMutual, blogName, color = 'rgb(var(--black))') =>
   svg({
-    xmlns: 'http://www.w3.org/2000/svg',
     class: mutualIconClass,
     viewBox: '0 0 1000 1000',
     fill: color,
   }, isMutual
     ? [
-        title({ xmlns: 'http://www.w3.org/2000/svg' }, [translate('Mutuals')]),
-        path({ xmlns: 'http://www.w3.org/2000/svg', d: drawPathMutuals }),
+        title({}, [translate('Mutuals')]),
+        path({ d: drawPathMutuals }),
       ]
     : [
-        title({ xmlns: 'http://www.w3.org/2000/svg' }, [translate('{{blogNameLink /}} follows you!').replace('{{blogNameLink /}}', blogName)]),
+        title({}, [translate('{{blogNameLink /}} follows you!').replace('{{blogNameLink /}}', blogName)]),
         buildSvg('ri-user-follow-line').firstElementChild,
       ],
   );

--- a/src/features/quote_replies/index.js
+++ b/src/features/quote_replies/index.js
@@ -1,5 +1,5 @@
 import { keyToCss } from '../../utils/css_map.js';
-import { dom } from '../../utils/dom.js';
+import { button } from '../../utils/dom.js';
 import { inject } from '../../utils/inject.js';
 import { buildStyle, displayInlineFlexUnlessDisabledAttr, notificationSelector } from '../../utils/interface.js';
 import { showErrorModal } from '../../utils/modals.js';
@@ -83,23 +83,17 @@ const processNotifications = notifications => notifications.forEach(async notifi
   const activityElement = notification.querySelector(activitySelector);
   if (!activityElement) return;
 
-  activityElement.after(dom(
-    'button',
-    {
-      class: `${buttonClass} ${notification.matches(dropdownSelector) ? dropdownButtonClass : ''}`,
-      [displayInlineFlexUnlessDisabledAttr]: '',
-      title: 'Quote this reply',
+  activityElement.after(button({
+    class: `${buttonClass} ${notification.matches(dropdownSelector) ? dropdownButtonClass : ''}`,
+    [displayInlineFlexUnlessDisabledAttr]: '',
+    title: 'Quote this reply',
+    click () {
+      this.disabled = true;
+      quoteReply(tumblelogName, notificationProps)
+        .catch(showErrorModal)
+        .finally(() => { this.disabled = false; });
     },
-    {
-      click () {
-        this.disabled = true;
-        quoteReply(tumblelogName, notificationProps)
-          .catch(showErrorModal)
-          .finally(() => { this.disabled = false; });
-      },
-    },
-    [buildSvg('ri-chat-quote-line')],
-  ));
+  }, [buildSvg('ri-chat-quote-line')]));
 });
 
 const quoteReply = async (tumblelogName, notificationProps) => {

--- a/src/utils/control_buttons.js
+++ b/src/utils/control_buttons.js
@@ -1,5 +1,5 @@
 import { keyToCss } from './css_map.js';
-import { dom } from './dom.js';
+import { button, div, span } from './dom.js';
 import { displayInlineBlockUnlessDisabledAttr } from './interface.js';
 import { timelineObject } from './react_props.js';
 import { buildSvg } from './remixicon.js';
@@ -15,9 +15,9 @@ $('.xkit-control-button-container').remove();
  * @returns {HTMLDivElement} A button that can be cloned with cloneControlButton()
  */
 export const createControlButtonTemplate = function (symbolId, buttonClass, label = '') {
-  return dom('span', { class: `xkit-control-button-container ${buttonClass}`, [displayInlineBlockUnlessDisabledAttr]: '' }, null, [
-    dom('button', { class: 'xkit-control-button', 'aria-label': label, title: label }, null, [
-      dom('span', { class: 'xkit-control-button-inner', tabindex: '-1' }, null, [
+  return span({ class: `xkit-control-button-container ${buttonClass}`, [displayInlineBlockUnlessDisabledAttr]: '' }, [
+    button({ class: 'xkit-control-button', 'aria-label': label, title: label }, [
+      span({ class: 'xkit-control-button-inner', tabindex: '-1' }, [
         buildSvg(symbolId),
       ]),
     ]),
@@ -50,7 +50,7 @@ const secondaryFooterRowClass = 'xkit-controls-row';
 const addSecondaryFooterRow = postElement => {
   const element =
     postElement.querySelector(`.${secondaryFooterRowClass}`) ||
-    dom('div', { class: secondaryFooterRowClass });
+    div({ class: secondaryFooterRowClass });
 
   element.isConnected || postElement.querySelector('footer').before(element);
   return element;

--- a/src/utils/dom.js
+++ b/src/utils/dom.js
@@ -90,6 +90,7 @@ export function element (tagName, properties = {}, children = []) {
 /** @type {V<HTMLInputElement>}     */ export const input = (props = {}) => element('input', props);
 /** @type {V<HTMLLinkElement>}      */ export const link = (props = {}) => element('link', props);
 
-/** @type {E<SVGPathElement>} */ export const path = (props = {}, children = []) => element('path', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);
-/** @type {E<SVGSVGElement>}  */ export const svg = (props = {}, children = []) => element('svg', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);
-/** @type {E<SVGUseElement>}  */ export const use = (props = {}, children = []) => element('use', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);
+/** @type {E<SVGPathElement>}   */ export const path = (props = {}, children = []) => element('path', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);
+/** @type {E<SVGSVGElement>}    */ export const svg = (props = {}, children = []) => element('svg', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);
+/** @type {E<SVGTitleElement>}  */ export const title = (props = {}, children = []) => element('title', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);
+/** @type {E<SVGUseElement>}    */ export const use = (props = {}, children = []) => element('use', { xmlns: 'http://www.w3.org/2000/svg', ...props }, children);

--- a/src/utils/remixicon.js
+++ b/src/utils/remixicon.js
@@ -1,4 +1,4 @@
-import { dom } from './dom.js';
+import { svg, use } from './dom.js';
 
 const symbolsUrl = browser.runtime.getURL('/lib/remixicon.symbol.svg');
 
@@ -18,6 +18,6 @@ if (document.querySelector(`svg[data-src="${symbolsUrl}"]`) === null) {
  * @param {string} symbolId RemixIcon symbol id to use
  * @returns {SVGElement} an SVG element that renders the specified icon
  */
-export const buildSvg = symbolId => dom('svg', { xmlns: 'http://www.w3.org/2000/svg' }, null, [
-  dom('use', { xmlns: 'http://www.w3.org/2000/svg', href: `#${symbolId}` }),
+export const buildSvg = symbolId => svg({ xmlns: 'http://www.w3.org/2000/svg' }, [
+  use({ xmlns: 'http://www.w3.org/2000/svg', href: `#${symbolId}` }),
 ]);

--- a/src/utils/remixicon.js
+++ b/src/utils/remixicon.js
@@ -18,6 +18,4 @@ if (document.querySelector(`svg[data-src="${symbolsUrl}"]`) === null) {
  * @param {string} symbolId RemixIcon symbol id to use
  * @returns {SVGElement} an SVG element that renders the specified icon
  */
-export const buildSvg = symbolId => svg({ xmlns: 'http://www.w3.org/2000/svg' }, [
-  use({ xmlns: 'http://www.w3.org/2000/svg', href: `#${symbolId}` }),
-]);
+export const buildSvg = symbolId => svg({}, [use({ href: `#${symbolId}` })]);


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
- relates to #2341

I'm trying to optimise `lib/remixicon.symbol.svg` away, which means drastically changing what `buildSvg` does. However, most of the usages of `buildSvg` are nested inside `dom()` calls, which I just can't abide. Not to mention, `buildSvg` uses `dom()` itself! Oh, the horror!

So, no more `dom()` and `buildSvg` in the same files. This is its own PR so that it can be tested separately from any actual changes to `buildSvg`.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
No visual changes expected.

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Load the modified addon, and smoke-test all the features affected:
- Mutual Checker (verify: mutuals icon, follower icon)
- Quick Tags (verify: post control button, post form button)
- Quote Replies
- Trim Reblogs
