### PR TITLE
perf: do not load jQuery in the control panel

### DIFF
--- a/src/action/popup.html
+++ b/src/action/popup.html
@@ -11,7 +11,6 @@
     <link rel="stylesheet" href="./acorn.css">
     <link rel="stylesheet" href="./popup.css">
     <script defer src="../browser_polyfill.js"></script>
-    <script defer src="../lib/jquery.slim.min.js"></script>
     <script defer src="./popup.js"></script>
     <script defer src="./render_backup.js"></script>
     <script type="module" src="./components/sponsor-progress/index.js"></script>

--- a/src/action/popup.js
+++ b/src/action/popup.js
@@ -81,7 +81,7 @@ document.getElementById('filter').addEventListener('input', event => {
 
   switch (event.currentTarget.value) {
     case 'all':
-      $('.filter-hidden').removeClass('filter-hidden');
+      featureElements.forEach(featureElement => featureElement.classList.remove('filter-hidden'));
       break;
     case 'enabled':
       featureElements.forEach(featureElement => featureElement.classList.toggle('filter-hidden', featureElement.disabled));


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
We don't really rely jQuery in the control panel as of #2042, but we're still evaluating and using it for... one line of code.

Let's not do that. Vanilla JS will do just fine.

This isn't really a refactor since, if anything, it makes that one line of code technically slightly harder to read. But I'd still like to do this anyway, since it saves CPU cycles for _basically_ no cost to the developer experience.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
N/A

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Load the modified addon, and open the control panel.

Smoke-test the filter dropdown; it should correctly hide and unhide features when you select Enabled, Disabled, or All.

Smoke-test Quick Tags' tag bundle management; reordering tag bundles should still work as before. (TIL: Sortable uses jQuery if it finds that `$` is defined.)

Smoke-test Painter's preferences; all the colour preferences should still bring up colour pickers, and those colour pickers should still work as before. (Coloris doesn't hook into jQuery in any way, but jQuery was originally only added to the control panel to enable Spectrum colour-picking, which was only added for `color`-type preferences.)