### PR TITLE
feat(utils): add custom cleanup utilities

### DIFF
--- a/src/utils/cleanup.js
+++ b/src/utils/cleanup.js
@@ -1,0 +1,56 @@
+/**
+ * Remove elements that have the specified ID from the document.
+ * @param {string} id A string representing the ID of the element to remove.
+ */
+export function removeElementsById (id) {
+  [...document.querySelectorAll(`#${CSS.escape(id)}`)].forEach(element => element.remove());
+}
+
+/**
+ * Remove elements that have the specified class name from the document.
+ * @param {string} className A string representing the class name of the elements to remove.
+ */
+export function removeElementsByClassName (className) {
+  [...document.querySelectorAll(`.${CSS.escape(className)}`)].forEach(element => element.remove());
+}
+
+/**
+ * Remove elements that have the specified attribute from the document.
+ * @param {string} attribute A string representing the attribute name to match.
+ */
+export function removeElementsByAttribute (attribute) {
+  [...document.querySelectorAll(`[${CSS.escape(attribute)}]`)].forEach(element => element.remove());
+}
+
+/**
+ * Remove elements that match the given CSS selector from the document.
+ * @param {string} selector A string containing one or more selectors to match.
+ */
+export function removeElementsBySelector (selector) {
+  [...document.querySelectorAll(selector)].forEach(element => element.remove());
+}
+
+/**
+ * Remove child elements that have the specified attribute from a parent element.
+ * @param {Element} parentNode The element to remove children from.
+ * @param {string} attribute A string representing the attribute name to match.
+ */
+export function removeChildrenByAttribute (parentNode, attribute) {
+  [...parentNode.querySelectorAll(`:scope > [${CSS.escape(attribute)}]`)].forEach(element => element.remove());
+}
+
+/**
+ * Remove the specified class name from all elements in the document.
+ * @param {string} className A string representing the class name to remove.
+ */
+export function removeClassNameFromElements (className) {
+  [...document.querySelectorAll(`.${CSS.escape(className)}`)].forEach(element => element.classList.remove(className));
+}
+
+/**
+ * Remove the specified attribute from all elements in the document.
+ * @param {string} attribute A string representing the name of the attribute to remove.
+ */
+export function removeAttributeFromElements (attribute) {
+  [...document.querySelectorAll(`[${CSS.escape(attribute)}]`)].forEach(element => element.removeAttribute(attribute));
+}

--- a/src/utils/cleanup.js
+++ b/src/utils/cleanup.js
@@ -43,7 +43,7 @@ export function removeChildrenByAttribute (parentNode, attribute) {
  * Remove the specified class name from all elements in the document.
  * @param {string} className A string representing the class name to remove.
  */
-export function removeClassNameFromElements (className) {
+export function removeClassName (className) {
   [...document.querySelectorAll(`.${CSS.escape(className)}`)].forEach(element => element.classList.remove(className));
 }
 
@@ -51,6 +51,6 @@ export function removeClassNameFromElements (className) {
  * Remove the specified attribute from all elements in the document.
  * @param {string} attribute A string representing the name of the attribute to remove.
  */
-export function removeAttributeFromElements (attribute) {
+export function removeAttribute (attribute) {
   [...document.querySelectorAll(`[${CSS.escape(attribute)}]`)].forEach(element => element.removeAttribute(attribute));
 }

--- a/src/utils/control_buttons.js
+++ b/src/utils/control_buttons.js
@@ -1,3 +1,4 @@
+import { removeElementsByClassName } from './cleanup.js';
 import { keyToCss } from './css_map.js';
 import { button, div, span } from './dom.js';
 import { getIcon } from './icons.js';
@@ -5,7 +6,7 @@ import { displayInlineBlockUnlessDisabledAttr } from './interface.js';
 import { timelineObject } from './react_props.js';
 
 // Remove outdated buttons when loading module
-$('.xkit-control-button-container').remove();
+removeElementsByClassName('xkit-control-button-container');
 
 /**
  * Create a button template that can be cloned with cloneControlButton() for inserting into the controls in a post's footer.

--- a/src/utils/hide_posts.js
+++ b/src/utils/hide_posts.js
@@ -1,3 +1,4 @@
+import { removeAttributeFromElements, removeElementsByAttribute, removeElementsByClassName } from './cleanup.js';
 import { button, div } from './dom.js';
 import { buildStyle, getTimelineItemWrapper } from './interface.js';
 import { anyPostPermalinkTimelineFilter, timelineSelector } from './timeline_id.js';
@@ -5,7 +6,7 @@ import { anyPostPermalinkTimelineFilter, timelineSelector } from './timeline_id.
 const controlsClass = 'xkit-hidden-post-controls';
 
 // Remove outdated elements when loading module
-$(`.${controlsClass}`).remove();
+removeElementsByClassName(controlsClass);
 
 const styleElement = buildStyle(`
 .${controlsClass} {
@@ -130,16 +131,19 @@ export const createPostHideFunctions = ({ id, permalinkPageControls }) => {
       getTimelineItemWrapper(postElement).toggleAttribute(hiddenAttribute, true);
     }
   };
+
   const showPost = postElement => {
     getTimelineItemWrapper(postElement).removeAttribute(hiddenAttribute);
     getTimelineItemWrapper(postElement).removeAttribute(controlledHiddenAttribute);
     postElement.closest(timelineSelector)?.querySelector(`[${controlsAttribute}]`)?.remove();
   };
+
   const showPosts = () => {
-    $(`[${hiddenAttribute}]`).removeAttr(hiddenAttribute);
-    $(`[${controlledHiddenAttribute}]`).removeAttr(controlledHiddenAttribute);
-    $(`[${controlsAttribute}]`).remove();
+    removeAttributeFromElements(hiddenAttribute);
+    removeAttributeFromElements(controlledHiddenAttribute);
+    removeElementsByAttribute(controlsAttribute);
   };
+
   showPosts();
 
   return { hidePost, showPost, showPosts };

--- a/src/utils/hide_posts.js
+++ b/src/utils/hide_posts.js
@@ -1,4 +1,4 @@
-import { removeAttributeFromElements, removeElementsByAttribute, removeElementsByClassName } from './cleanup.js';
+import { removeAttribute, removeElementsByAttribute, removeElementsByClassName } from './cleanup.js';
 import { button, div } from './dom.js';
 import { buildStyle, getTimelineItemWrapper } from './interface.js';
 import { anyPostPermalinkTimelineFilter, timelineSelector } from './timeline_id.js';
@@ -139,8 +139,8 @@ export const createPostHideFunctions = ({ id, permalinkPageControls }) => {
   };
 
   const showPosts = () => {
-    removeAttributeFromElements(hiddenAttribute);
-    removeAttributeFromElements(controlledHiddenAttribute);
+    removeAttribute(hiddenAttribute);
+    removeAttribute(controlledHiddenAttribute);
     removeElementsByAttribute(controlsAttribute);
   };
 

--- a/src/utils/icons.js
+++ b/src/utils/icons.js
@@ -1,10 +1,11 @@
+import { removeElementsByClassName } from './cleanup.js';
 import { aside, svg, use } from './dom.js';
 import { memoize } from './memoize.js';
 
 const symbolsClassName = 'xkit-symbols';
 
 // Remove outdated symbols on module load
-$(`.${symbolsClassName}`).remove();
+removeElementsByClassName(symbolsClassName);
 
 const symbols = aside({ class: symbolsClassName });
 document.head.append(symbols);

--- a/src/utils/meatballs.js
+++ b/src/utils/meatballs.js
@@ -1,3 +1,4 @@
+import { removeChildrenByAttribute, removeElementsBySelector } from './cleanup.js';
 import { keyToCss } from './css_map.js';
 import { button } from './dom.js';
 import { inject } from './inject.js';
@@ -34,7 +35,7 @@ export const registerMeatballItem = function ({ id, label, onclick, postFilter }
 
 export const unregisterMeatballItem = id => {
   delete meatballItems.post[id];
-  $(`[data-xkit-post-meatball-button="${id}"]`).remove();
+  removeElementsBySelector(`[data-xkit-post-meatball-button="${id}"]`);
 };
 
 /**
@@ -53,7 +54,7 @@ export const registerBlogMeatballItem = function ({ id, label, onclick, blogFilt
 
 export const unregisterBlogMeatballItem = id => {
   delete meatballItems.blog[id];
-  $(`[data-xkit-blog-meatball-button="${id}"]`).remove();
+  removeElementsBySelector(`[data-xkit-blog-meatball-button="${id}"]`);
 };
 
 const addMeatballItems = meatballMenus => meatballMenus.forEach(async meatballMenu => {
@@ -77,7 +78,7 @@ const addMeatballItems = meatballMenus => meatballMenus.forEach(async meatballMe
 });
 
 const addTypedMeatballItems = async ({ meatballMenu, type, reactData, reactDataKey }) => {
-  $(meatballMenu).children(`[data-xkit-${type}-meatball-button]`).remove();
+  removeChildrenByAttribute(meatballMenu, `data-xkit-${type}-meatball-button`);
 
   Object.keys(meatballItems[type]).sort().forEach(id => {
     const menuIsAriakit = meatballMenu.matches(ariakitMenuSelector);

--- a/src/utils/mega_editor.js
+++ b/src/utils/mega_editor.js
@@ -49,6 +49,6 @@ export const megaEdit = async function (postIds, options) {
 
   return inject(
     '/main_world/post_request.js',
-    [`https://www.tumblr.com/${pathname}`, $.param(requestBody)],
+    [`https://www.tumblr.com/${pathname}`, (new URLSearchParams(requestBody)).toString()],
   );
 };

--- a/src/utils/post_actions.js
+++ b/src/utils/post_actions.js
@@ -1,3 +1,4 @@
+import { removeElementsByClassName } from './cleanup.js';
 import { keyToCss } from './css_map.js';
 import { button, label } from './dom.js';
 import { getIcon } from './icons.js';
@@ -5,7 +6,7 @@ import { displayBlockUnlessDisabledAttr } from './interface.js';
 import { pageModifications } from './mutations.js';
 
 // Remove outdated post options when loading module
-$('.xkit-post-option').remove();
+removeElementsByClassName('xkit-post-option');
 
 const postOptions = {};
 

--- a/src/utils/sidebar.js
+++ b/src/utils/sidebar.js
@@ -1,9 +1,10 @@
+import { removeElementsById } from './cleanup.js';
 import { keyToCss } from './css_map.js';
 import { dom } from './dom.js';
 import { blogViewSelector, displayBlockUnlessDisabledAttr } from './interface.js';
 import { pageModifications } from './mutations.js';
 
-$('#xkit-sidebar').remove();
+removeElementsById('xkit-sidebar');
 
 const sidebarItems = dom('div', { id: 'xkit-sidebar', [displayBlockUnlessDisabledAttr]: '' });
 const conditions = new Map();


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
I was thinking—hey, we managed to squash the extension bundle a ton just by removing RemixIcon, why not do the same with jQuery? We only use it for a select few things. Why not just write some helpers around `querySelectorAll` instead?

So, I did that, starting with just the `utils/` folder so as to limit the testing needed per approval. Replacing all our jQuery usages in one PR would be nuts.

The one jQuery usage that is not supplanted by a custom util is the usage of `$.param()` in the mega edit utility, which has instead been replaced with its vanilla equivalent (`(new URLSearchParams()).toString()`). These methods differ in that `$.param` can accept and properly convert object/array values to parameters, but we're not supplying `$.param` with anything except string values, so it doesn't actually matter.

Only now that I open this PR do I realise that jQuery Slim is only 56 KB uncompressed, so even if we go through with this, the extension bundle won't shrink that much and will likely have approximately zero performance impact on any machine.

...but it's about the principle of the thing! We don't need it, we shouldn't bundle it!

Oh, I guess removing it would resolve some `web-ext lint` warnings. That's always good.
(Remind me to try out another different colour picker library later...)

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
N/A, no behavioural changes expected

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Load the modified addon on Firefox, and verify that the following are still removed and re-inserted on extension restart:
- Post control buttons (Quick Tags, Trim Reblogs)
- Hidden post controls (PostBlock, Tweaks)
- `<aside id="xkit-symbols">` (Quick Tags, Trim Reblogs)
- Meatball menu buttons (PostBlock, Mirror Posts, NotificationBlock)
- Post form control buttons (Quick Tags)
- Sidebar sections (Limit Checker, Tag Tracking+)

Additionally, on any browser:
- Hidden posts should still be unhidden when expanding them on a blog view permalink page
- Hidden posts should still be unhidden when disabling the respective feature/option that hid them
- Meatball menu buttons should still be removed when disabling the respective feature that added them
- Mass Deleter should still be able to delete posts
- Tag Replacer should still be able to edit posts
