### PR TITLE
fix(Sidebar util): Improve sidebar item spacing

### DIFF
--- a/src/content_scripts/sidebar.css
+++ b/src/content_scripts/sidebar.css
@@ -1,11 +1,15 @@
 .xkit-sidebar-item {
   width: 100%;
-  margin-bottom: 38px;
+  margin-block: 38px;
 
   font-family: var(--font-family);
   font-size: 1.125rem;
   font-weight: 400;
   line-height: 1.333;
+}
+
+.in-flex-container > .xkit-sidebar-item {
+  margin-block: 5px;
 }
 
 .xkit-sidebar-item > h1 {
@@ -81,7 +85,7 @@
 }
 
 nav .xkit-sidebar-item {
-  margin-bottom: 0.75em;
+  margin-block: 0.75em;
 }
 
 nav .xkit-sidebar-item > h1 {

--- a/src/content_scripts/sidebar.css
+++ b/src/content_scripts/sidebar.css
@@ -1,6 +1,6 @@
 .xkit-sidebar-item {
   width: 100%;
-  margin-block: 38px;
+  margin-bottom: 38px;
 
   font-family: var(--font-family);
   font-size: 1.125rem;
@@ -8,6 +8,9 @@
   line-height: 1.333;
 }
 
+.with-top-margin > .xkit-sidebar-item {
+  margin-top: 38px;
+}
 .in-flex-container > .xkit-sidebar-item {
   margin-block: 5px;
 }

--- a/src/utils/interface.js
+++ b/src/utils/interface.js
@@ -110,6 +110,7 @@ export const displayBlockUnlessDisabledAttr = 'data-xkit-display-block';
 export const displayInlineBlockUnlessDisabledAttr = 'data-xkit-display-inline-block';
 export const displayFlexUnlessDisabledAttr = 'data-xkit-display-flex';
 export const displayInlineFlexUnlessDisabledAttr = 'data-xkit-display-inline-flex';
+export const displayContentsUnlessDisabledAttr = 'data-xkit-display-contents';
 
 /**
  * This variable is set to "unset" in the src/content_scripts/interface.css static stylesheet.
@@ -140,6 +141,9 @@ document.documentElement.append(
     }
     [${displayInlineFlexUnlessDisabledAttr}] {
       display: var(--none-if-xkit-disabled, inline-flex);
+    }
+    [${displayContentsUnlessDisabledAttr}] {
+      display: var(--none-if-xkit-disabled, contents);
     }
   `),
 );

--- a/src/utils/sidebar.js
+++ b/src/utils/sidebar.js
@@ -87,7 +87,7 @@ const mrecContainerSelector = `${keyToCss('mrecContainer')} *`;
 // Sidebar on explore/search/hubs
 const desktopContainerSelector = `aside ${keyToCss('desktopContainer', 'summary')}`;
 // Sidebar on most other desktop pages
-const sidebarItemSelector = keyToCss('sidebarItem', 'sidebarContent');
+const sidebarItemSelector = keyToCss('sidebarItem', 'sidebarContent', 'sidebarScrollableContent');
 // Footer beneath sidebar area
 const aboutFooterSelector = `${keyToCss('about')}${keyToCss('inSidebar')}`;
 // Mobile drawer

--- a/src/utils/sidebar.js
+++ b/src/utils/sidebar.js
@@ -1,12 +1,12 @@
 import { removeElementsById } from './cleanup.js';
 import { keyToCss } from './css_map.js';
 import { dom } from './dom.js';
-import { blogViewSelector, displayBlockUnlessDisabledAttr } from './interface.js';
+import { blogViewSelector, displayContentsUnlessDisabledAttr } from './interface.js';
 import { pageModifications } from './mutations.js';
 
 removeElementsById('xkit-sidebar');
 
-const sidebarItems = dom('div', { id: 'xkit-sidebar', [displayBlockUnlessDisabledAttr]: '' });
+const sidebarItems = dom('div', { id: 'xkit-sidebar', [displayContentsUnlessDisabledAttr]: '' });
 const conditions = new Map();
 
 const carrotSvg = dom('svg', {
@@ -111,6 +111,11 @@ const addSidebarToPage = (siblingCandidates) => {
   const insertAbove = getComputedStyle(target).position === 'sticky' ||
     target.matches(desktopContainerSelector) ||
     target.matches(aboutFooterSelector);
+
+  sidebarItems.classList.toggle(
+    'in-flex-container',
+    getComputedStyle(target.parentElement).display === 'flex',
+  );
 
   target[insertAbove ? 'before' : 'after'](sidebarItems);
 };

--- a/src/utils/sidebar.js
+++ b/src/utils/sidebar.js
@@ -116,6 +116,10 @@ const addSidebarToPage = (siblingCandidates) => {
     'in-flex-container',
     getComputedStyle(target.parentElement).display === 'flex',
   );
+  sidebarItems.classList.toggle(
+    'with-top-margin',
+    target.matches(`section + *, ${keyToCss('summaryInfo')} ~ *`),
+  );
 
   target[insertAbove ? 'before' : 'after'](sidebarItems);
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Hey, actually, you know what? Unconditional `display: contents` is kind of fine actually? (We can definitely choose not to do this, if we want the ability to put increased spacing around the block of sidebar elements. But this was the simplest solution.)

This makes sidebar item spacing symmetrical top/bottom in all of the locations that I know of where we can insert a sidebar, and makes sidebar items respect the `gap` value if inserted into a flex container. Please share your opinions on spacing when reviewing this.

Resolves #2368.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

#### Should be improved:

| | Before | After |
| - | - | - |
| Community Page | <img width="417" height="431" src="https://github.com/user-attachments/assets/6ba408f8-5b1c-4e30-a5df-a4c863d5df5a" /> | <img width="417" height="431" src="https://github.com/user-attachments/assets/6e2a4dde-f5ee-44c3-87f3-0352350dcccc" /> |
| Mobile Drawer| <img width="417" height="431" src="https://github.com/user-attachments/assets/5f7266e4-b7b8-4d5a-9c0b-aee0b766dc2c" /> | <img width="417" height="431"  src="https://github.com/user-attachments/assets/11209d62-be63-44f7-a4e3-d033ad064a1a" /> |
| Tagged Page | <img width="417" height="431" src="https://github.com/user-attachments/assets/7babc43a-6d67-4ad8-9579-5b70ebcd6e6f" /> | <img width="417" height="431" src="https://github.com/user-attachments/assets/b4e0e269-1c8c-451b-a6f5-1849f8f0711a" /> |
| Saved Posts Page |  <img width="386" height="358" src="https://github.com/user-attachments/assets/dd455a67-5849-4451-9605-3abc6a221191" /> | <img width="386" height="358" src="https://github.com/user-attachments/assets/ae31dc77-6364-41d1-83a6-bca54ad6384b" /> |

#### Should be identical:

| | Before | After |
| - | - | - |
| Most Pages — under premium cta, hidden recommended blogs | <img width="417" height="431" src="https://github.com/user-attachments/assets/ae475d92-b3b2-43e9-9811-0c53cb4fc3ec" /> | <img width="417" height="431" src="https://github.com/user-attachments/assets/ce49e68c-3d31-41d0-b074-8f398822e35e" /> |
| Most Pages — under search bar | <img width="417" height="431" src="https://github.com/user-attachments/assets/b4490a1d-f705-4a97-838d-03fa8e905d12" /> | <img width="417" height="431" src="https://github.com/user-attachments/assets/b4490a1d-f705-4a97-838d-03fa8e905d12" /> |
| Most Pages — under recommended blogs | <img width="417" height="431" src="https://github.com/user-attachments/assets/a5650f8c-99b0-4dc6-b7d5-41888ef21659" /> | <img width="417" height="431" src="https://github.com/user-attachments/assets/a5650f8c-99b0-4dc6-b7d5-41888ef21659" /> |
| Inbox | <img width="417" height="431" src="https://github.com/user-attachments/assets/0f63922d-2118-4c8e-a3e7-9ca9e4bba123" /> | <img width="417" height="431" src="https://github.com/user-attachments/assets/0f63922d-2118-4c8e-a3e7-9ca9e4bba123" /> |

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Confirm that the displayed spacing is applied in the specified locations. Try to find other places we insert sidebar items that I have forgotten; do they have correct-looking spacing?
- Confirm that sidebar items vanish when XKit Rewritten is disabled in Firefox.