### PR TITLE
refactor(Mutual Checker): Use hypothetical isFollowingYou react data

### DIFF
--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -83,7 +83,7 @@ const addIcons = function (postElements) {
       ? await getIsFollowing(blogName, postElement)
       : false;
     const isMutual = followingBlog
-      ? await getIsFollowingYou(blogName)
+      ? await getIsFollowingYou(blogName, postElement)
       : false;
 
     if (isMutual) {
@@ -102,7 +102,7 @@ const addBlogCardIcons = blogCardLinks =>
     if (!blogName || userBlogNames.includes(blogName)) return;
 
     const followingBlog = await getIsFollowing(blogName, blogCardLink);
-    const isFollowingYou = await getIsFollowingYou(blogName);
+    const isFollowingYou = await getIsFollowingYou(blogName, blogCardLink);
     const isMutual = followingBlog && isFollowingYou;
 
     if (isFollowingYou) {
@@ -116,7 +116,7 @@ const getIsFollowing = async (blogName, element) => {
       await blogData(element),
       (await timelineObject(element))?.blog,
       (await timelineObject(element))?.authorBlog,
-    ].find((data) => blogName === data?.name);
+    ].find((data) => blogName === data?.name && data.followed !== undefined);
 
     following[blogName] = blog
       ? Promise.resolve(blog.followed)
@@ -127,11 +127,19 @@ const getIsFollowing = async (blogName, element) => {
   return following[blogName];
 };
 
-const getIsFollowingYou = (blogName) => {
+const getIsFollowingYou = async (blogName, element) => {
   if (followingYou[blogName] === undefined) {
-    followingYou[blogName] = apiFetch(`/v2/blog/${primaryBlogName}/followed_by`, { queryParams: { query: blogName } })
-      .then(({ response: { followedBy } }) => followedBy)
-      .catch(() => Promise.resolve(false));
+    const blog = [
+      await blogData(element),
+      (await timelineObject(element))?.blog,
+      (await timelineObject(element))?.authorBlog,
+    ].find((data) => blogName === data?.name && data.isFollowingYou !== undefined);
+
+    followingYou[blogName] = blog
+      ? Promise.resolve(blog.isFollowingYou)
+      : apiFetch(`/v2/blog/${primaryBlogName}/followed_by`, { queryParams: { query: blogName } })
+        .then(({ response: { followedBy } }) => followedBy)
+        .catch(() => Promise.resolve(false));
   }
   return followingYou[blogName];
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Mutual Checker's code currently checks Tumblr's internal data to see if it can determine if someone follows you, falling back to an API request if it can't. Tumblr's internal blog data can be configured by Staff to include/not include various fields (the `fields[blogs]` query parameter in the API requests performed to populate the page) in various circumstances, so while we usually don't have to fetch here, sometimes we do.

Mutual Checker doesn't use the same possibly-API-fetch-saving code path for whether a user is following you, as we didn't observe that field being included anywhere. I assume it isn't. However, there's no particular reason it couldn't be. This PR copies the code from one to the other, so that if Staff does include that field for whatever reason, we automatically save the request. It's not more maintenance burden if it actually reduces the unique line of code count even if it increases the raw line of code count, right?

Obviously feel free to not spend the time reviewing this, April, unless you can think of a reason it would ever be useful.

Note that yes, I tested this with the timeline API request hacked to always include `?is_following_you`, and it indeed does make Mutual Checker function with no additional API requests. (Of course, this is not the same as "no API impact" if Tumblr's servers must do additional work to include that field.)

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Smoke test Mutual Checker.