### PR TITLE
feat(Mutual Checker): update "follows you!" icon

### DIFF
--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -1,11 +1,10 @@
 import { keyToCss } from '../../utils/css_map.js';
-import { path, svg, title } from '../../utils/dom.js';
+import { path, svg, title, use } from '../../utils/dom.js';
 import { buildStyle, getTimelineItemWrapper, filterPostElements, getPopoverWrapper, notificationSelector } from '../../utils/interface.js';
 import { translate } from '../../utils/language_data.js';
 import { onNewPosts, onNewNotifications, pageModifications } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
 import { blogData, notificationObject, timelineObject } from '../../utils/react_props.js';
-import { buildSvg } from '../../utils/remixicon.js';
 import { followingTimelineSelector } from '../../utils/timeline_id.js';
 import { apiFetch } from '../../utils/tumblr_helpers.js';
 import { primaryBlogName, userBlogNames } from '../../utils/user.js';
@@ -155,8 +154,9 @@ export const main = async function () {
 const createIcon = (isMutual, blogName, color = 'rgb(var(--black))') =>
   svg({
     class: mutualIconClass,
+    fill: 'currentColor',
+    style: `color: ${color}`,
     viewBox: '0 0 1000 1000',
-    fill: color,
   }, isMutual
     ? [
         title({}, [translate('Mutuals')]),
@@ -164,7 +164,7 @@ const createIcon = (isMutual, blogName, color = 'rgb(var(--black))') =>
       ]
     : [
         title({}, [translate('{{blogNameLink /}} follows you!').replace('{{blogNameLink /}}', blogName)]),
-        buildSvg('ri-user-follow-line').firstElementChild,
+        use({ href: '#managed-icon__ds-user-following-outline' }),
       ],
   );
 

--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -152,21 +152,15 @@ export const main = async function () {
 };
 
 const createIcon = (isMutual, blogName, color = 'rgb(var(--black))') =>
-  svg({
-    class: mutualIconClass,
-    fill: 'currentColor',
-    style: `color: ${color}`,
-    viewBox: '0 0 1000 1000',
-  }, isMutual
-    ? [
+  isMutual
+    ? (svg({ class: mutualIconClass, fill: color, viewBox: '0 0 1000 1000' }, [
         title({}, [translate('Mutuals')]),
         path({ d: drawPathMutuals }),
-      ]
-    : [
+      ]))
+    : (svg({ class: mutualIconClass, style: `color: ${color}`, viewBox: '0 0 24 24' }, [
         title({}, [translate('{{blogNameLink /}} follows you!').replace('{{blogNameLink /}}', blogName)]),
         use({ href: '#managed-icon__ds-user-following-outline' }),
-      ],
-  );
+      ]));
 
 export const clean = async function () {
   onNewPosts.removeListener(addIcons);

--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -151,7 +151,7 @@ export const main = async function () {
   }
 };
 
-const createIcon = (isMutual, blogName, color = 'rgb(var(--black))') =>
+const createIcon = (isMutual, blogName, color = 'var(--content-fg)') =>
   isMutual
     ? (svg({ class: mutualIconClass, fill: color, viewBox: '0 0 1000 1000' }, [
         title({}, [translate('Mutuals')]),


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
Updates the "follows you!" blog card icon to one of Tumblr's design system icons.

I believe this is the one usage of `buildSvg` that doesn't just use the same icon that's used for the feature in the control panel; removing this usage gets `buildSvg` closer to how I'm envisioning it would work in a world where we don't commit `remixicon.symbol.svg`.

This shouldn't change how the mutual icon renders at all.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
Before | After | Before | After
-|-|-|-
<img width="294" height="600" alt="Screenshot 2026-08-24 at 3 46 09 pm" src="https://github.com/user-attachments/assets/e148d599-f7ab-4806-ba50-984a7395b4c7" /> | <img width="294" height="600" alt="Screenshot 2026-08-24 at 3 46 19 pm" src="https://github.com/user-attachments/assets/42bc8a8d-e59c-4bf7-ab4f-63eb1f693e35" /> | <img width="294" height="600" alt="Screenshot 2026-08-24 at 3 46 32 pm" src="https://github.com/user-attachments/assets/b91ffbab-6911-46ed-83f9-2068747fab23" /> | <img width="294" height="600" alt="Screenshot 2026-08-24 at 3 46 44 pm" src="https://github.com/user-attachments/assets/99688021-b49d-4676-a0ab-d3432bc2cdb8" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Enable Mutual Checker
3. Find a post from a mutual
    - **Expected result**: The mutual icon is still inserted into the post header as normal
    - **Expected result**: Hovering the mutual icon shows the usual "Mutuals" hovertext
4. Hover a mutual's avatar
    - **Expected result**: The mutual icon is still inserted into the blog card as normal
    - **Expected result**: Hovering the mutual icon shows the usual "Mutuals" hovertext
5. Hover a follower's avatar
    - **Expected result**: The Tumblr following icon is inserted into the blog card
    - **Expected result**: Hovering the following icon shows the usual "{blogName} follows you!" hovertext
