### PR TITLE
fix(Sidebar util): Items on community pages being covered by ad

### DIFF
--- a/src/utils/sidebar.js
+++ b/src/utils/sidebar.js
@@ -87,7 +87,7 @@ const mrecContainerSelector = `${keyToCss('mrecContainer')} *`;
 // Sidebar on explore/search/hubs
 const desktopContainerSelector = `aside ${keyToCss('desktopContainer', 'summary')}`;
 // Sidebar on most other desktop pages
-const sidebarItemSelector = keyToCss('sidebarItem', 'sidebarContent');
+const sidebarItemSelector = keyToCss('sidebarItem', 'sidebarContent', 'sidebarScrollableContent');
 // Footer beneath sidebar area
 const aboutFooterSelector = `${keyToCss('about')}${keyToCss('inSidebar')}`;
 // Mobile drawer


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

> Sidebar items for e.g. limit checker and tag replacer appear on community pages, but they are placed below the sticky sidebar ad. The add covers them when one scrolls down.

Resolves #1977.

Note that the sidebar item spacing is weird on community pages; that will be a second PR.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a


### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

Enable Limit Checker and/or Tag Replacer. Navigate to a community page. Confirm that the sidebar items are above the sticky sidebar ad.