### PR TITLE
fix(Icons util): Multiple duplicate symbol elements being created

### DIFF
--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -1,4 +1,5 @@
 import { aside, svg, use } from './dom.js';
+import { memoize } from './memoize.js';
 
 const symbolsClassName = 'xkit-symbols';
 
@@ -8,21 +9,23 @@ $(`.${symbolsClassName}`).remove();
 const symbols = aside({ class: symbolsClassName });
 document.head.append(symbols);
 
+const getSymbolId = memoize(featureName => {
+  const symbolId = `${symbolsClassName}__${featureName}`;
+
+  fetch(browser.runtime.getURL(`/features/${featureName}/icon.svg`))
+    .then(result => new Promise(resolve => setTimeout(() => resolve(result), 2000)))
+    .then(iconResponse => iconResponse.text())
+    .then(iconText => new DOMParser().parseFromString(iconText, 'image/svg+xml').firstElementChild)
+    .then(iconElement => {
+      iconElement.setAttribute('id', symbolId);
+      symbols.append(iconElement);
+    });
+
+  return symbolId;
+});
+
 /**
  * @param {string} featureName The internal name of a feature calling this utility (e.g. `"quick_tags"`)
  * @returns {SVGSVGElement} An SVG element that renders the icon for the specified feature
  */
-export const getIcon = featureName => {
-  const symbolId = `${symbolsClassName}__${featureName}`;
-  if (document.getElementById(symbolId) === null) {
-    fetch(browser.runtime.getURL(`/features/${featureName}/icon.svg`))
-      .then(iconResponse => iconResponse.text())
-      .then(iconText => new DOMParser().parseFromString(iconText, 'image/svg+xml').firstElementChild)
-      .then(iconElement => {
-        iconElement.setAttribute('id', symbolId);
-        symbols.append(iconElement);
-      });
-  }
-
-  return svg({}, [use({ href: `#${symbolId}` })]);
-};
+export const getIcon = featureName => svg({}, [use({ href: `#${getSymbolId(featureName)}` })]);

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -13,7 +13,6 @@ const getSymbolId = memoize(featureName => {
   const symbolId = `${symbolsClassName}__${featureName}`;
 
   fetch(browser.runtime.getURL(`/features/${featureName}/icon.svg`))
-    .then(result => new Promise(resolve => setTimeout(() => resolve(result), 2000)))
     .then(iconResponse => iconResponse.text())
     .then(iconText => new DOMParser().parseFromString(iconText, 'image/svg+xml').firstElementChild)
     .then(iconElement => {


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

As described in the linked issue, this fixes a small race condition and prevents multiple duplicate symbol elements from being created by the new version of the icons util.

Resolves #2358.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Smoke test icon insertion.