### PR TITLE
fix(No Recommended): Enable blog/community carousel hiding in masonry views

### DIFF
--- a/src/features/no_recommended/hide_blog_carousels.js
+++ b/src/features/no_recommended/hide_blog_carousels.js
@@ -2,6 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle, getTimelineItemWrapper } from '../../utils/interface.js';
 import { pageModifications } from '../../utils/mutations.js';
 import { timelineObject } from '../../utils/react_props.js';
+import { timelineSelector } from '../../utils/timeline_id.js';
 
 const hiddenAttribute = 'data-no-recommended-blog-carousels-hidden';
 
@@ -12,6 +13,7 @@ export const styleElement = buildStyle(`
 `);
 
 const carouselSelector = `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')}`;
+const masonryCarouselSelector = `${keyToCss('desktopContainer')} > ${keyToCss('recommendedBlogs')}`;
 
 const hideBlogCarousels = carousels =>
   carousels.forEach(async carousel => {
@@ -19,17 +21,24 @@ const hideBlogCarousels = carousels =>
     if (elements.some(({ objectType }) => objectType === 'blog')) {
       const timelineItem = getTimelineItemWrapper(carousel);
       if (
-        timelineItem.previousElementSibling.querySelector(keyToCss('titleObject')) ||
-        timelineItem.previousElementSibling.dataset.cellId?.startsWith('timelineObject:title')
+        timelineItem.previousElementSibling?.querySelector(keyToCss('titleObject')) ||
+        timelineItem.previousElementSibling?.dataset.cellId?.startsWith('timelineObject:title')
       ) {
         timelineItem.toggleAttribute(hiddenAttribute, true);
         timelineItem.previousElementSibling.toggleAttribute(hiddenAttribute, true);
+      } else if (
+        timelineItem.querySelector(keyToCss('titleObject'))
+      ) {
+        timelineItem.toggleAttribute(hiddenAttribute, true);
       }
     }
   });
 
 export const main = async function () {
-  pageModifications.register(carouselSelector, hideBlogCarousels);
+  pageModifications.register(
+    `${timelineSelector} :is(${carouselSelector}, ${masonryCarouselSelector})`,
+    hideBlogCarousels,
+  );
 };
 
 export const clean = async function () {

--- a/src/features/no_recommended/hide_community_carousels.js
+++ b/src/features/no_recommended/hide_community_carousels.js
@@ -2,6 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle, getTimelineItemWrapper } from '../../utils/interface.js';
 import { pageModifications } from '../../utils/mutations.js';
 import { timelineObject } from '../../utils/react_props.js';
+import { timelineSelector } from '../../utils/timeline_id.js';
 
 const hiddenAttribute = 'data-no-recommended-community-carousels-hidden';
 
@@ -12,6 +13,7 @@ export const styleElement = buildStyle(`
 `);
 
 const carouselSelector = `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')}`;
+const masonryCarouselSelector = keyToCss('communityRows');
 
 const hideCommunityCarousels = carousels =>
   carousels.forEach(async carousel => {
@@ -19,17 +21,24 @@ const hideCommunityCarousels = carousels =>
     if (elements.some(({ objectType }) => objectType === 'community_card')) {
       const timelineItem = getTimelineItemWrapper(carousel);
       if (
-        timelineItem.previousElementSibling.querySelector(keyToCss('titleObject')) ||
-        timelineItem.previousElementSibling.dataset.cellId?.startsWith('timelineObject:title')
+        timelineItem.previousElementSibling?.querySelector(keyToCss('titleObject')) ||
+        timelineItem.previousElementSibling?.dataset.cellId?.startsWith('timelineObject:title')
       ) {
         timelineItem.toggleAttribute(hiddenAttribute, true);
         timelineItem.previousElementSibling.toggleAttribute(hiddenAttribute, true);
+      } else if (
+        timelineItem.querySelector(keyToCss('titleObject'))
+      ) {
+        timelineItem.toggleAttribute(hiddenAttribute, true);
       }
     }
   });
 
 export const main = async function () {
-  pageModifications.register(carouselSelector, hideCommunityCarousels);
+  pageModifications.register(
+    `${timelineSelector} :is(${carouselSelector}, ${masonryCarouselSelector})`,
+    hideCommunityCarousels,
+  );
 };
 
 export const clean = async function () {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

In masonry views, recommended blog/tag/community elements between posts are displayed differently and No Recommended fails to hide them. This fixes two of the three.

This currently doesn't include tag carousels since... I can't find one. I wrote "Check out these tags" in the linked issue, though, so obviously they exist. Based on staring at a bunch of minified javascript, I'd believe you if you told me the correct selector for them is or includes `keyToCss('tagGrid')`, but also if you did not say that. So.

Related/mostly resolves: #2322.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that the "Hide recommended blogs between posts" and "Hide recommended communities between posts" No Recommended options still works on normal timelines.
- Confirm that the "Hide recommended blogs between posts" and "Hide recommended communities between posts" No Recommended options work on masonry-view timelines.