### PR TITLE
fix(No Recommended): Enable tag carousel hiding in masonry views

### DIFF
--- a/src/features/no_recommended/hide_tag_carousels.js
+++ b/src/features/no_recommended/hide_tag_carousels.js
@@ -2,6 +2,7 @@ import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle, getTimelineItemWrapper } from '../../utils/interface.js';
 import { pageModifications } from '../../utils/mutations.js';
 import { timelineObject } from '../../utils/react_props.js';
+import { timelineSelector } from '../../utils/timeline_id.js';
 
 const hiddenAttribute = 'data-no-recommended-tag-carousels-hidden';
 
@@ -12,6 +13,7 @@ export const styleElement = buildStyle(`
 `);
 
 const carouselSelector = `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')}`;
+const masonryCarouselSelector = keyToCss('tagRows');
 
 const hideTagCarousels = carousels =>
   carousels.forEach(async carousel => {
@@ -19,17 +21,24 @@ const hideTagCarousels = carousels =>
     if (elements.some(({ objectType }) => objectType === 'tag_carousel_card')) {
       const timelineItem = getTimelineItemWrapper(carousel);
       if (
-        timelineItem.previousElementSibling.querySelector(keyToCss('titleObject')) ||
-        timelineItem.previousElementSibling.dataset.cellId?.startsWith('timelineObject:title')
+        timelineItem.previousElementSibling?.querySelector(keyToCss('titleObject')) ||
+        timelineItem.previousElementSibling?.dataset.cellId?.startsWith('timelineObject:title')
       ) {
         timelineItem.toggleAttribute(hiddenAttribute, true);
         timelineItem.previousElementSibling.toggleAttribute(hiddenAttribute, true);
+      } else if (
+        timelineItem.querySelector(keyToCss('titleObject'))
+      ) {
+        timelineItem.toggleAttribute(hiddenAttribute, true);
       }
     }
   });
 
 export const main = async function () {
-  pageModifications.register(carouselSelector, hideTagCarousels);
+  pageModifications.register(
+    `${timelineSelector} :is(${carouselSelector}, ${masonryCarouselSelector})`,
+    hideTagCarousels,
+  );
 };
 
 export const clean = async function () {

--- a/src/features/no_recommended/hide_tag_carousels.js
+++ b/src/features/no_recommended/hide_tag_carousels.js
@@ -1,6 +1,7 @@
 import { keyToCss } from '../../utils/css_map.js';
 import { buildStyle, getTimelineItemWrapper } from '../../utils/interface.js';
 import { pageModifications } from '../../utils/mutations.js';
+import { timelineObject } from '../../utils/react_props.js';
 
 const hiddenAttribute = 'data-no-recommended-tag-carousels-hidden';
 
@@ -10,20 +11,25 @@ export const styleElement = buildStyle(`
   [${hiddenAttribute}] > div img, [${hiddenAttribute}] > div canvas { visibility: hidden; }
 `);
 
-const tagCardSelector = keyToCss('tagCard');
-const listTimelineObjectSelector = keyToCss('listTimelineObject');
-const carouselWrapperSelector = `${listTimelineObjectSelector} ${keyToCss('carouselWrapper')}`;
+const carouselSelector = `${keyToCss('listTimelineObject')} ${keyToCss('carouselWrapper')}`;
 
-const hideTagCarousels = carouselWrappers => carouselWrappers
-  .filter(carouselWrapper => carouselWrapper.querySelector(tagCardSelector) !== null)
-  .map(getTimelineItemWrapper)
-  .forEach(timelineItem => {
-    timelineItem.toggleAttribute(hiddenAttribute, true);
-    timelineItem.previousElementSibling.toggleAttribute(hiddenAttribute, true);
+const hideTagCarousels = carousels =>
+  carousels.forEach(async carousel => {
+    const { elements } = await timelineObject(carousel);
+    if (elements.some(({ objectType }) => objectType === 'tag_carousel_card')) {
+      const timelineItem = getTimelineItemWrapper(carousel);
+      if (
+        timelineItem.previousElementSibling.querySelector(keyToCss('titleObject')) ||
+        timelineItem.previousElementSibling.dataset.cellId?.startsWith('timelineObject:title')
+      ) {
+        timelineItem.toggleAttribute(hiddenAttribute, true);
+        timelineItem.previousElementSibling.toggleAttribute(hiddenAttribute, true);
+      }
+    }
   });
 
 export const main = async function () {
-  pageModifications.register(carouselWrapperSelector, hideTagCarousels);
+  pageModifications.register(carouselSelector, hideTagCarousels);
 };
 
 export const clean = async function () {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

In masonry views, recommended blog/tag/community elements between posts are displayed differently and No Recommended fails to hide them. This fixes the final one.

See #2322.

For some reason, it seems like we changed the blog/community carousel hiding code, but not the tag carousel code? I don't remember why now.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that the "Hide recommended tags between posts" No Recommended option still works on normal timelines.
- Confirm that the "Hide recommended tags between posts" No Recommended options work on masonry-view timelines.

The For You page is where I found one of these (eventually).