### PR TITLE
feat: Run features in alphabetical order; make control button order consistent

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default [
    */
   ...neostandard({
     env: ['browser', 'jquery', 'webextensions'],
+    globals: { name: 'off' },
     ignores: ['src/lib/**'],
     semi: true,
   }),

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -12,20 +12,21 @@
 
   const timestamp = Date.now(); // Prevent referencing outdated resources after Firefox extension update/restart
 
-  const getFeature = name => import(browser.runtime.getURL(`/features/${name}/index.js`));
-  const getUtil = name => import(browser.runtime.getURL(`/utils/${name}.js`));
+  const importFeature = name => import(browser.runtime.getURL(`/features/${name}/index.js`));
+  const importUtil = name => import(browser.runtime.getURL(`/utils/${name}.js`));
 
-  const runFeature = async function ({
-    main,
-    clean,
-    stylesheet,
-    styleElement,
-    onStorageChanged,
-  }) {
+  const runFeature = async function (name) {
+    const {
+      main,
+      clean,
+      stylesheet,
+      styleElement,
+      onStorageChanged,
+    } = await importFeature(name);
+
     if (main) {
       main().catch(console.error);
     }
-
     if (stylesheet) {
       const link = Object.assign(document.createElement('link'), {
         rel: 'stylesheet',
@@ -34,7 +35,6 @@
       });
       document.documentElement.appendChild(link);
     }
-
     if (styleElement) {
       styleElement.dataset.xkitFeature = name;
       document.documentElement.append(styleElement);
@@ -55,19 +55,19 @@
     browser.storage.local.onChanged.addListener(restartListeners[name]);
   };
 
-  const destroyFeature = async function ({
-    clean,
-    stylesheet,
-    styleElement,
-  }) {
+  const destroyFeature = async function (name) {
+    const {
+      clean,
+      stylesheet,
+      styleElement,
+    } = await importFeature(name);
+
     if (clean) {
       clean().catch(console.error);
     }
-
     if (stylesheet) {
       document.querySelector(`link[href^="${browser.runtime.getURL(`/features/${name}/index.css`)}"]`)?.remove();
     }
-
     if (styleElement) {
       styleElement.remove();
     }
@@ -85,8 +85,8 @@
       const newlyDisabled = oldValue.filter(x => newValue.includes(x) === false);
       const newlyEnabled = newValue.filter(x => oldValue.includes(x) === false);
 
-      (await Promise.all(newlyDisabled.map(getFeature))).forEach(destroyFeature);
-      (await Promise.all(newlyEnabled.map(getFeature))).forEach(runFeature);
+      newlyDisabled.forEach(destroyFeature);
+      newlyEnabled.forEach(runFeature);
     }
   };
 
@@ -148,14 +148,15 @@
      * Fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await.
      * @see https://bugs.webkit.org/show_bug.cgi?id=242740
      */
-    await Promise.all(['css_map', 'language_data', 'user'].map(getUtil));
+    await Promise.all(['css_map', 'language_data', 'user'].map(importUtil));
 
     /**
-     * Populates the module cache and then runs features in order.
-     * This ensures that feature run order is unaffected by module resolution timing.
+     * Populates the module cache, ensuring that feature run order is unaffected by module resolution.
      * @see https://github.com/AprilSylph/XKit-Rewritten/discussions/2357
      */
-    (await Promise.all(orderedEnabledFeatures.map(getFeature))).forEach(runFeature);
+    await Promise.all(orderedEnabledFeatures.map(importFeature));
+
+    orderedEnabledFeatures.forEach(runFeature);
 
     warnOnExtensionContextInvalidated();
   };

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -12,6 +12,9 @@
 
   const timestamp = Date.now(); // Prevent referencing outdated resources after Firefox extension update/restart
 
+  const importFeature = name => import(browser.runtime.getURL(`/features/${name}/index.js`));
+  const importUtil = name => import(browser.runtime.getURL(`/utils/${name}.js`));
+
   const runFeature = async function (name) {
     const {
       main,
@@ -19,7 +22,7 @@
       stylesheet,
       styleElement,
       onStorageChanged,
-    } = await import(browser.runtime.getURL(`/features/${name}/index.js`));
+    } = await importFeature(name);
 
     if (main) {
       main().catch(console.error);
@@ -57,7 +60,7 @@
       clean,
       stylesheet,
       styleElement,
-    } = await import(browser.runtime.getURL(`/features/${name}/index.js`));
+    } = await importFeature(name);
 
     if (clean) {
       clean().catch(console.error);
@@ -139,15 +142,20 @@
       initMainWorld(),
     ]);
 
+    const orderedEnabledFeatures = installedFeatures.filter(name => enabledFeatures.includes(name));
+
     /**
      * Fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await
      * @see https://github.com/sveltejs/kit/issues/7805#issuecomment-1330078207
      */
-    await Promise.all(['css_map', 'language_data', 'user'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
+    await Promise.all(['css_map', 'language_data', 'user'].map(importUtil));
 
-    installedFeatures
-      .filter(featureName => enabledFeatures.includes(featureName))
-      .forEach(runFeature);
+    /**
+     * Populates the module cache, ensuring that feature run order is unaffected by module resolution.
+     */
+    await Promise.all(orderedEnabledFeatures.map(importFeature));
+
+    orderedEnabledFeatures.forEach(runFeature);
 
     warnOnExtensionContextInvalidated();
   };

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -82,11 +82,11 @@
     if (enabledFeatures) {
       const { oldValue = [], newValue = [] } = enabledFeatures;
 
-      const newlyEnabled = newValue.filter(x => oldValue.includes(x) === false);
       const newlyDisabled = oldValue.filter(x => newValue.includes(x) === false);
+      const newlyEnabled = newValue.filter(x => oldValue.includes(x) === false);
 
-      (await Promise.all(newlyEnabled.map(getFeature))).forEach(runFeature);
       (await Promise.all(newlyDisabled.map(getFeature))).forEach(destroyFeature);
+      (await Promise.all(newlyEnabled.map(getFeature))).forEach(runFeature);
     }
   };
 

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -12,21 +12,20 @@
 
   const timestamp = Date.now(); // Prevent referencing outdated resources after Firefox extension update/restart
 
-  const importFeature = name => import(browser.runtime.getURL(`/features/${name}/index.js`));
-  const importUtil = name => import(browser.runtime.getURL(`/utils/${name}.js`));
+  const getFeature = name => import(browser.runtime.getURL(`/features/${name}/index.js`));
+  const getUtil = name => import(browser.runtime.getURL(`/utils/${name}.js`));
 
-  const runFeature = async function (name) {
-    const {
-      main,
-      clean,
-      stylesheet,
-      styleElement,
-      onStorageChanged,
-    } = await importFeature(name);
-
+  const runFeature = async function ({
+    main,
+    clean,
+    stylesheet,
+    styleElement,
+    onStorageChanged,
+  }) {
     if (main) {
       main().catch(console.error);
     }
+
     if (stylesheet) {
       const link = Object.assign(document.createElement('link'), {
         rel: 'stylesheet',
@@ -35,6 +34,7 @@
       });
       document.documentElement.appendChild(link);
     }
+
     if (styleElement) {
       styleElement.dataset.xkitFeature = name;
       document.documentElement.append(styleElement);
@@ -55,19 +55,19 @@
     browser.storage.local.onChanged.addListener(restartListeners[name]);
   };
 
-  const destroyFeature = async function (name) {
-    const {
-      clean,
-      stylesheet,
-      styleElement,
-    } = await importFeature(name);
-
+  const destroyFeature = async function ({
+    clean,
+    stylesheet,
+    styleElement,
+  }) {
     if (clean) {
       clean().catch(console.error);
     }
+
     if (stylesheet) {
       document.querySelector(`link[href^="${browser.runtime.getURL(`/features/${name}/index.css`)}"]`)?.remove();
     }
+
     if (styleElement) {
       styleElement.remove();
     }
@@ -85,8 +85,8 @@
       const newlyEnabled = newValue.filter(x => oldValue.includes(x) === false);
       const newlyDisabled = oldValue.filter(x => newValue.includes(x) === false);
 
-      newlyEnabled.forEach(runFeature);
-      newlyDisabled.forEach(destroyFeature);
+      (await Promise.all(newlyEnabled.map(getFeature))).forEach(runFeature);
+      (await Promise.all(newlyDisabled.map(getFeature))).forEach(destroyFeature);
     }
   };
 
@@ -148,15 +148,14 @@
      * Fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await.
      * @see https://bugs.webkit.org/show_bug.cgi?id=242740
      */
-    await Promise.all(['css_map', 'language_data', 'user'].map(importUtil));
+    await Promise.all(['css_map', 'language_data', 'user'].map(getUtil));
 
     /**
-     * Populates the module cache, ensuring that feature run order is unaffected by module resolution.
+     * Populates the module cache and then runs features in order.
+     * This ensures that feature run order is unaffected by module resolution timing.
      * @see https://github.com/AprilSylph/XKit-Rewritten/discussions/2357
      */
-    await Promise.all(orderedEnabledFeatures.map(importFeature));
-
-    orderedEnabledFeatures.forEach(runFeature);
+    (await Promise.all(orderedEnabledFeatures.map(getFeature))).forEach(runFeature);
 
     warnOnExtensionContextInvalidated();
   };

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -145,13 +145,14 @@
     const orderedEnabledFeatures = installedFeatures.filter(name => enabledFeatures.includes(name));
 
     /**
-     * Fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await
-     * @see https://github.com/sveltejs/kit/issues/7805#issuecomment-1330078207
+     * Fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await.
+     * @see https://bugs.webkit.org/show_bug.cgi?id=242740
      */
     await Promise.all(['css_map', 'language_data', 'user'].map(importUtil));
 
     /**
      * Populates the module cache, ensuring that feature run order is unaffected by module resolution.
+     * @see https://github.com/AprilSylph/XKit-Rewritten/discussions/2357
      */
     await Promise.all(orderedEnabledFeatures.map(importFeature));
 


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Background: #2357.

This refactors the main content script slightly so that feature modules are resolved (simultaneously) before they're run (sequentially in alphabetical order), meaning that any code in a feature's main function is consistently run before/after code in a different feature's main function. This causes the control buttons inserted by Quick Tags and Trim Reblogs to always be in the same positions instead of randomly flipping each time a page is opened, if both features are enabled (as the mutations util is, generally speaking, order-preserving).

Naturally, the moment you start awaiting nontrivial things, stably ordering feature code gets harder, but we may as well make it stable where possible.

As noted in https://github.com/AprilSylph/XKit-Rewritten/discussions/2357#discussioncomment-18211340, this calls import() on the same path twice, which uses the module cache; https://github.com/AprilSylph/XKit-Rewritten/blob/master/src/main_world/index.js declines to do this by implementing an explicit cache. We could do so here, e.g.

```diff
- const importFeature = name => import(browser.runtime.getURL(`/features/${name}/index.js`));
- const importUtil = name => import(browser.runtime.getURL(`/utils/${name}.js`));
+ const moduleCache = {};
+ const importFeature = name => (moduleCache[name] ??= import(browser.runtime.getURL(`/features/${name}/index.js`)));
+ const importUtil = name => (moduleCache[name] ??= import(browser.runtime.getURL(`/utils/${name}.js`)));
```

(Or, you know, something that doesn't use an assignment's return value to save loc.)

There is a subtle difference (https://gist.github.com/marcustyphoon/55b336b451a64c9edb8089b296dcce24) the way the main world script uses it now, but it's inconsequential in practice and goes away if you put the ??= in an awaited function. I guess it should probably be consistent?

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Enable Quick Tags and Trim Reblogs. Refresh a page with an editable post a few times and confirm that the Quick Tags button always comes before the Trim Reblogs button.
- Confirm that enabling and disabling features works.
- Confirm that a feature like CleanFeed with automatic onStorageChanged behavior renders preference changes in real time.