### PR TITLE
refactor: `runFeature` → `runFeatures`

### DIFF
--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -21,15 +21,12 @@
 
   const timestamp = Date.now(); // Prevent referencing outdated resources after Firefox extension update/restart
 
-  /** @type {(name: string) => Promise<FeatureModule>} */
-  const getFeature = name => import(browser.runtime.getURL(`/features/${name}/index.js`));
-
   /**
    * @param {string[]} names Internal feature names to resolve modules for.
    * @returns {Promise<[string, FeatureModule][]>} Entries of feature modules, keyed by name.
    */
   const getFeatures = names => Promise.all(
-    names.map(async (name) => [name, await getFeature(name)]),
+    names.map(async (name) => [name, await import(browser.runtime.getURL(`/features/${name}/index.js`))]),
   );
 
   const runFeatures = async function (names) {

--- a/src/content_scripts/main.js
+++ b/src/content_scripts/main.js
@@ -1,5 +1,14 @@
 'use strict';
 
+/**
+ * @typedef FeatureModule
+ * @property {() => Promise<void>}  main The function for running the feature when it is enabled.
+ * @property {() => Promise<void>}  clean The function for cleaning up the feature when it is disabled.
+ * @property {() => Promise<void>}  [onStorageChanged] Preference handling for the feature. If not provided, the feature is restarted when its preferences change.
+ * @property {boolean}              [stylesheet] Whether or not the feature has a static stylesheet at `index.css`. Optional.
+ * @property {HTMLStyleElement}     [styleElement] A style element constructed by the `buildStyle()` utility. Optional.
+ */
+
 {
   const MAX_BOOT_ATTEMPTS = 3600; // 60 seconds on 60Hz displays; 10 seconds on 360Hz displays
 
@@ -12,68 +21,84 @@
 
   const timestamp = Date.now(); // Prevent referencing outdated resources after Firefox extension update/restart
 
-  const importFeature = name => import(browser.runtime.getURL(`/features/${name}/index.js`));
-  const importUtil = name => import(browser.runtime.getURL(`/utils/${name}.js`));
+  /** @type {(name: string) => Promise<FeatureModule>} */
+  const getFeature = name => import(browser.runtime.getURL(`/features/${name}/index.js`));
 
-  const runFeature = async function (name) {
-    const {
-      main,
-      clean,
-      stylesheet,
-      styleElement,
-      onStorageChanged,
-    } = await importFeature(name);
+  /**
+   * @param {string[]} names Internal feature names to resolve modules for.
+   * @returns {Promise<[string, FeatureModule][]>} Entries of feature modules, keyed by name.
+   */
+  const getFeatures = names => Promise.all(
+    names.map(async (name) => [name, await getFeature(name)]),
+  );
 
-    if (main) {
-      main().catch(console.error);
-    }
-    if (stylesheet) {
-      const link = Object.assign(document.createElement('link'), {
-        rel: 'stylesheet',
-        href: browser.runtime.getURL(`/features/${name}/index.css?t=${timestamp}`),
-        className: 'xkit',
-      });
-      document.documentElement.appendChild(link);
-    }
-    if (styleElement) {
-      styleElement.dataset.xkitFeature = name;
-      document.documentElement.append(styleElement);
-    }
+  const runFeatures = async function (names) {
+    (await getFeatures(names)).forEach(([name, module]) => {
+      const {
+        main,
+        clean,
+        stylesheet,
+        styleElement,
+        onStorageChanged,
+      } = module;
 
-    restartListeners[name] = async (changes) => {
-      const { [enabledFeaturesKey]: enabledFeatures } = changes;
-      if (enabledFeatures && !enabledFeatures.newValue.includes(name)) return;
-
-      if (onStorageChanged instanceof Function) {
-        onStorageChanged(changes);
-      } else if (Object.keys(changes).some(key => key.startsWith(`${name}.preferences`) && changes[key].oldValue !== undefined)) {
-        await clean?.();
-        await main?.();
+      if (main) {
+        main().catch(console.error);
       }
-    };
 
-    browser.storage.local.onChanged.addListener(restartListeners[name]);
+      if (stylesheet) {
+        const link = Object.assign(document.createElement('link'), {
+          rel: 'stylesheet',
+          href: browser.runtime.getURL(`/features/${name}/index.css?t=${timestamp}`),
+          className: 'xkit',
+        });
+        document.documentElement.appendChild(link);
+      }
+
+      if (styleElement) {
+        styleElement.dataset.xkitFeature = name;
+        document.documentElement.append(styleElement);
+      }
+
+      restartListeners[name] = async (changes) => {
+        const { [enabledFeaturesKey]: enabledFeatures } = changes;
+        if (enabledFeatures && !enabledFeatures.newValue.includes(name)) return;
+
+        if (onStorageChanged instanceof Function) {
+          onStorageChanged(changes);
+        } else if (Object.keys(changes).some(key => key.startsWith(`${name}.preferences`) && changes[key].oldValue !== undefined)) {
+          await clean?.();
+          await main?.();
+        }
+      };
+
+      browser.storage.local.onChanged.addListener(restartListeners[name]);
+    });
   };
 
-  const destroyFeature = async function (name) {
-    const {
-      clean,
-      stylesheet,
-      styleElement,
-    } = await importFeature(name);
+  const destroyFeatures = async function (names) {
+    (await getFeatures(names)).forEach(([name, module]) => {
+      const {
+        clean,
+        stylesheet,
+        styleElement,
+      } = module;
 
-    if (clean) {
-      clean().catch(console.error);
-    }
-    if (stylesheet) {
-      document.querySelector(`link[href^="${browser.runtime.getURL(`/features/${name}/index.css`)}"]`)?.remove();
-    }
-    if (styleElement) {
-      styleElement.remove();
-    }
+      if (clean) {
+        clean().catch(console.error);
+      }
 
-    browser.storage.local.onChanged.removeListener(restartListeners[name]);
-    delete restartListeners[name];
+      if (stylesheet) {
+        document.querySelector(`link[href^="${browser.runtime.getURL(`/features/${name}/index.css`)}"]`)?.remove();
+      }
+
+      if (styleElement) {
+        styleElement.remove();
+      }
+
+      browser.storage.local.onChanged.removeListener(restartListeners[name]);
+      delete restartListeners[name];
+    });
   };
 
   const onStorageChanged = async function (changes) {
@@ -85,8 +110,8 @@
       const newlyDisabled = oldValue.filter(x => newValue.includes(x) === false);
       const newlyEnabled = newValue.filter(x => oldValue.includes(x) === false);
 
-      newlyDisabled.forEach(destroyFeature);
-      newlyEnabled.forEach(runFeature);
+      destroyFeatures(newlyDisabled);
+      runFeatures(newlyEnabled);
     }
   };
 
@@ -142,21 +167,13 @@
       initMainWorld(),
     ]);
 
-    const orderedEnabledFeatures = installedFeatures.filter(name => enabledFeatures.includes(name));
-
     /**
      * Fixes WebKit (Chromium, Safari) simultaneous import failure of files with unresolved top level await.
      * @see https://bugs.webkit.org/show_bug.cgi?id=242740
      */
-    await Promise.all(['css_map', 'language_data', 'user'].map(importUtil));
+    await Promise.all(['css_map', 'language_data', 'user'].map(name => import(browser.runtime.getURL(`/utils/${name}.js`))));
 
-    /**
-     * Populates the module cache, ensuring that feature run order is unaffected by module resolution.
-     * @see https://github.com/AprilSylph/XKit-Rewritten/discussions/2357
-     */
-    await Promise.all(orderedEnabledFeatures.map(importFeature));
-
-    orderedEnabledFeatures.forEach(runFeature);
+    runFeatures(installedFeatures.filter(name => enabledFeatures.includes(name)));
 
     warnOnExtensionContextInvalidated();
   };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
- developed from https://github.com/AprilSylph/XKit-Rewritten/pull/2359#issuecomment-5477447845

> ...huh, I guess there are no usages of `runFeature`/`destroyFeature` that aren't trying to run/destroy multiple features from an arbitrary array. So, on that front, making them expect an array argument makes a ton of sense.

This diff best viewed excluding whitespace-only changes.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
N/A

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
1. Load the modified addon
2. Open a Tumblr tab
3. Enable a feature with its own preference-handling code (e.g. Classic Footer)
    - **Expected result**: The feature activates instantly
    - **Expected result**: Changes to the feature's preference are reflected instantly
4. Enable a feature with a static stylesheet (e.g. Classic Search)
    - **Expected result**: The feature activates instantly
    - **Expected result**: The feature's stylesheet is applied to the page
5. Enable a feature with a constructed style element (e.g. Sidebar Blogs)
    - **Expected result**: The feature activates instantly
    - **Expected result**: The feature's style element is applied to the page
5. Reload the tab
    - **Expected result**: All enabled features activate after pageload
6. Disable a feature
    - **Expected result**: The feature deactivates instantly
    - **Expected result**: The feature's accompanying stylesheet and/or style element are removed from the page
