### PR TITLE
feat(Mutual Checker): Share api query results between open tabs

### DIFF
--- a/src/features/mutual_checker/index.js
+++ b/src/features/mutual_checker/index.js
@@ -24,6 +24,11 @@ const followingYou = {};
 let showOnlyMutuals;
 let showOnlyMutualNotifications;
 
+const channel = new BroadcastChannel(`xkit-mutual-checker-${primaryBlogName}`);
+channel.addEventListener('message', ({ data: { blogName, isFollowingYou } }) => {
+  followingYou[blogName] = Promise.resolve(isFollowingYou);
+});
+
 const styleElement = buildStyle(`
   svg.xkit-mutual-icon {
     vertical-align: text-bottom;
@@ -132,6 +137,8 @@ const getIsFollowingYou = (blogName) => {
     followingYou[blogName] = apiFetch(`/v2/blog/${primaryBlogName}/followed_by`, { queryParams: { query: blogName } })
       .then(({ response: { followedBy } }) => followedBy)
       .catch(() => Promise.resolve(false));
+
+    followingYou[blogName].then(isFollowingYou => channel.postMessage({ blogName, isFollowingYou }));
   }
   return followingYou[blogName];
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

It's pretty much the lowest-hanging-fruit possible, but hey, if it's there, why not start with it?

This reduces the API load created by Mutual Checker in a specific case (having multiple tabs open, scrolling on one, then scrolling on the other) by copying API fetch results from one to the other in real time, as mentioned at the end of #2376. This isn't a big savings, but it has, that I can think of, zero negative impact: fetch results are sent in real time, so they can never be more stale than what a tab would have had in its cache anyway; the only user-visible effect can be that a result in a tab is fresher than it otherwise would have been.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

n/a

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->

- Open two Tumblr tabs. Open the networking dev tools tab in each. Filter by `followed_by`.
- Navigate both tabs to a feed with multiple followed blogs (containing at least one mutual).
- Scroll down one of them if necessary, until you see a network request corresponding to a blog you know is a mutual. Confirm that a post by said blog appears with a mutuals icon.
- Scroll down the other tab to the same location. Confirm that a post by said blog appears with a mutuals icon, but that the tab did not perform the relevant fetch.