### PR TITLE
refactor(Tag Tracking+): Improve loop edge cases, misc cleanup

### DIFF
--- a/src/features/tag_tracking_plus/index.js
+++ b/src/features/tag_tracking_plus/index.js
@@ -83,7 +83,7 @@ const updateSidebarStatus = () => {
 
 let currentRefreshLoop;
 const startRefreshLoop = async () => {
-  const thisRefreshLoop = Date.now();
+  const thisRefreshLoop = Symbol('loop identifier');
   currentRefreshLoop = thisRefreshLoop;
 
   for (const tag of trackedTags) {

--- a/src/features/tag_tracking_plus/index.js
+++ b/src/features/tag_tracking_plus/index.js
@@ -21,6 +21,8 @@ let sidebarItem;
 const refreshCount = async function (tag) {
   if (!trackedTags.includes(tag)) return;
 
+  console.info(`Tag Tracking+: REFRESHING ${tag}`);
+
   let unreadCountString = '⚠️';
 
   try {
@@ -95,7 +97,7 @@ const startRefreshLoop = async () => {
       if (currentRefreshLoop !== thisRefreshLoop) return;
       await Promise.all([
         refreshCount(tag),
-        new Promise(resolve => setTimeout(resolve, 30000)),
+        new Promise(resolve => setTimeout(resolve, 5000)),
       ]);
     }
   }

--- a/src/features/tag_tracking_plus/index.js
+++ b/src/features/tag_tracking_plus/index.js
@@ -81,18 +81,26 @@ const updateSidebarStatus = () => {
   }
 };
 
-const refreshAllCounts = async (isFirstRun = false) => {
+let currentRefreshLoop;
+const startRefreshLoop = async () => {
+  const thisRefreshLoop = Date.now();
+  currentRefreshLoop = thisRefreshLoop;
+
   for (const tag of trackedTags) {
-    await Promise.all([
-      refreshCount(tag),
-      new Promise(resolve => setTimeout(resolve, isFirstRun ? 0 : 30000)),
-    ]);
+    if (currentRefreshLoop !== thisRefreshLoop) return;
+    await refreshCount(tag);
+  }
+  while (true) {
+    for (const tag of trackedTags) {
+      if (currentRefreshLoop !== thisRefreshLoop) return;
+      await Promise.all([
+        refreshCount(tag),
+        new Promise(resolve => setTimeout(resolve, 30000)),
+      ]);
+    }
   }
 };
-
-let intervalID = 0;
-const startRefreshInterval = () => { intervalID = setInterval(refreshAllCounts, 30000 * trackedTags.length); };
-const stopRefreshInterval = () => clearInterval(intervalID);
+const stopRefreshLoop = () => { currentRefreshLoop = undefined; };
 
 const processPosts = async function (postElements) {
   const { pathname, searchParams } = new URL(location);
@@ -165,15 +173,18 @@ export const main = async function () {
       count: '\u22EF',
     })),
   });
+
+  if (!trackedTags.length) return;
+
   sidebarItem.dataset.onlyShowNew = onlyShowNew;
   updateSidebarStatus();
 
   onNewPosts.addListener(processPosts);
-  refreshAllCounts(true).then(startRefreshInterval);
+  startRefreshLoop();
 };
 
 export const clean = async function () {
-  stopRefreshInterval();
+  stopRefreshLoop();
   onNewPosts.removeListener(processPosts);
 
   removeSidebarItem('tag-tracking-plus');

--- a/src/features/tag_tracking_plus/index.js
+++ b/src/features/tag_tracking_plus/index.js
@@ -6,7 +6,8 @@ import { addSidebarItem, removeSidebarItem } from '../../utils/sidebar.js';
 import { tagTimelineFilter } from '../../utils/timeline_id.js';
 import { apiFetch, onClickNavigate } from '../../utils/tumblr_helpers.js';
 
-const storageKey = 'tag_tracking_plus.trackedTagTimestamps';
+const timestampsStorageKey = 'tag_tracking_plus.trackedTagTimestamps';
+/** @type {Record<string, number>} */
 let timestamps;
 
 const excludeClass = 'xkit-tag-tracking-plus-done';
@@ -125,14 +126,14 @@ const processPosts = async function (postElements) {
   }
 
   if (updated) {
-    await browser.storage.local.set({ [storageKey]: timestamps });
+    await browser.storage.local.set({ [timestampsStorageKey]: timestamps });
     refreshCount(currentTag);
   }
 };
 
 export const onStorageChanged = async (changes) => {
   const {
-    [storageKey]: timestampsChanges,
+    [timestampsStorageKey]: timestampsChanges,
     'tag_tracking_plus.preferences.onlyShowNew': onlyShowNewChanges,
   } = changes;
 
@@ -150,7 +151,7 @@ export const main = async function () {
 
   trackedTags.forEach(tag => unreadCounts.set(tag, undefined));
 
-  ({ [storageKey]: timestamps = {} } = await browser.storage.local.get(storageKey));
+  ({ [timestampsStorageKey]: timestamps = {} } = await browser.storage.local.get(timestampsStorageKey));
 
   const { onlyShowNew } = await getPreferences('tag_tracking_plus');
 

--- a/src/features/tag_tracking_plus/index.js
+++ b/src/features/tag_tracking_plus/index.js
@@ -21,8 +21,6 @@ let sidebarItem;
 const refreshCount = async function (tag) {
   if (!trackedTags.includes(tag)) return;
 
-  console.info(`Tag Tracking+: REFRESHING ${tag}`);
-
   let unreadCountString = '⚠️';
 
   try {
@@ -97,7 +95,7 @@ const startRefreshLoop = async () => {
       if (currentRefreshLoop !== thisRefreshLoop) return;
       await Promise.all([
         refreshCount(tag),
-        new Promise(resolve => setTimeout(resolve, 5000)),
+        new Promise(resolve => setTimeout(resolve, 30000)),
       ]);
     }
   }


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

Note: every change in this PR is included in/superseded by #2375. It only makes sense to review this if not imminently merging that one (which: extremely reasonable position)... or, in theory, to reduce the diff of that PR, but actually this implementation differs more from it than I hoped, so it doesn't really do that.

This:
- Rewrites the Tag Tracking+ refresh loop so that it can actually be immediately stopped instead of finishing its loop unconditionally, firing up to 100 extra API requests over time if the feature is disabled. Now: because we use `onStorageChanged` in Tag Tracking+, this doesn't happen on preference changes, so it only happens on manual feature disable; yes this is _entirely_ pointless. There might be edge cases where this rewrite also improves loop timing consistency, as it no longer has a setInterval call that's up to 50 minutes in duration, but I can't think of a situation where the old code would actually misbehave. Putting the device to sleep? Nah, should be fine.
- Stops doing anything after adding the sidebar if there are 0 tracked tags. Resolves #2338.
- Renames storageKey to timestampsStorageKey (and types the storage object).

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->
n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Optionally, un-revert the test commit.
- Enable Tag Tracking+ with browser dev tools open. Disable it during the initial load waterfall and confirm that API fetches immediately stop.
- Enable Tag Tracking+ with browser dev tools open. Disable it after the initial load waterfall during regular background refreshing and confirm that API fetches immediately stop.
- Smoke test Tag Tracking+.