### PR TITLE
fix(No Recommended): Prevent sidebar recommended blogs option hiding incorrect content

### DIFF
--- a/src/features/no_recommended/hide_recommended_blogs.js
+++ b/src/features/no_recommended/hide_recommended_blogs.js
@@ -21,7 +21,7 @@ const hideTagPageRecommended = blogsLists =>
 export const main = async function () {
   pageModifications.register('aside h1', hideDashboardRecommended);
 
-  const blogsListSelector = `${keyToCss('desktopContainer')} > ${keyToCss('recommendedBlogs')}`;
+  const blogsListSelector = `aside ${keyToCss('desktopContainer')} > ${keyToCss('recommendedBlogs')}`;
   pageModifications.register(blogsListSelector, hideTagPageRecommended);
 };
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

The "Hide recommended blogs in the sidebar" option should, obviously, only apply within the sidebar. The selector used for the tag page currently may erroneously apply in masonry timelines, however; this makes it more specific.

Related: #2322.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Confirm that the "Hide recommended blogs in the sidebar" No Recommended option still works on tagged pages.
