### PR TITLE
feat(Tag Tracking+): Reduce API load when multiple Tumblr tabs are open

### DIFF
--- a/src/action/render_backup.js
+++ b/src/action/render_backup.js
@@ -20,8 +20,14 @@ const sleep = ms => new Promise(resolve => setTimeout(() => resolve(), ms));
 
 class UserInterrupt extends Error { name = 'UserInterrupt'; }
 
+const getCurrentStorage = () => browser.storage.local.get()
+  .then(storageLocal => {
+    const entries = Object.entries(storageLocal);
+    return Object.fromEntries(entries.filter(([key]) => !key.startsWith('caches.')));
+  });
+
 const onStorageChanged = async function () {
-  const storageLocal = await browser.storage.local.get();
+  const storageLocal = await getCurrentStorage();
   exportValueTextarea.value = JSON.stringify(storageLocal, null, 2);
 };
 
@@ -42,7 +48,7 @@ const localCopy = () => {
 };
 
 const localExport = async function () {
-  const storageLocal = await browser.storage.local.get();
+  const storageLocal = await getCurrentStorage();
   const stringifiedStorage = JSON.stringify(storageLocal, null, 2);
   const storageBlob = new Blob([stringifiedStorage], { type: 'application/json' });
   const blobUrl = URL.createObjectURL(storageBlob);
@@ -114,7 +120,7 @@ async function onImportSubmit (event) {
     importSuccessBar.hidden = true;
     importErrorBar.hidden = true;
 
-    const currentStorage = await browser.storage.local.get();
+    const currentStorage = await getCurrentStorage();
     const parsedStorage = JSON.parse(importText);
 
     if (Object.keys(currentStorage).length !== 0) {

--- a/src/features/tag_tracking_plus/index.js
+++ b/src/features/tag_tracking_plus/index.js
@@ -6,19 +6,52 @@ import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
 import { tagTimelineFilter } from '../../utils/timeline_id.js';
 import { apiFetch, onClickNavigate } from '../../utils/tumblr_helpers.js';
 
-const storageKey = 'tag_tracking_plus.trackedTagTimestamps';
+const timestampsStorageKey = 'tag_tracking_plus.trackedTagTimestamps';
+/** @type {Record<string, number>} */
 let timestamps;
+
+const unreadCountsStorageKey = 'caches.tag_tracking_plus.unreadCounts';
+/** @type {Record<string, { unreadCountString: string, updated: number }>} */
+let unreadCounts;
 
 const excludeClass = 'xkit-tag-tracking-plus-done';
 const includeFiltered = true;
 
-let trackedTags;
-const unreadCounts = new Map();
+let trackedTags = [];
+let trackedTagsString;
 
 let sidebarItem;
 
+const BACKGROUND_REFRESH_INTERVAL = 10_000; // Minimum time between background refresh fetches (of any tag).
+const PER_TAG_BACKGROUND_REFRESH_INTERVAL = 120_000; // Minimum time between background refresh fetches of a specific tag.
+const INTIIAL_LOAD_INTERVAL = 500; // Minimum time between initial load fetches.
+
+const INITIAL_LOAD_STORED_COUNT_MAX_AGE = 30_000; // During initial load (i.e. reloading the page), load stored counts up to this age instead of fetching.
+
+const countIsStale = (tag, ttl) => unreadCounts[tag] && Date.now() - unreadCounts[tag].updated > ttl;
+
+// If multiple browser tabs are currently refreshing the same set of tracked tag(s), only allow one to refresh.
+let lastRefreshInAnotherTab = 0;
+const otherTabRefreshChannel = new BroadcastChannel('xkit-tag-tracking-plus-refresh-sync');
+otherTabRefreshChannel.addEventListener('message', event => {
+  if (event.data.trackedTagsString === trackedTagsString) {
+    lastRefreshInAnotherTab = Date.now();
+  }
+});
+const thisTabShouldRefresh = interval => {
+  const timeSinceRefresh = Date.now() - lastRefreshInAnotherTab;
+  if (timeSinceRefresh < interval * 1.5) {
+    console.info(`Tag Tracking+: skipping refresh; another tab refreshed ${timeSinceRefresh}ms ago`);
+    return false;
+  }
+  otherTabRefreshChannel.postMessage({ trackedTagsString });
+  return true;
+};
+
 const refreshCount = async function (tag) {
   if (!trackedTags.includes(tag)) return;
+
+  console.info(`Tag Tracking+: REFRESHING ${tag}`);
 
   let unreadCountString = '⚠️';
 
@@ -58,40 +91,64 @@ const refreshCount = async function (tag) {
     console.error(exception);
   }
 
-  const unreadCountElement = sidebarItem.querySelector(`[data-count-for="#${tag}"]`);
-
-  unreadCountElement.textContent = unreadCountString;
-  if (unreadCountElement.closest('li')) {
-    unreadCountElement.closest('li').dataset.new = unreadCountString !== '0';
-  }
-
-  unreadCounts.set(tag, unreadCountString);
-  updateSidebarStatus();
+  unreadCounts[tag] = { unreadCountString, updated: Date.now() };
+  await browser.storage.local.set({ [unreadCountsStorageKey]: unreadCounts });
 };
 
-const updateSidebarStatus = () => {
-  if (sidebarItem) {
-    sidebarItem.dataset.loading = [...unreadCounts.values()].some(
-      unreadCountString => unreadCountString === undefined,
-    );
-    sidebarItem.dataset.hasNew = [...unreadCounts.values()].some(
-      unreadCountString => unreadCountString && unreadCountString !== '0',
-    );
+const updateSidebar = () => {
+  const loadedTrackedTags = trackedTags.filter(tag => unreadCounts[tag]);
+  loadedTrackedTags.forEach(tag => {
+    const { unreadCountString } = unreadCounts[tag];
+    const unreadCountElement = sidebarItem.querySelector(`[data-count-for="#${tag}"]`);
+    unreadCountElement.textContent = unreadCountString;
+    if (unreadCountElement.closest('li')) {
+      unreadCountElement.closest('li').dataset.new = unreadCountString !== '0';
+    }
+  });
+  if (loadedTrackedTags.length === trackedTags.length) {
+    sidebarItem.dataset.loading = false;
+  }
+  sidebarItem.dataset.hasNew = loadedTrackedTags.some(tag => unreadCounts[tag].unreadCountString !== '0');
+};
+
+const refreshNextCount = async () => {
+  const nonLoadedTag = trackedTags.find(tag => !unreadCounts[tag]);
+  const erroredTag = trackedTags.find(tag => unreadCounts[tag]?.unreadCountString === '⚠️');
+
+  if (nonLoadedTag) {
+    await refreshCount(nonLoadedTag);
+  } else if (erroredTag) {
+    await refreshCount(erroredTag);
+  } else {
+    const oldestTag = [...trackedTags]
+      .sort((a, b) => unreadCounts[a].updated - unreadCounts[b].updated)
+      .at(0);
+    if (countIsStale(oldestTag, PER_TAG_BACKGROUND_REFRESH_INTERVAL)) {
+      await refreshCount(oldestTag);
+    } else {
+      console.info(`Tag Tracking+: no need to refresh; oldest tag ${oldestTag} is fresh!`);
+    }
   }
 };
 
-const refreshAllCounts = async (isFirstRun = false) => {
-  for (const tag of trackedTags) {
+let currentRefreshLoop;
+const startRefreshLoop = async () => {
+  const thisRefreshLoop = Symbol('loop identifier');
+  currentRefreshLoop = thisRefreshLoop;
+
+  // eslint-disable-next-line no-unmodified-loop-condition
+  while (currentRefreshLoop === thisRefreshLoop) {
+    const interval = trackedTags.every(tag => unreadCounts[tag])
+      ? BACKGROUND_REFRESH_INTERVAL
+      : INTIIAL_LOAD_INTERVAL;
+
     await Promise.all([
-      refreshCount(tag),
-      new Promise(resolve => setTimeout(resolve, isFirstRun ? 0 : 30000)),
+      thisTabShouldRefresh(interval) && refreshNextCount(),
+      new Promise(resolve => setTimeout(resolve, interval)),
     ]);
   }
 };
-
-let intervalID = 0;
-const startRefreshInterval = () => { intervalID = setInterval(refreshAllCounts, 30000 * trackedTags.length); };
-const stopRefreshInterval = () => clearInterval(intervalID);
+const stopRefreshLoop = () => { currentRefreshLoop = undefined; };
 
 const processPosts = async function (postElements) {
   const { pathname, searchParams } = new URL(location);
@@ -125,19 +182,24 @@ const processPosts = async function (postElements) {
   }
 
   if (updated) {
-    await browser.storage.local.set({ [storageKey]: timestamps });
+    await browser.storage.local.set({ [timestampsStorageKey]: timestamps });
     refreshCount(currentTag);
   }
 };
 
 export const onStorageChanged = async (changes) => {
   const {
-    [storageKey]: timestampsChanges,
+    [timestampsStorageKey]: timestampsChanges,
+    [unreadCountsStorageKey]: unreadCountsChanges,
     'tag_tracking_plus.preferences.onlyShowNew': onlyShowNewChanges,
   } = changes;
 
   if (timestampsChanges) {
     timestamps = timestampsChanges.newValue;
+  }
+  if (unreadCountsChanges) {
+    unreadCounts = unreadCountsChanges.newValue;
+    updateSidebar();
   }
   if (onlyShowNewChanges) {
     sidebarItem.dataset.onlyShowNew = onlyShowNewChanges.newValue;
@@ -147,12 +209,7 @@ export const onStorageChanged = async (changes) => {
 export const main = async function () {
   const trackedTagsData = (await apiFetch('/v2/user/tags')) ?? {};
   trackedTags = trackedTagsData.response?.tags?.map(({ name }) => name) ?? [];
-
-  trackedTags.forEach(tag => unreadCounts.set(tag, undefined));
-
-  ({ [storageKey]: timestamps = {} } = await browser.storage.local.get(storageKey));
-
-  const { onlyShowNew } = await getPreferences('tag_tracking_plus');
+  trackedTagsString = JSON.stringify(trackedTags);
 
   sidebarItem = addSidebarItem({
     id: 'tag-tracking-plus',
@@ -164,20 +221,40 @@ export const main = async function () {
       count: '\u22EF',
     })),
   });
+
+  if (!trackedTags.length) return;
+
+  const { onlyShowNew } = await getPreferences('tag_tracking_plus');
+
   sidebarItem.dataset.onlyShowNew = onlyShowNew;
-  updateSidebarStatus();
+  sidebarItem.dataset.loading = true;
+
+  ({
+    [timestampsStorageKey]: timestamps = {},
+    [unreadCountsStorageKey]: unreadCounts = {},
+  } = await browser.storage.local.get([timestampsStorageKey, unreadCountsStorageKey]));
+
+  // Discard stale stored counts.
+  for (const tag of Object.keys(unreadCounts)) {
+    if (countIsStale(tag, INITIAL_LOAD_STORED_COUNT_MAX_AGE)) {
+      delete unreadCounts[tag];
+    }
+  }
+  await browser.storage.local.set({ [unreadCountsStorageKey]: unreadCounts });
 
   onNewPosts.addListener(processPosts);
-  refreshAllCounts(true).then(startRefreshInterval);
+  startRefreshLoop();
 };
 
 export const clean = async function () {
-  stopRefreshInterval();
+  stopRefreshLoop();
   onNewPosts.removeListener(processPosts);
 
   removeSidebarItem('tag-tracking-plus');
 
-  unreadCounts.clear();
+  trackedTags = [];
+  trackedTagsString = undefined;
+  lastRefreshInAnotherTab = 0;
 };
 
 export const stylesheet = true;

--- a/src/features/tag_tracking_plus/index.js
+++ b/src/features/tag_tracking_plus/index.js
@@ -1,6 +1,7 @@
 import { filterPostElements } from '../../utils/interface.js';
 import { onNewPosts } from '../../utils/mutations.js';
 import { getPreferences } from '../../utils/preferences.js';
+import { createRateLimitFunction } from '../../utils/rate_limit.js';
 import { timelineObject } from '../../utils/react_props.js';
 import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
 import { tagTimelineFilter } from '../../utils/timeline_id.js';
@@ -17,36 +18,19 @@ let unreadCounts;
 const excludeClass = 'xkit-tag-tracking-plus-done';
 const includeFiltered = true;
 
-let trackedTags = [];
-let trackedTagsString;
+let trackedTags;
 
 let sidebarItem;
 
-const BACKGROUND_REFRESH_INTERVAL = 10_000; // Minimum time between background refresh fetches (of any tag).
-const PER_TAG_BACKGROUND_REFRESH_INTERVAL = 120_000; // Minimum time between background refresh fetches of a specific tag.
-const INTIIAL_LOAD_INTERVAL = 500; // Minimum time between initial load fetches.
+const INTERVAL = 500; // Minimum time between count refresh fetches.
+const INTERVAL_BACKGROUND = 10_000; // Minimum time between background count refresh fetches (of any tag).
+const INTERVAL_PER_TAG = 120_000; // Minimum time between background count refresh fetches of a specific tag.
 
 const INITIAL_LOAD_STORED_COUNT_MAX_AGE = 30_000; // During initial load (i.e. reloading the page), load stored counts up to this age instead of fetching.
 
 const countIsStale = (tag, ttl) => unreadCounts[tag] && Date.now() - unreadCounts[tag].updated > ttl;
 
-// If multiple browser tabs are currently refreshing the same set of tracked tag(s), only allow one to refresh.
-let lastRefreshInAnotherTab = 0;
-const otherTabRefreshChannel = new BroadcastChannel('xkit-tag-tracking-plus-refresh-sync');
-otherTabRefreshChannel.addEventListener('message', event => {
-  if (event.data.trackedTagsString === trackedTagsString) {
-    lastRefreshInAnotherTab = Date.now();
-  }
-});
-const thisTabShouldRefresh = interval => {
-  const timeSinceRefresh = Date.now() - lastRefreshInAnotherTab;
-  if (timeSinceRefresh < interval * 1.5) {
-    console.info(`Tag Tracking+: skipping refresh; another tab refreshed ${timeSinceRefresh}ms ago`);
-    return false;
-  }
-  otherTabRefreshChannel.postMessage({ trackedTagsString });
-  return true;
-};
+let shouldRefresh;
 
 const refreshCount = async function (tag) {
   if (!trackedTags.includes(tag)) return;
@@ -123,7 +107,7 @@ const refreshNextCount = async () => {
     const oldestTag = [...trackedTags]
       .sort((a, b) => unreadCounts[a].updated - unreadCounts[b].updated)
       .at(0);
-    if (countIsStale(oldestTag, PER_TAG_BACKGROUND_REFRESH_INTERVAL)) {
+    if (countIsStale(oldestTag, INTERVAL_PER_TAG)) {
       await refreshCount(oldestTag);
     } else {
       console.info(`Tag Tracking+: no need to refresh; oldest tag ${oldestTag} is fresh!`);
@@ -138,13 +122,10 @@ const startRefreshLoop = async () => {
 
   // eslint-disable-next-line no-unmodified-loop-condition
   while (currentRefreshLoop === thisRefreshLoop) {
-    const interval = trackedTags.every(tag => unreadCounts[tag])
-      ? BACKGROUND_REFRESH_INTERVAL
-      : INTIIAL_LOAD_INTERVAL;
-
+    const fullyLoaded = trackedTags.every(tag => unreadCounts[tag]);
     await Promise.all([
-      thisTabShouldRefresh(interval) && refreshNextCount(),
-      new Promise(resolve => setTimeout(resolve, interval)),
+      shouldRefresh(fullyLoaded ? INTERVAL_BACKGROUND : INTERVAL) && refreshNextCount(),
+      new Promise(resolve => setTimeout(resolve, INTERVAL)),
     ]);
   }
 };
@@ -209,7 +190,6 @@ export const onStorageChanged = async (changes) => {
 export const main = async function () {
   const trackedTagsData = (await apiFetch('/v2/user/tags')) ?? {};
   trackedTags = trackedTagsData.response?.tags?.map(({ name }) => name) ?? [];
-  trackedTagsString = JSON.stringify(trackedTags);
 
   sidebarItem = addSidebarItem({
     id: 'tag-tracking-plus',
@@ -242,6 +222,11 @@ export const main = async function () {
   }
   await browser.storage.local.set({ [unreadCountsStorageKey]: unreadCounts });
 
+  shouldRefresh = createRateLimitFunction({
+    id: `tag-tracking-plus-${JSON.stringify(trackedTags)}`,
+    multiTab: true,
+  });
+
   onNewPosts.addListener(processPosts);
   startRefreshLoop();
 };
@@ -251,10 +236,6 @@ export const clean = async function () {
   onNewPosts.removeListener(processPosts);
 
   removeSidebarItem('tag-tracking-plus');
-
-  trackedTags = [];
-  trackedTagsString = undefined;
-  lastRefreshInAnotherTab = 0;
 };
 
 export const stylesheet = true;

--- a/src/features/tag_tracking_plus/index.js
+++ b/src/features/tag_tracking_plus/index.js
@@ -11,8 +11,15 @@ const timestampsStorageKey = 'tag_tracking_plus.trackedTagTimestamps';
 /** @type {Record<string, number>} */
 let timestamps;
 
+/**
+ * @typedef {object} UnreadCount
+ * @property {string} unreadCountString String representing a tag's unread post count.
+ * @property {number} updated Unix time value of the last time this entry was fetched.
+ * @property {boolean} loaded If `false`, this stored value is not used to render the sidebar yet. Used to create a visually consistent "waterfall" sidebar load sequence even when using some cached data.
+ */
+
 const unreadCountsStorageKey = 'caches.tag_tracking_plus.unreadCounts';
-/** @type {Record<string, { unreadCountString: string, updated: number }>} */
+/** @type {Record<string, UnreadCount>} */
 let unreadCounts;
 
 const excludeClass = 'xkit-tag-tracking-plus-done';
@@ -75,12 +82,18 @@ const refreshCount = async function (tag) {
     console.error(exception);
   }
 
-  unreadCounts[tag] = { unreadCountString, updated: Date.now() };
+  unreadCounts[tag] = { unreadCountString, updated: Date.now(), loaded: true };
+  await browser.storage.local.set({ [unreadCountsStorageKey]: unreadCounts });
+};
+
+const loadStoredCount = async tag => {
+  console.info(`Tag Tracking+: loading ${tag} from storage!`);
+  unreadCounts[tag].loaded = true;
   await browser.storage.local.set({ [unreadCountsStorageKey]: unreadCounts });
 };
 
 const updateSidebar = () => {
-  const loadedTrackedTags = trackedTags.filter(tag => unreadCounts[tag]);
+  const loadedTrackedTags = trackedTags.filter(tag => unreadCounts[tag]?.loaded);
   loadedTrackedTags.forEach(tag => {
     const { unreadCountString } = unreadCounts[tag];
     const unreadCountElement = sidebarItem.querySelector(`[data-count-for="#${tag}"]`);
@@ -96,11 +109,13 @@ const updateSidebar = () => {
 };
 
 const refreshNextCount = async () => {
-  const nonLoadedTag = trackedTags.find(tag => !unreadCounts[tag]);
+  const nonLoadedTag = trackedTags.find(tag => !unreadCounts[tag]?.loaded);
   const erroredTag = trackedTags.find(tag => unreadCounts[tag]?.unreadCountString === '⚠️');
 
   if (nonLoadedTag) {
-    await refreshCount(nonLoadedTag);
+    unreadCounts[nonLoadedTag]
+      ? await loadStoredCount(nonLoadedTag)
+      : await refreshCount(nonLoadedTag);
   } else if (erroredTag) {
     await refreshCount(erroredTag);
   } else {
@@ -122,7 +137,7 @@ const startRefreshLoop = async () => {
 
   // eslint-disable-next-line no-unmodified-loop-condition
   while (currentRefreshLoop === thisRefreshLoop) {
-    const fullyLoaded = trackedTags.every(tag => unreadCounts[tag]);
+    const fullyLoaded = trackedTags.every(tag => unreadCounts[tag]?.loaded);
     await Promise.all([
       shouldRefresh(fullyLoaded ? INTERVAL_BACKGROUND : INTERVAL) && refreshNextCount(),
       new Promise(resolve => setTimeout(resolve, INTERVAL)),
@@ -218,6 +233,15 @@ export const main = async function () {
   for (const tag of Object.keys(unreadCounts)) {
     if (countIsStale(tag, INITIAL_LOAD_STORED_COUNT_MAX_AGE)) {
       delete unreadCounts[tag];
+    }
+  }
+  if (onlyShowNew === false) {
+    // Mark (fresh) tracked stored counts as not loaded until `loadStoredCount` is called on them.
+    // Creates a visually consistent "waterfall" sidebar load sequence.
+    for (const tag of Object.keys(unreadCounts)) {
+      if (trackedTags.includes(tag)) {
+        unreadCounts[tag].loaded = false;
+      }
     }
   }
   await browser.storage.local.set({ [unreadCountsStorageKey]: unreadCounts });

--- a/src/utils/rate_limit.js
+++ b/src/utils/rate_limit.js
@@ -1,0 +1,45 @@
+/**
+ * Creates a function for rate limiting a task, with support for coordinating between browser tabs.
+ * The returned function should be called as a necessary condition for running a task. It will return true only if the task has not been run recently within a specified interval. Thus, tasks contingent upon the function will only execute as frequently as the specified interval.
+ * If configured, the function will only return true if the task has not been run in another browser tab running the same code within an increased interval. Thus, tasks contingent upon the function will only execute in **any** tab as frequently as the specified interval.
+ * @param {object} options Destructured
+ * @param {string} options.id Identifier for this rate limit instance
+ * @param {boolean} options.multiTab Whether to coordinate between browser tabs.
+ * @returns {(interval: number) => boolean} A function that returns true if it has not been called in the last `interval` milliseconds.
+ */
+export const createRateLimitFunction = ({ id, multiTab }) => {
+  let lastRun = 0;
+  let lastRunInOtherTab = 0;
+  let channel;
+
+  if (multiTab) {
+    channel = new BroadcastChannel(`xkit-multi-tab-rate-limit-${id}`);
+    channel.addEventListener('message', () => { lastRunInOtherTab = Date.now(); });
+  }
+
+  return function shouldRunTask (interval) {
+    const now = Date.now();
+    const timeSinceThisTabRun = now - lastRun;
+    const timeSinceOtherTabRun = now - lastRunInOtherTab;
+
+    // Higher delay before taking over from another executing tab than before repeating execution in current tab makes multi tab execution prioritize one tab when called frequently, minimizing race condition risk.
+    const minimumDelay = interval * 0.9;
+    const otherTabMinimumDelay = minimumDelay * 2;
+
+    if (timeSinceThisTabRun < minimumDelay) {
+      console.info(
+        `XKit Rewritten: skipping ${id.slice(0, 17)} task; this tab ran it ${timeSinceThisTabRun}ms ago`,
+      );
+      return false;
+    }
+    if (timeSinceOtherTabRun < otherTabMinimumDelay) {
+      console.info(
+        `XKit Rewritten: skipping ${id.slice(0, 17)} task; another tab ran it ${timeSinceOtherTabRun}ms ago`,
+      );
+      return false;
+    }
+    channel?.postMessage(true);
+    lastRun = Date.now();
+    return true;
+  };
+};


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

I think this is my first version of #1813 that I'm not aware of any bugs in.

This is a full(?) version of what I hoped to do to Tag Tracking+: an implementation which:
- does not perform more API fetches with many tabs open than with one tab open
- does not perform more API fetches when opening/refreshing many tabs than when opening/refreshing one tab
- does not perform as many API fetches if you open a tab, close it, open a new tab, close it, etc. as previously
- does not meaningfully change the user experience
- improves edge case behavior (repeatedly disabling/enabling the feature, only tracking one tag)

General description of the implementation:
- Unread counts are stored in storage, along with their last-updated timestamps, which is a single source of truth for every tab (besides the dom). A count never goes back to `...` and a sidebar never goes back to `data-loaded=false`; besides this, all tabs' sidebars are rendered using the same data (`updateSidebar` depends only on storage and is called only in `onStorageChanged`).
- As the storage is a cache—any entries older than 30 seconds are wiped on feature enable—I had the idea that we could exclude the storage entry from the backup tab export, but we of course don't have to do this. (Every tag tracked by any user that's been logged in with the feature enabled on the installation is already in there; we're adding basically no additional data to the export.)
- Only one tab may refresh at a time (per tracked tag list)*, implemented by each tab keeping a timestamp of when any other tab has refreshed and declining to refresh unless it's been longer than the desired interval (i.e. the actively refreshing tab must have been closed). This isn't 100% robust (closed-tab race condition chance; waking a computer from sleep), but it should fix itself quickly.
- Refresh behavior is also dependent entirely on storage contents (checked in real time), so it doesn't matter which tab does the refresh.
  - A new tab marks all of its tracked tags as "needs initial load" in `main`; if any tags need initial load, they're loaded in order by the refreshing tab at up to 2/sec.
  - If no tags need initial load, tracked tags are refreshed in least-up-to-date order at an arbitrary rate until (with few enough tracked tags) they're all fresher than an arbitrary ttl. (Not sure what we want to set these numbers to, but I think it makes sense to have both of them.)
- Stopping the refresh loop is rewritten so that it actually stops immediately (idk what to call the technique honestly).
- On initial load—i.e. when hard navigating to tumblr, refreshing the page, or enabling the feature—storage contents are wiped **unless** they're quite recent (30 seconds). This means all or a significant chunk of an initial load can be reused if you f5 during it, open a new tab during it, etc, but f5 still means "fetch new counts, please."
- _In a separate commit, because maybe this is getting too cute:_ when in show-all-counts mode, even though fresh cached counts are used during initial load instead of fetching, a "loaded" boolean field is used to make them not appear in the sidebar immediately (which looks kind of strange if they're preceded by some non-cached tags); instead, they become "loaded" and visible when they would otherwise have been fetched, preserving the "waterfall" sequential load sequence. Yes, this means the caching doesn't meaningfully reduce the load time in show-all-counts mode if you keep this commit.

*Not tested, but I think conceptually the e.g. "six Firefox container tabs logged into three accounts with different tracked tag lists" scenario should work correctly (at up to 3x API load vs a single tab, depending on tracked tag count and overlap). Tabs with the same tracked tag list should elect a single tab that's allowed to refresh.

Note: I don't love the errored-tag behavior here, but I'm not sure what the ideal behavior actually is. The main problem when deciding that is that in practice the main way I see the ⚠️ appear is when interrupting a fetch by closing a tab/putting the computer to sleep/disconnecting from the internet (probably shouldn't sync that to other tabs at all, and if one does, the tab should probably immediately retry the errored tag), but that doesn't necessarily demand the same behavior as "something is wrong with fetching this tag specifically" (in which case one should probably only reattempt it as part of the cycle... or at minimum shouldn't spam attempts every half a second at the expense of all other tags).

Draft because of that, because console.info() calls are not removed currently, and because maybe I can still think of a solution with fewer lines of code.

**edit:** Oh, and reminder to myself to consider using `document.hasFocus()` in some way. Also, potentially always run a 500ms loop and do nothing if the count mod 60 (or whatever) isn't zero in background-refresh mode, as this is more flexible.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a (I could take a video of side by side tabs with devtools open, I suppose, but that would be a lot of work)

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

tba