### PR TITLE
feat(Classic Footer): Always grey out reblog buttons on posts that cannot be reblogged

### DIFF
--- a/src/features/classic_footer/index.js
+++ b/src/features/classic_footer/index.js
@@ -7,6 +7,7 @@ import { getPreferences } from '../../utils/preferences.js';
 import { timelineObject, trailItem } from '../../utils/react_props.js';
 
 const activeAttribute = 'data-classic-footer';
+const forceDisableReblogAttribute = 'data-classic-footer-force-disable-reblog';
 const noteCountClass = 'xkit-classic-footer-note-count';
 const modernStyleClass = 'xkit-classic-footer-ds-look';
 const reblogLinkClass = 'xkit-classic-footer-reblog-link';
@@ -199,6 +200,13 @@ export const styleElement = buildStyle(`
   .${reblogLinkClass} ~ ${reblogButtonSelector}:not(:has(${quickActionsSelector})) {
     display: none;
   }
+
+  [${forceDisableReblogAttribute}] ${reblogButtonSelector} {
+    cursor: not-allowed;
+    opacity: 0.5;
+    color: var(--content-fg-secondary) !important;
+    background-color: transparent !important;
+  }
 `);
 
 const getTranslationTemplate = (noteCount) => {
@@ -287,9 +295,7 @@ const processPosts = (postElements) => postElements.forEach(async postElement =>
       engagementControls.closest('footer').toggleAttribute(activeAttribute, true);
       engagementControls.before(noteCountButton);
 
-      if (noReblogMenu) {
-        processReblogButton(engagementControls.querySelector(reblogButtonSelector), timelineObjectData, trailItemData);
-      }
+      processReblogButton(engagementControls.querySelector(reblogButtonSelector), timelineObjectData, trailItemData);
     });
 });
 
@@ -336,22 +342,27 @@ const processReblogButton = (reblogButton, timelineObjectData, trailItemData) =>
   const { canReblog, id } = trailItemData?.post ?? timelineObjectData;
   const { reblogKey } = timelineObjectData; // Trail items have the same reblog key as their parent post
 
-  if (!canReblog) return;
+  if (!canReblog) {
+    reblogButton.closest('footer').toggleAttribute(
+      forceDisableReblogAttribute,
+      reblogButton.getAttribute('aria-disabled') !== 'true',
+    );
+  } else if (noReblogMenu) {
+    const reblogLinkPath = `/reblog/${name}/${id}/${reblogKey}`;
+    const styleContent = `${reblogMenuPortalSelector}:has([role="menuitem"][href^="${reblogLinkPath}"]) { display: none; }`;
 
-  const reblogLinkPath = `/reblog/${name}/${id}/${reblogKey}`;
-  const styleContent = `${reblogMenuPortalSelector}:has([role="menuitem"][href^="${reblogLinkPath}"]) { display: none; }`;
+    const reblogLink = a({
+      'aria-label': reblogButton.getAttribute('aria-label'),
+      class: reblogLinkClass,
+      click: onReblogLinkClick,
+      href: reblogLinkPath,
+    }, [
+      link({ rel: 'stylesheet', class: 'xkit', href: `data:text/css,${encodeURIComponent(styleContent)}` }),
+      reblogButton.firstElementChild.cloneNode(true)],
+    );
 
-  const reblogLink = a({
-    'aria-label': reblogButton.getAttribute('aria-label'),
-    class: reblogLinkClass,
-    click: onReblogLinkClick,
-    href: reblogLinkPath,
-  }, [
-    link({ rel: 'stylesheet', class: 'xkit', href: `data:text/css,${encodeURIComponent(styleContent)}` }),
-    reblogButton.firstElementChild.cloneNode(true)],
-  );
-
-  reblogButton.before(reblogLink);
+    reblogButton.before(reblogLink);
+  }
 };
 
 export const onStorageChanged = async function (changes) {
@@ -369,6 +380,7 @@ export const main = async function () {
 export const clean = async function () {
   pageModifications.unregister(processPosts);
   $(`[${activeAttribute}]`).removeAttr(activeAttribute);
+  $(`[${forceDisableReblogAttribute}]`).removeAttr(forceDisableReblogAttribute);
   $(`.${noteCountClass}`).remove();
   $(`.${reblogLinkClass}`).remove();
 };


### PR DESCRIPTION
### Description
<!--
  What is the goal of this pull request?
  How does it achieve that goal?
  Any other context needed to understand the changes?

  Please properly link any issues that this PR aims to resolve:
  https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
-->

> With the new Tumblr footer design, a post that cannot be reblogged but that has reblogs must have a clickable reblog button, as that's the only reasonable/primary way for a user to get to the list of reblogs. It will produce a menu that says "This post is not available to be reblogged. [See reblogs]"

This greys out the reblog button if Classic Footer is enabled and the post in question cannot be reblogged, even if there are reblog notes on it and Tumblr's code does not do this, as discussed in the linked issue.

This doesn't actually prevent the user from clicking the button, even though it applies the "not-allowed" cursor, because I don't actually see any reason to prevent the click. The popup is informative.

Resolves #2152.

Best viewed with whitespace changes hidden.

### Screenshots
<!--
  What do the changes in this pull request look like in action?
  Would they be better illustrated by screenshots, or by screen recordings?

  Please provide a side-by-side "Before" & "After" comparison if applicable:
  https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/organizing-information-with-tables

  Skip this section if no visual differences are expected.
-->

<img width="171" src="https://github.com/user-attachments/assets/fd9a9061-59e5-4e6d-bda9-26de71533a49" />

### Testing steps
<!--
  What is the intended behaviour of this pull request?
  How exactly can a maintainer reproduce it?

  Please assume your reviewer will load the addon in a temporary profile.
  Feel free to upload a configuration file if the setup is complex.
-->


Find, or create, a post ([ex](https://www.tumblr.com/blowery/827561533264494592)) with reblogs disabled, but which has reblogs. Enable Classic Footer and confirm that the reblog button appears disabled, including when hovered, but its tooltip still appears. Compare with a post with disabled reblogs with no reblogs ([ex](https://www.tumblr.com/transienttest/827588714668703744/no-reblogs)).
