### PR TITLE
refactor: drop remaining `$.param` usages

### DIFF
--- a/src/features/mass_privater/index.js
+++ b/src/features/mass_privater/index.js
@@ -154,6 +154,7 @@ const showPostsNotFound = ({ name }) =>
     buttons: [modalCompleteButton],
   });
 
+/** @type {(params: { uuid: string; name: string; tags: string[]; before: number; }) => Promise<void>} */
 const privatePosts = async ({ uuid, name, tags, before }) => {
   const gatherStatus = dom('span', null, null, ['Gathering posts...']);
   const privateStatus = dom('span');
@@ -194,10 +195,10 @@ const privatePosts = async ({ uuid, name, tags, before }) => {
 
   if (tags.length) {
     for (const tag of tags) {
-      await collect(`/v2/blog/${uuid}/posts?${$.param({ tag, before, limit: 50 })}`);
+      await collect(`/v2/blog/${uuid}/posts?${new URLSearchParams({ tag, before, limit: 50 })}`);
     }
   } else {
-    await collect(`/v2/blog/${uuid}/posts?${$.param({ before, limit: 50 })}`);
+    await collect(`/v2/blog/${uuid}/posts?${new URLSearchParams({ before, limit: 50 })}`);
   }
   const filteredPostIds = [...filteredPostIdsSet];
 

--- a/src/features/tag_replacer/index.js
+++ b/src/features/tag_replacer/index.js
@@ -170,6 +170,7 @@ const showTagNotFound = ({ tag, name }) => showModal({
   buttons: [modalCompleteButton],
 });
 
+/** @type {(params: { uuid: string; oldTag: string; toAdd: string[], toRemove: string[] }) => Promise<void>} */
 const replaceTag = async ({ uuid, oldTag, toAdd, toRemove }) => {
   const gatherStatus = dom('span', null, null, ['Gathering posts...']);
   const removeStatus = dom('span');
@@ -187,7 +188,7 @@ const replaceTag = async ({ uuid, oldTag, toAdd, toRemove }) => {
   });
 
   const taggedPosts = [];
-  let resource = `/v2/blog/${uuid}/posts?${$.param({ tag: oldTag, limit: 50 })}`;
+  let resource = `/v2/blog/${uuid}/posts?${new URLSearchParams({ tag: oldTag, limit: 50 })}`;
 
   while (resource) {
     await Promise.all([


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->
- see also: #2373 &rarr; [`ab7f750`](https://github.com/AprilSylph/XKit-Rewritten/pull/2373/changes/ab7f750d5fac61a34917f47fd98e6326ed74cf74)

We're not using the object conversion features of `$.param`, so we don't need to use it. The vanilla `URLSearchParams` constructor will do just fine, instead.

Bonus: when we know the object is going to be cast to a string, we don't even need to call `.toString()` on it manually!

So, it's literally a drop-in replacement here.

...I did write some JSdoc as well. I love types...

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
N/A

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->
Make sure that Mass Privater and Tag Replacer both still work.
Be sure to test Mass Privater both with and without tag criteria.
